### PR TITLE
feat: target nearest enemy (task 009)

### DIFF
--- a/docs/Tasks/Tasks_Prototype_2.txt
+++ b/docs/Tasks/Tasks_Prototype_2.txt
@@ -6,7 +6,7 @@
 006 | TODO | Remove the pre-placed tower from Proto #1 so towers only appear when placed by the player.
 007 | DONE | Make “Next Wave” button start the current wave, disable the button during the wave, and spawn enemies along the waypoint path.
 008 | TODO | Show enemy HP as a small visible bar above each enemy.
-009 | TODO | Keep the existing tower attack from Proto #1 but adapt it to target any enemy within range in the new grid/path system. The logic I propose is to select the first enemy seen as target and when it goes out of sight, look for the next seen. Mb use queue or something like that.
+009 | DONE | Keep the existing tower attack from Proto #1 but adapt it to target any enemy within range in the new grid/path system. The logic I propose is to select the first enemy seen as target and when it goes out of sight, look for the next seen. Mb use queue or something like that.
 010 | TODO | When an enemy is killed, grant +1 Gold and update the HUD immediately.
 011 | TODO | When an enemy reaches the base, remove it and decrease Lives by 1 in the HUD.
 012 | TODO | End a wave when all its enemies are gone, re-enable “Next Wave”, increase Wave by 1, and award +3 Gold.

--- a/src/game.js
+++ b/src/game.js
@@ -74,6 +74,7 @@ class Game {
     this.projectileRadius = 6;
     this.lastShot = 0;
     this.lastTime = 0;
+    this.target = null;
 
     this.lives = 10;
     this.gold = 15;
@@ -256,22 +257,46 @@ class Game {
       }
     }
 
-    const target = this.enemies[0];
-    if (target) {
-      const towerCenter = this.tower.center();
+    const towerCenter = this.tower.center();
+    if (this.target) {
       const enemyCenter = {
-        x: target.x + target.w / 2,
-        y: target.y + target.h / 2
+        x: this.target.x + this.target.w / 2,
+        y: this.target.y + this.target.h / 2
       };
-      const dx = enemyCenter.x - towerCenter.x;
-      const dy = enemyCenter.y - towerCenter.y;
-      const dist = Math.hypot(dx, dy);
-
-      if (dist <= this.tower.range && timestamp - this.lastShot >= 1000) {
-        const angle = Math.atan2(dy, dx);
-        this.spawnProjectile(angle);
-        this.lastShot = timestamp;
+      const dist = Math.hypot(
+        enemyCenter.x - towerCenter.x,
+        enemyCenter.y - towerCenter.y
+      );
+      if (dist > this.tower.range || !this.enemies.includes(this.target)) {
+        this.target = null;
       }
+    }
+
+    if (!this.target) {
+      for (const e of this.enemies) {
+        const enemyCenter = { x: e.x + e.w / 2, y: e.y + e.h / 2 };
+        const dist = Math.hypot(
+          enemyCenter.x - towerCenter.x,
+          enemyCenter.y - towerCenter.y
+        );
+        if (dist <= this.tower.range) {
+          this.target = e;
+          break;
+        }
+      }
+    }
+
+    if (this.target && timestamp - this.lastShot >= 1000) {
+      const enemyCenter = {
+        x: this.target.x + this.target.w / 2,
+        y: this.target.y + this.target.h / 2
+      };
+      const angle = Math.atan2(
+        enemyCenter.y - towerCenter.y,
+        enemyCenter.x - towerCenter.x
+      );
+      this.spawnProjectile(angle);
+      this.lastShot = timestamp;
     }
 
     this.updateProjectiles(dt);


### PR DESCRIPTION
## Summary
- allow tower to track a single enemy and retarget when out of range
- mark task 009 as done

## Testing
- `node --version`
- `node --check src/game.js`


------
https://chatgpt.com/codex/tasks/task_e_6897920646c483238af8a96b65e6012e