### PR TITLE
feat: add fixed tower slots

### DIFF
--- a/docs/Tasks/Tasks_Prototype_3.txt
+++ b/docs/Tasks/Tasks_Prototype_3.txt
@@ -1,7 +1,7 @@
 Prototype 3 — Task List
 
 001 | TODO | Remove build mode toggle and highlighting logic from Prototype 2. Tapping an empty slot should always mean build attempt.
-002 | TODO | Replace grid system with fixed tower slots. Arrange ~10 slots total: 5 on top row and 5 on bottom row, flanking the straight enemy path. Show empty slots as outlined circles or squares.
+002 | DONE | Replace grid system with fixed tower slots. Arrange ~10 slots total: 5 on top row and 5 on bottom row, flanking the straight enemy path. Show empty slots as outlined circles or squares.
 003 | TODO | Implement tower building: tap empty slot to place Level 1 tower (cost 10). If not enough gold, ignore and briefly highlight slot.
 004 | TODO | Add color property to enemies: 'red' or 'blue'. Show by filling their sprite/rectangle.
 005 | TODO | Add color property to towers. Default new tower = 'red'.

--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -1,7 +1,7 @@
 export default class Enemy {
-    constructor(maxHp = 3) {
+    constructor(maxHp = 3, y = 365) {
         this.x = 0;
-        this.y = 365;
+        this.y = y;
         this.w = 30;
         this.h = 30;
         this.speed = 100;

--- a/src/Game.js
+++ b/src/Game.js
@@ -15,8 +15,9 @@ export default class Game {
         this.projectileSpawnInterval = 500;
         this.lastTime = 0;
         this.initStats();
+        this.pathY = canvas.height / 2 - 15;
+        this.base = { x: canvas.width - 40, y: this.pathY, w: 40, h: 40 };
         this.createGrid();
-        this.base = { x: canvas.width - 40, y: 360, w: 40, h: 40 };
         this.update = this.update.bind(this);
     }
 
@@ -42,8 +43,14 @@ export default class Game {
 
     createGrid() {
         this.grid = [];
-        for (let i = 0; i < 10; i++) {
-            this.grid.push({ x: 20 + i * 80, y: 340, w: 40, h: 40, occupied: false });
+        const topY = this.pathY - 100;
+        const bottomY = this.pathY + 100;
+        const startX = 60;
+        const step = 140;
+        for (let i = 0; i < 5; i++) {
+            const x = startX + i * step;
+            this.grid.push({ x, y: topY, w: 40, h: 40, occupied: false });
+            this.grid.push({ x, y: bottomY, w: 40, h: 40, occupied: false });
         }
     }
 
@@ -59,7 +66,7 @@ export default class Game {
 
     spawnEnemy() {
         const hp = this.enemyHpPerWave[this.wave - 1] ?? this.enemyHpPerWave[this.enemyHpPerWave.length - 1];
-        this.enemies.push(new Enemy(hp));
+        this.enemies.push(new Enemy(hp, this.pathY));
         this.spawned += 1;
     }
 

--- a/src/render.js
+++ b/src/render.js
@@ -11,7 +11,9 @@ export function draw(game) {
 function drawGround(game) {
     const ctx = game.ctx;
     ctx.fillStyle = '#888';
-    ctx.fillRect(0, 380, game.canvas.width, 20);
+    const pathHeight = 20;
+    const y = game.pathY + (30 - pathHeight) / 2;
+    ctx.fillRect(0, y, game.canvas.width, pathHeight);
 }
 
 function drawBase(game) {
@@ -24,7 +26,13 @@ function drawGrid(game) {
     const ctx = game.ctx;
     ctx.strokeStyle = 'rgba(0,0,0,0.3)';
     game.grid.forEach(cell => {
-        ctx.strokeRect(cell.x, cell.y, cell.w, cell.h);
+        if (!cell.occupied) {
+            const cx = cell.x + cell.w / 2;
+            const cy = cell.y + cell.h / 2;
+            ctx.beginPath();
+            ctx.arc(cx, cy, cell.w / 2, 0, Math.PI * 2);
+            ctx.stroke();
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- replace grid with fixed tower slots on two rows
- center the enemy path and path graphics
- allow enemies to spawn at arbitrary path y

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a799cfa52483238705e48585e4824e