### PR TITLE
Remove build mode toggle and hover highlighting

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -27,8 +27,6 @@ export default class Game {
         this.gold = this.initialGold;
         this.wave = 1;
         this.maxWaves = 5;
-        this.buildMode = false;
-        this.hoverCell = null;
         this.towerCost = 10;
         this.waveInProgress = false;
         this.spawnInterval = 0.5;
@@ -158,15 +156,11 @@ export default class Game {
         this.projectiles = [];
         this.waveInProgress = false;
         this.nextWaveBtn.disabled = false;
-        this.buildMode = false;
-        this.hoverCell = null;
-        this.placeTowerBtn.classList.remove('active');
         this.grid.forEach(cell => (cell.occupied = false));
         this.spawned = 0;
         this.spawnTimer = 0;
         this.gameOver = false;
         this.statusEl.textContent = '';
-        this.placeTowerBtn.disabled = false;
         updateHUD(this);
     }
 

--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,6 @@
             <span id="wave">Wave: 1/5</span>
             <span id="status"></span>
             <button id="nextWave">Next Wave</button>
-            <button id="placeTower">Place Tower (10)</button>
             <button id="restart">Restart</button>
         </div>
         <canvas id="game" width="800" height="450"></canvas>

--- a/src/render.js
+++ b/src/render.js
@@ -4,7 +4,6 @@ export function draw(game) {
     drawGround(game);
     drawBase(game);
     drawGrid(game);
-    drawHoverCell(game);
     drawEntities(game);
 }
 
@@ -26,15 +25,6 @@ function drawGrid(game) {
     game.grid.forEach(cell => {
         ctx.strokeRect(cell.x, cell.y, cell.w, cell.h);
     });
-}
-
-export function drawHoverCell(game) {
-    if (!game.buildMode || !game.hoverCell) return;
-    const ctx = game.ctx;
-    const affordable = game.gold >= game.towerCost;
-    const placeable = !game.hoverCell.occupied;
-    ctx.fillStyle = affordable && placeable ? 'rgba(0,255,0,0.3)' : 'rgba(255,0,0,0.3)';
-    ctx.fillRect(game.hoverCell.x, game.hoverCell.y, game.hoverCell.w, game.hoverCell.h);
 }
 
 export function drawEntities(game) {

--- a/src/style.css
+++ b/src/style.css
@@ -10,7 +10,3 @@ body {
     padding: 10px;
     font-family: sans-serif;
 }
-
-#placeTower.active {
-    background: #ff0;
-}

--- a/src/ui.js
+++ b/src/ui.js
@@ -3,8 +3,6 @@ import Tower from './Tower.js';
 export function bindUI(game) {
     bindHUD(game);
     bindButtons(game);
-    bindMouseMove(game);
-    bindMouseLeave(game);
     bindCanvasClick(game);
     updateHUD(game);
 }
@@ -15,50 +13,29 @@ function bindHUD(game) {
     game.waveEl = document.getElementById('wave');
     game.statusEl = document.getElementById('status');
     game.nextWaveBtn = document.getElementById('nextWave');
-    game.placeTowerBtn = document.getElementById('placeTower');
     game.restartBtn = document.getElementById('restart');
 }
 
 function bindButtons(game) {
-    game.placeTowerBtn.addEventListener('click', () => {
-        game.buildMode = !game.buildMode;
-        game.placeTowerBtn.classList.toggle('active', game.buildMode);
-        if (!game.buildMode) game.hoverCell = null;
-    });
     game.nextWaveBtn.addEventListener('click', () => game.startWave());
     game.restartBtn.addEventListener('click', () => game.restart());
 }
 
-function bindMouseMove(game) {
-    game.canvas.addEventListener('mousemove', e => {
+function bindCanvasClick(game) {
+    game.canvas.addEventListener('click', e => {
         const rect = game.canvas.getBoundingClientRect();
         const mx = e.clientX - rect.left;
         const my = e.clientY - rect.top;
-        game.hoverCell = null;
-        if (!game.buildMode) return;
         for (const cell of game.grid) {
             if (mx >= cell.x && mx <= cell.x + cell.w && my >= cell.y && my <= cell.y + cell.h) {
-                game.hoverCell = cell;
+                if (game.gold >= game.towerCost && !cell.occupied) {
+                    game.towers.push(new Tower(cell.x, cell.y));
+                    cell.occupied = true;
+                    game.gold -= game.towerCost;
+                    updateHUD(game);
+                }
                 break;
             }
-        }
-    });
-}
-
-function bindMouseLeave(game) {
-    game.canvas.addEventListener('mouseleave', () => {
-        game.hoverCell = null;
-    });
-}
-
-function bindCanvasClick(game) {
-    game.canvas.addEventListener('click', () => {
-        if (!game.buildMode || !game.hoverCell) return;
-        if (game.gold >= game.towerCost && !game.hoverCell.occupied) {
-            game.towers.push(new Tower(game.hoverCell.x, game.hoverCell.y));
-            game.hoverCell.occupied = true;
-            game.gold -= game.towerCost;
-            updateHUD(game);
         }
     });
 }
@@ -73,6 +50,5 @@ export function endGame(game, text) {
     game.statusEl.textContent = text;
     game.statusEl.style.color = 'red';
     game.nextWaveBtn.disabled = true;
-    game.placeTowerBtn.disabled = true;
     game.gameOver = true;
 }

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -25,7 +25,6 @@ function attachDomStubs(game) {
     game.waveEl = { textContent: '' };
     game.statusEl = { textContent: '', style: {} };
     game.nextWaveBtn = { disabled: false };
-    game.placeTowerBtn = { classList: { remove: () => {} }, disabled: false };
 }
 
 test('spawnProjectile main', () => {
@@ -143,11 +142,8 @@ test('resetState restores initial game values', () => {
     game.enemies.push({});
     game.projectiles.push({});
     game.waveInProgress = true;
-    game.buildMode = true;
-    game.hoverCell = {};
     game.grid[0].occupied = true;
     game.nextWaveBtn.disabled = true;
-    game.placeTowerBtn.disabled = true;
     game.statusEl.textContent = 'status';
     game.resetState();
     assert.equal(game.lives, game.initialLives);
@@ -157,10 +153,7 @@ test('resetState restores initial game values', () => {
     assert.equal(game.enemies.length, 0);
     assert.equal(game.projectiles.length, 0);
     assert.equal(game.waveInProgress, false);
-    assert.equal(game.buildMode, false);
-    assert.equal(game.hoverCell, null);
     assert.equal(game.nextWaveBtn.disabled, false);
-    assert.equal(game.placeTowerBtn.disabled, false);
     assert.equal(game.grid[0].occupied, false);
     assert.equal(game.statusEl.textContent, '');
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { drawHoverCell, drawEntities, draw } from '../src/render.js';
+import { drawEntities, draw } from '../src/render.js';
 
 function makeFakeCtx() {
     const ops = [];
@@ -16,69 +16,6 @@ function makeFakeCtx() {
         fill() { ops.push(['fill']); },
     };
 }
-
-test('drawHoverCell does nothing when buildMode false or hoverCell null', () => {
-    const ctx = makeFakeCtx();
-    const cell = { x: 10, y: 20, w: 30, h: 40, occupied: false };
-    const baseGame = {
-        ctx,
-        buildMode: true,
-        hoverCell: cell,
-        gold: 100,
-        towerCost: 50,
-    };
-
-    drawHoverCell({ ...baseGame, buildMode: false });
-    assert.equal(ctx.ops.length, 0);
-
-    drawHoverCell({ ...baseGame, hoverCell: null });
-    assert.equal(ctx.ops.length, 0);
-});
-
-test('drawHoverCell draws green highlight when affordable and placeable', () => {
-    const ctx = makeFakeCtx();
-    const cell = { x: 10, y: 20, w: 30, h: 40, occupied: false };
-    const game = {
-        ctx,
-        buildMode: true,
-        hoverCell: cell,
-        gold: 100,
-        towerCost: 50,
-    };
-
-    drawHoverCell(game);
-
-    assert.deepEqual(ctx.ops, [
-        ['fillStyle', 'rgba(0,255,0,0.3)'],
-        ['fillRect', 10, 20, 30, 40],
-    ]);
-});
-
-test('drawHoverCell draws red highlight when unaffordable or occupied', () => {
-    const ctx = makeFakeCtx();
-    const cell = { x: 0, y: 0, w: 20, h: 20, occupied: false };
-    const baseGame = {
-        ctx,
-        buildMode: true,
-        hoverCell: cell,
-        gold: 30,
-        towerCost: 50,
-    };
-
-    drawHoverCell(baseGame);
-    assert.deepEqual(ctx.ops, [
-        ['fillStyle', 'rgba(255,0,0,0.3)'],
-        ['fillRect', 0, 0, 20, 20],
-    ]);
-
-    ctx.ops.length = 0;
-
-    drawHoverCell({ ...baseGame, gold: 100, hoverCell: { ...cell, occupied: true } });
-    assert.deepEqual(ctx.ops, [
-        ['fillStyle', 'rgba(255,0,0,0.3)'],
-        ['fillRect', 0, 0, 20, 20],
-    ]);
-});
 
 test('drawEntities draws towers, enemies and projectiles', () => {
     const ctx = makeFakeCtx();
@@ -111,7 +48,7 @@ test('drawEntities draws towers, enemies and projectiles', () => {
     );
 });
 
-test('draw clears canvas, draws hover cell, entities and projectiles', () => {
+test('draw clears canvas, draws entities and projectiles', () => {
     const ctx = makeFakeCtx();
     let towerCalled = false;
     let enemyCalled = false;
@@ -127,10 +64,6 @@ test('draw clears canvas, draws hover cell, entities and projectiles', () => {
         enemies: [enemy],
         projectiles: [projectile],
         projectileRadius: 4,
-        buildMode: true,
-        hoverCell: { x: 1, y: 2, w: 3, h: 4, occupied: false },
-        gold: 100,
-        towerCost: 50,
     };
 
     draw(game);
@@ -140,7 +73,5 @@ test('draw clears canvas, draws hover cell, entities and projectiles', () => {
     assert.ok(enemyCalled);
     const twoPi = Math.PI * 2;
     assert.ok(ctx.ops.some(op => op[0] === 'arc' && op[1] === 25 && op[2] === 35 && op[3] === 4 && op[4] === 0 && op[5] === twoPi));
-    assert.ok(ctx.ops.some(op => op[0] === 'fillStyle' && op[1] === 'rgba(0,255,0,0.3)'));
-    assert.ok(ctx.ops.some(op => op[0] === 'fillRect' && op[1] === 1 && op[2] === 2 && op[3] === 3 && op[4] === 4));
 });
 


### PR DESCRIPTION
## Summary
- Build towers directly by clicking an empty slot with enough gold
- Remove build-mode UI elements and hover highlighting from rendering
- Clean up tests to reflect the simplified build mechanic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a799818be88323b5d775a4f7148c5d