### PR TITLE
feat: add enemy color

### DIFF
--- a/docs/Tasks/Tasks_Prototype_3.txt
+++ b/docs/Tasks/Tasks_Prototype_3.txt
@@ -3,7 +3,7 @@ Prototype 3 — Task List
 001 | TODO | Remove build mode toggle and highlighting logic from Prototype 2. Tapping an empty slot should always mean build attempt.
 002 | TODO | Replace grid system with fixed tower slots. Arrange ~10 slots total: 5 on top row and 5 on bottom row, flanking the straight enemy path. Show empty slots as outlined circles or squares.
 003 | TODO | Implement tower building: tap empty slot to place Level 1 tower (cost 10). If not enough gold, ignore and briefly highlight slot.
-004 | TODO | Add color property to enemies: 'red' or 'blue'. Show by filling their sprite/rectangle.
+004 | DONE | Add color property to enemies: 'red' or 'blue'. Show by filling their sprite/rectangle.
 005 | TODO | Add color property to towers. Default new tower = 'red'.
 006 | TODO | Implement color damage rules: if tower.color = enemy.color → 1.0× damage, else 0.4× damage.
 007 | TODO | Implement global switch cooldown system: one timer shared by all towers. Tap on a tower switches its color (red ↔ blue) only if cooldown = 0. Set cooldown = 2s.

--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -1,5 +1,5 @@
 export default class Enemy {
-    constructor(maxHp = 3) {
+    constructor(maxHp = 3, color = 'red') {
         this.x = 0;
         this.y = 365;
         this.w = 30;
@@ -7,6 +7,7 @@ export default class Enemy {
         this.speed = 100;
         this.maxHp = maxHp;
         this.hp = this.maxHp;
+        this.color = color;
     }
 
     update(dt) {
@@ -14,7 +15,7 @@ export default class Enemy {
     }
 
     draw(ctx) {
-        ctx.fillStyle = 'red';
+        ctx.fillStyle = this.color;
         ctx.fillRect(this.x, this.y, this.w, this.h);
 
         const barWidth = this.w;

--- a/src/Game.js
+++ b/src/Game.js
@@ -59,7 +59,8 @@ export default class Game {
 
     spawnEnemy() {
         const hp = this.enemyHpPerWave[this.wave - 1] ?? this.enemyHpPerWave[this.enemyHpPerWave.length - 1];
-        this.enemies.push(new Enemy(hp));
+        const color = Math.random() < 0.5 ? 'red' : 'blue';
+        this.enemies.push(new Enemy(hp, color));
         this.spawned += 1;
     }
 

--- a/test/enemy.test.js
+++ b/test/enemy.test.js
@@ -18,20 +18,29 @@ test('isOutOfBounds returns correct value', () => {
     assert.equal(enemy.isOutOfBounds(800), false);
 });
 
-test('draw draws enemy and health bar correctly', () => {
-    const enemy = new Enemy(10);
+test('draw uses enemy color and health bar correctly', () => {
+    const enemy = new Enemy(10, 'blue');
     enemy.hp = 5; // half health
     const ctx = makeFakeCtx();
     enemy.draw(ctx);
 
     // body
+    assert.deepEqual(ctx.ops[0], ['fillStyle', 'blue']);
     assert.deepEqual(ctx.ops[1], ['fillRect', 0, 365, 30, 30]);
     // health bar background
+    assert.deepEqual(ctx.ops[2], ['fillStyle', 'red']);
     assert.deepEqual(ctx.ops[3], ['fillRect', 0, 359, 30, 4]);
     // health bar current hp
+    assert.deepEqual(ctx.ops[4], ['fillStyle', 'green']);
     assert.deepEqual(ctx.ops[5], ['fillRect', 0, 359, 15, 4]);
     // border
+    assert.deepEqual(ctx.ops[6], ['strokeStyle', 'black']);
     assert.deepEqual(ctx.ops[7], ['strokeRect', 0, 359, 30, 4]);
+});
+
+test('default enemy color is red', () => {
+    const enemy = new Enemy();
+    assert.equal(enemy.color, 'red');
 });
 
 function makeFakeCtx() {


### PR DESCRIPTION
## Summary
- add color attribute to enemy and render using it
- spawn enemies with random red/blue color
- test enemy color and mark task 4 done

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a799f0a11c8323a0243aca8ecb68cb