### PR TITLE
Remove pre-placed tower and adjust starting gold

### DIFF
--- a/docs/Tasks/Tasks_Prototype_2.txt
+++ b/docs/Tasks/Tasks_Prototype_2.txt
@@ -3,7 +3,7 @@
 003 | DONE | Make “Place Tower (10)” toggle build mode and visually highlight when active.
 004 | DONE | In build mode, highlight the hovered grid cell green if placeable and affordable, or red if blocked or unaffordable.
 005 | DONE | Allow placing an tower on a green cell, deducting 10 Gold and marking the cell as occupied.
-006 | TODO | Remove the pre-placed tower from Proto #1 so towers only appear when placed by the player. Initial money must be enough to buy 2 towers.
+006 | DONE | Remove the pre-placed tower from Proto #1 so towers only appear when placed by the player. Initial money must be enough to buy 2 towers.
 007 | DONE | Make “Next Wave” button start the current wave, disable the button during the wave, and spawn enemies along the waypoint path.
 008 | DONE | Show enemy HP as a small visible bar above each enemy.
 009 | DONE | Keep the existing tower attack from Proto #1 but adapt it to target any enemy within range in the new grid/path system. The logic I propose is to select the first enemy seen as target and when it goes out of sight, look for the next seen. Mb use queue or something like that.

--- a/src/game.js
+++ b/src/game.js
@@ -69,7 +69,7 @@ class Game {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d');
     this.enemies = [];
-    this.towers = [new Tower(400, 280)];
+    this.towers = [];
     this.projectiles = [];
     this.projectileSpeed = 400;
     this.projectileRadius = 6;
@@ -77,7 +77,7 @@ class Game {
     this.target = null;
 
     this.lives = 10;
-    this.gold = 15;
+    this.gold = 20;
     this.wave = 1;
     this.maxWaves = 5;
     this.buildMode = false;

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
   <body>
     <div id="hud">
       <span id="lives">Lives: 10</span>
-      <span id="gold">Gold: 15</span>
+      <span id="gold">Gold: 20</span>
       <span id="wave">Wave: 1/5</span>
       <button id="nextWave">Next Wave</button>
       <button id="placeTower">Place Tower (10)</button>


### PR DESCRIPTION
## Summary
- Start with no towers so players must build their own
- Increase initial gold to allow buying two towers
- Mark task 6 as complete in prototype 2 task list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f982ccd08323b2b375d24130449e