### PR TITLE
Fix build mode highlight after restart

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -354,6 +354,9 @@ class Game {
   }
 
   restart() {
+    // remember whether the game loop has stopped so we can safely resume it
+    const wasGameOver = this.gameOver;
+
     this.lives = this.inititalLives;
     this.gold = this.inititalGold;
     this.wave = 1;
@@ -368,10 +371,16 @@ class Game {
     this.grid.forEach(cell => (cell.occupied = false));
     this.spawned = 0;
     this.spawnTimer = 0;
-	this.gameOver =  false;
+    this.gameOver = false;
     this.statusEl.textContent = "";
     this.placeTowerBtn.disabled = false;
     this.updateHUD();
+
+    // if the game loop was stopped (after WIN/LOSE) restart it so highlighting works
+    if (wasGameOver) {
+      this.lastTime = performance.now();
+      requestAnimationFrame(this.update);
+    }
   }
 
   run() {


### PR DESCRIPTION
## Summary
- ensure Restart resumes the game loop so build-mode cell highlighting always renders

## Testing
- `node --check src/game.js`
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a22b65bdcc83238b2b3100b6261396