### PR TITLE
Add HUD and build mode toggle for prototype 2

### DIFF
--- a/docs/Tasks/Tasks_Prototype_2.txt
+++ b/docs/Tasks/Tasks_Prototype_2.txt
@@ -1,6 +1,6 @@
 001 | DONE | Add grid that shows 10 places to build towers along enemy path (which stays the same).
-002 | TODO | Add a HUD above the canvas showing Lives=10, Gold=15, Wave=1/5, and buttons “Next Wave” and “Place Tower (10)”.
-003 | TODO | Make “Place Tower (10)” toggle build mode and visually highlight when active.
+002 | DONE | Add a HUD above the canvas showing Lives=10, Gold=15, Wave=1/5, and buttons “Next Wave” and “Place Tower (10)”.
+003 | DONE | Make “Place Tower (10)” toggle build mode and visually highlight when active.
 004 | TODO | In build mode, highlight the hovered grid cell green if placeable and affordable, or red if blocked or unaffordable.
 005 | TODO | Allow placing an tower on a green cell, deducting 10 Gold and marking the cell as occupied.
 006 | TODO | Remove the pre-placed tower from Proto #1 so towers only appear when placed by the player.

--- a/src/game.js
+++ b/src/game.js
@@ -64,6 +64,25 @@ class Game {
     this.gameOver = false;
     this.win = false;
 
+    this.lives = 10;
+    this.gold = 15;
+    this.wave = 1;
+    this.maxWaves = 5;
+    this.buildMode = false;
+
+    this.livesEl = document.getElementById('lives');
+    this.goldEl = document.getElementById('gold');
+    this.waveEl = document.getElementById('wave');
+    this.nextWaveBtn = document.getElementById('nextWave');
+    this.placeTowerBtn = document.getElementById('placeTower');
+
+    this.placeTowerBtn.addEventListener('click', () => {
+      this.buildMode = !this.buildMode;
+      this.placeTowerBtn.classList.toggle('active', this.buildMode);
+    });
+
+    this.updateHUD();
+
     this.grid = [];
     for (let i = 0; i < 10; i++) {
       this.grid.push({ x: 20 + i * 80, y: 340, w: 40, h: 40 });
@@ -80,6 +99,12 @@ class Game {
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(text, this.canvas.width / 2, this.canvas.height / 2);
+  }
+
+  updateHUD() {
+    this.livesEl.textContent = `Lives: ${this.lives}`;
+    this.goldEl.textContent = `Gold: ${this.gold}`;
+    this.waveEl.textContent = `Wave: ${this.wave}/${this.maxWaves}`;
   }
 
   spawnProjectile(angle) {

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,13 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <div id="hud">
+      <span id="lives">Lives: 10</span>
+      <span id="gold">Gold: 15</span>
+      <span id="wave">Wave: 1/5</span>
+      <button id="nextWave">Next Wave</button>
+      <button id="placeTower">Place Tower (10)</button>
+    </div>
     <canvas id="game" width="800" height="450"></canvas>
     <script src="game.js"></script>
   </body>

--- a/src/style.css
+++ b/src/style.css
@@ -2,3 +2,15 @@ body {
   margin: 0;
   background: #fff;
 }
+
+#hud {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  font-family: sans-serif;
+}
+
+#placeTower.active {
+  background: #ff0;
+}


### PR DESCRIPTION
## Summary
- Add on-screen HUD showing Lives, Gold, and Wave info plus Next Wave and Place Tower buttons
- Toggle build mode via Place Tower button with visual active highlight
- Record completion of tasks 2 and 3 in the prototype 2 task list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a8d394348323ac88ca3b68f28a78