### PR TITLE
Add Tower unit tests

### DIFF
--- a/test/tower.test.js
+++ b/test/tower.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Tower from '../src/Tower.js';
+
+test('center returns tower midpoint', () => {
+    const tower = new Tower(10, 20);
+    const c = tower.center();
+    assert.deepEqual(c, { x: 30, y: 40 });
+});
+
+test('draw draws range and tower body correctly', () => {
+    const tower = new Tower(50, 60);
+    const ctx = makeFakeCtx();
+    tower.draw(ctx);
+    assert.deepEqual(ctx.ops[0], ['beginPath']);
+    assert.deepEqual(ctx.ops[1], ['arc', 70, 80, 120, 0, Math.PI * 2]);
+    assert.deepEqual(ctx.ops[2], ['strokeStyle', 'rgba(0,0,255,0.3)']);
+    assert.deepEqual(ctx.ops[3], ['stroke']);
+    assert.deepEqual(ctx.ops[4], ['fillStyle', 'blue']);
+    assert.deepEqual(ctx.ops[5], ['fillRect', 50, 60, 40, 40]);
+});
+
+function makeFakeCtx() {
+    const ops = [];
+    return {
+        ops,
+        beginPath() { ops.push(['beginPath']); },
+        arc(x, y, r, s, e) { ops.push(['arc', x, y, r, s, e]); },
+        set strokeStyle(v) { ops.push(['strokeStyle', v]); },
+        stroke() { ops.push(['stroke']); },
+        set fillStyle(v) { ops.push(['fillStyle', v]); },
+        fillRect(x, y, w, h) { ops.push(['fillRect', x, y, w, h]); },
+    };
+}
+


### PR DESCRIPTION
## Summary
- test Tower.center calculations and drawing behavior
- remove constructor defaults test per review

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77deb1024832399c04dd4563ba612