### PR TITLE
feat: add base with life decrement

### DIFF
--- a/docs/Tasks/Tasks_Prototype_2.txt
+++ b/docs/Tasks/Tasks_Prototype_2.txt
@@ -8,7 +8,7 @@
 008 | DONE | Show enemy HP as a small visible bar above each enemy.
 009 | DONE | Keep the existing tower attack from Proto #1 but adapt it to target any enemy within range in the new grid/path system. The logic I propose is to select the first enemy seen as target and when it goes out of sight, look for the next seen. Mb use queue or something like that.
 010 | DONE | When an enemy is killed, grant +1 Gold and update the HUD immediately.
-011 | TODO | Draw something that will signify base. When an enemy reaches the base, remove it and decrease Lives by 1 in the HUD.
+011 | DONE | Draw something that will signify base. When an enemy reaches the base, remove it and decrease Lives by 1 in the HUD.
 012 | TODO | End a wave when all its enemies are gone, re-enable “Next Wave”, increase Wave by 1, and award +3 Gold.
 013 | TODO | Increase wave difficulty by raising enemy HP per wave according to the spec. Store spec any way you deem appropriate. Remember, the main thing is development speed and nothing else.
 014 | TODO | After Wave 5 ends and no enemies remain, show “WIN” in the HUD and stop the game.

--- a/src/game.js
+++ b/src/game.js
@@ -140,6 +140,8 @@ class Game {
       this.grid.push({ x: 20 + i * 80, y: 340, w: 40, h: 40, occupied: false });
     }
 
+    this.base = { x: this.canvas.width - 40, y: 360, w: 40, h: 40 };
+
     this.update = this.update.bind(this);
   }
 
@@ -230,6 +232,9 @@ class Game {
     ctx.fillStyle = '#888';
     ctx.fillRect(0, 380, this.canvas.width, 20);
 
+    ctx.fillStyle = 'green';
+    ctx.fillRect(this.base.x, this.base.y, this.base.w, this.base.h);
+
     ctx.strokeStyle = 'rgba(0,0,0,0.3)';
     this.grid.forEach(cell => {
       ctx.strokeRect(cell.x, cell.y, cell.w, cell.h);
@@ -269,7 +274,11 @@ class Game {
     for (let i = this.enemies.length - 1; i >= 0; i--) {
       const e = this.enemies[i];
       e.update(dt);
-      if (e.isOutOfBounds(this.canvas.width)) {
+      if (e.x + e.w >= this.base.x) {
+        this.enemies.splice(i, 1);
+        this.lives -= 1;
+        this.updateHUD();
+      } else if (e.isOutOfBounds(this.canvas.width)) {
         this.enemies.splice(i, 1);
       }
     }


### PR DESCRIPTION
## Summary
- render a base at end of the path
- subtract a life when enemies reach the base
- document task 11 as complete

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f9bc578c8323b6186c2a707f0284