### PR TITLE
Add tower placement grid

### DIFF
--- a/docs/Tasks/Tasks_Prototype_2.txt
+++ b/docs/Tasks/Tasks_Prototype_2.txt
@@ -1,4 +1,4 @@
-001 | TODO | Add grid that shows 10 places to build towers along enemy path (which stays the same).
+001 | DONE | Add grid that shows 10 places to build towers along enemy path (which stays the same).
 002 | TODO | Add a HUD above the canvas showing Lives=10, Gold=15, Wave=1/5, and buttons “Next Wave” and “Place Tower (10)”.
 003 | TODO | Make “Place Tower (10)” toggle build mode and visually highlight when active.
 004 | TODO | In build mode, highlight the hovered grid cell green if placeable and affordable, or red if blocked or unaffordable.

--- a/src/game.js
+++ b/src/game.js
@@ -64,6 +64,11 @@ class Game {
     this.gameOver = false;
     this.win = false;
 
+    this.grid = [];
+    for (let i = 0; i < 10; i++) {
+      this.grid.push({ x: 20 + i * 80, y: 340, w: 40, h: 40 });
+    }
+
     this.update = this.update.bind(this);
   }
 
@@ -125,6 +130,11 @@ class Game {
 
     ctx.fillStyle = '#888';
     ctx.fillRect(0, 380, this.canvas.width, 20);
+
+    ctx.strokeStyle = 'rgba(0,0,0,0.3)';
+    this.grid.forEach(cell => {
+      ctx.strokeRect(cell.x, cell.y, cell.w, cell.h);
+    });
 
     this.tower.draw(ctx);
     this.enemy.draw(ctx);


### PR DESCRIPTION
## Summary
- draw a 10-cell grid near the path to indicate tower build locations
- update prototype 2 task list

## Testing
- `node --check src/game.js`


------
https://chatgpt.com/codex/tasks/task_e_6896a4fe0f048323b991a872f3d61802