### PR TITLE
Highlight tower slot when gold is insufficient

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -41,7 +41,7 @@ export default class Game {
     createGrid() {
         this.grid = [];
         for (let i = 0; i < 10; i++) {
-            this.grid.push({ x: 20 + i * 80, y: 340, w: 40, h: 40, occupied: false });
+            this.grid.push({ x: 20 + i * 80, y: 340, w: 40, h: 40, occupied: false, highlight: false });
         }
     }
 
@@ -156,7 +156,14 @@ export default class Game {
         this.projectiles = [];
         this.waveInProgress = false;
         this.nextWaveBtn.disabled = false;
-        this.grid.forEach(cell => (cell.occupied = false));
+        this.grid.forEach(cell => {
+            cell.occupied = false;
+            cell.highlight = false;
+            if (cell.highlightTimeout) {
+                clearTimeout(cell.highlightTimeout);
+                cell.highlightTimeout = null;
+            }
+        });
         this.spawned = 0;
         this.spawnTimer = 0;
         this.gameOver = false;

--- a/src/Tower.js
+++ b/src/Tower.js
@@ -6,6 +6,7 @@ export default class Tower {
         this.h = 40;
         this.range = 120;
         this.lastShot = 0;
+        this.level = 1;
     }
 
     center() {

--- a/src/render.js
+++ b/src/render.js
@@ -21,8 +21,14 @@ function drawBase(game) {
 
 function drawGrid(game) {
     const ctx = game.ctx;
-    ctx.strokeStyle = 'rgba(0,0,0,0.3)';
     game.grid.forEach(cell => {
+        if (cell.highlight) {
+            ctx.strokeStyle = 'red';
+            ctx.lineWidth = 3;
+        } else {
+            ctx.strokeStyle = 'rgba(0,0,0,0.3)';
+            ctx.lineWidth = 1;
+        }
         ctx.strokeRect(cell.x, cell.y, cell.w, cell.h);
     });
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -21,18 +21,27 @@ function bindButtons(game) {
     game.restartBtn.addEventListener('click', () => game.restart());
 }
 
-function bindCanvasClick(game) {
+export function bindCanvasClick(game) {
     game.canvas.addEventListener('click', e => {
         const rect = game.canvas.getBoundingClientRect();
         const mx = e.clientX - rect.left;
         const my = e.clientY - rect.top;
         for (const cell of game.grid) {
             if (mx >= cell.x && mx <= cell.x + cell.w && my >= cell.y && my <= cell.y + cell.h) {
-                if (game.gold >= game.towerCost && !cell.occupied) {
-                    game.towers.push(new Tower(cell.x, cell.y));
-                    cell.occupied = true;
-                    game.gold -= game.towerCost;
-                    updateHUD(game);
+                if (!cell.occupied) {
+                    if (game.gold >= game.towerCost) {
+                        game.towers.push(new Tower(cell.x, cell.y));
+                        cell.occupied = true;
+                        game.gold -= game.towerCost;
+                        updateHUD(game);
+                    } else {
+                        cell.highlight = true;
+                        clearTimeout(cell.highlightTimeout);
+                        cell.highlightTimeout = setTimeout(() => {
+                            cell.highlight = false;
+                            cell.highlightTimeout = null;
+                        }, 200);
+                    }
                 }
                 break;
             }

--- a/test/building.test.js
+++ b/test/building.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Game from '../src/Game.js';
+import { bindCanvasClick } from '../src/ui.js';
+
+function makeFakeCanvas() {
+    const ctx = {
+        fillRect() {},
+        clearRect() {},
+        beginPath() {},
+        arc() {},
+        fill() {},
+        stroke() {},
+        strokeRect() {},
+    };
+    const handlers = {};
+    return {
+        width: 800,
+        height: 450,
+        getContext: () => ctx,
+        addEventListener(type, cb) {
+            handlers[type] = cb;
+        },
+        getBoundingClientRect() {
+            return { left: 0, top: 0 };
+        },
+        dispatch(type, evt) {
+            handlers[type]?.(evt);
+        },
+    };
+}
+
+function attachDomStubs(game) {
+    game.livesEl = { textContent: '' };
+    game.goldEl = { textContent: '' };
+    game.waveEl = { textContent: '' };
+    game.statusEl = { textContent: '', style: {} };
+}
+
+test('builds tower when player has enough gold', () => {
+    const canvas = makeFakeCanvas();
+    const game = new Game(canvas);
+    attachDomStubs(game);
+    bindCanvasClick(game);
+
+    const cell = game.grid[0];
+    canvas.dispatch('click', { clientX: cell.x + 1, clientY: cell.y + 1 });
+
+    assert.equal(game.towers.length, 1);
+    assert.equal(cell.occupied, true);
+    assert.equal(game.gold, game.initialGold - game.towerCost);
+    assert.equal(game.towers[0].level, 1);
+});
+
+test('highlights slot when not enough gold', () => {
+    const canvas = makeFakeCanvas();
+    const game = new Game(canvas);
+    attachDomStubs(game);
+    game.gold = 0;
+    bindCanvasClick(game);
+
+    const cell = game.grid[0];
+    let timeoutFn = null;
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = fn => {
+        timeoutFn = fn;
+        return {};
+    };
+
+    canvas.dispatch('click', { clientX: cell.x + 1, clientY: cell.y + 1 });
+
+    assert.equal(game.towers.length, 0);
+    assert.equal(cell.occupied, false);
+    assert.equal(cell.highlight, true);
+
+    timeoutFn();
+    assert.equal(cell.highlight, false);
+
+    globalThis.setTimeout = originalSetTimeout;
+});
+


### PR DESCRIPTION
## Summary
- Add level property to towers and support slot highlighting when players lack gold
- Track and reset highlight state for grid cells; render highlighted slots in red
- Expand UI click handler to flash empty slots instead of building when gold is insufficient and add tests for building behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a79ce2ba008323afe7a5b8b1dbd65e