### PR TITLE
Implement color damage rules

### DIFF
--- a/docs/Tasks/Tasks_Prototype_3.txt
+++ b/docs/Tasks/Tasks_Prototype_3.txt
@@ -5,7 +5,7 @@ Prototype 3 — Task List
 003 | TODO | Implement tower building: tap empty slot to place Level 1 tower (cost 10). If not enough gold, ignore and briefly highlight slot.
 004 | DONE | Add color property to enemies: 'red' or 'blue'. Show by filling their sprite/rectangle.
 005 | DONE | Add color property to towers. Default new tower = 'red'.
-006 | TODO | Implement color damage rules: if tower.color = enemy.color → 1.0× damage, else 0.4× damage.
+006 | DONE | Implement color damage rules: if tower.color = enemy.color → 1.0× damage, else 0.4× damage.
 007 | TODO | Implement global switch cooldown system: one timer shared by all towers. Tap on a tower switches its color (red ↔ blue) only if cooldown = 0. Set cooldown = 2s.
 008 | TODO | Add HUD indicator for switch cooldown (“Switch ready” bar or simple text).
 009 | TODO | Implement auto-merge mechanic at end of wave: scan slots left to right; if two adjacent towers have same color and same level, merge into one tower (level+1), free second slot. Do only one merge pass per wave.

--- a/src/Game.js
+++ b/src/Game.js
@@ -58,7 +58,9 @@ export default class Game {
             x: c.x,
             y: c.y,
             vx: Math.cos(angle) * this.projectileSpeed,
-            vy: Math.sin(angle) * this.projectileSpeed
+            vy: Math.sin(angle) * this.projectileSpeed,
+            color: tower.color,
+            damage: 1
         });
     }
 

--- a/src/projectiles.js
+++ b/src/projectiles.js
@@ -11,7 +11,9 @@ export function hitEnemy(game, p, index) {
     for (let j = game.enemies.length - 1; j >= 0; j--) {
         const e = game.enemies[j];
         if (p.x >= e.x && p.x <= e.x + e.w && p.y >= e.y && p.y <= e.y + e.h) {
-            e.hp -= 1;
+            const multiplier = p.color === e.color ? 1 : 0.4;
+            const damage = (p.damage ?? 1) * multiplier;
+            e.hp -= damage;
             game.projectiles.splice(index, 1);
             if (e.hp <= 0) {
                 game.enemies.splice(j, 1);

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -40,6 +40,8 @@ test('spawnProjectile main', () => {
     assert.equal(projectile.y, 220);
     assert.ok(Math.abs(projectile.vx - 432.24) < 0.01);
     assert.ok(Math.abs(projectile.vy - 673.18) < 0.01);
+    assert.equal(projectile.color, tower.color);
+    assert.equal(projectile.damage, 1);
 });
 
 test('spawnEnemy main', () => {

--- a/test/projectiles.test.js
+++ b/test/projectiles.test.js
@@ -30,8 +30,8 @@ test('moveProjectiles updates positions', () => {
 
 test('hitEnemy damages enemy and removes projectile when enemy survives', () => {
     const game = makeGame();
-    const enemy = { x: 10, y: 10, w: 20, h: 20, hp: 2 };
-    const projectile = { x: 15, y: 15 };
+    const enemy = { x: 10, y: 10, w: 20, h: 20, hp: 2, color: 'red' };
+    const projectile = { x: 15, y: 15, color: 'red', damage: 1 };
     game.enemies.push(enemy);
     game.projectiles.push(projectile);
 
@@ -46,8 +46,8 @@ test('hitEnemy damages enemy and removes projectile when enemy survives', () => 
 
 test('hitEnemy removes enemy and updates gold when enemy dies', () => {
     const game = makeGame();
-    const enemy = { x: 10, y: 10, w: 20, h: 20, hp: 1 };
-    const projectile = { x: 15, y: 15 };
+    const enemy = { x: 10, y: 10, w: 20, h: 20, hp: 1, color: 'red' };
+    const projectile = { x: 15, y: 15, color: 'red', damage: 1 };
     game.enemies.push(enemy);
     game.projectiles.push(projectile);
 
@@ -62,10 +62,10 @@ test('hitEnemy removes enemy and updates gold when enemy dies', () => {
 
 test('handleProjectileHits removes offscreen and hit projectiles', () => {
     const game = makeGame();
-    const enemy = { x: 10, y: 10, w: 20, h: 20, hp: 1 };
-    const pHit = { x: 15, y: 15 };
-    const pMiss = { x: 100, y: 100 };
-    const pOff = { x: -5, y: 0 };
+    const enemy = { x: 10, y: 10, w: 20, h: 20, hp: 1, color: 'red' };
+    const pHit = { x: 15, y: 15, color: 'red', damage: 1 };
+    const pMiss = { x: 100, y: 100, color: 'red', damage: 1 };
+    const pOff = { x: -5, y: 0, color: 'red', damage: 1 };
     game.enemies.push(enemy);
     game.projectiles.push(pHit, pMiss, pOff);
 
@@ -75,4 +75,20 @@ test('handleProjectileHits removes offscreen and hit projectiles', () => {
     assert.deepEqual(game.projectiles[0], pMiss);
     assert.equal(game.enemies.length, 0);
     assert.equal(game.gold, 1);
+});
+
+test('hitEnemy deals reduced damage when colors differ', () => {
+    const game = makeGame();
+    const enemy = { x: 10, y: 10, w: 20, h: 20, hp: 1, color: 'blue' };
+    const projectile = { x: 15, y: 15, color: 'red', damage: 1 };
+    game.enemies.push(enemy);
+    game.projectiles.push(projectile);
+
+    const result = hitEnemy(game, projectile, 0);
+
+    assert.equal(result, true);
+    assert.ok(Math.abs(enemy.hp - 0.6) < 1e-6);
+    assert.equal(game.projectiles.length, 0);
+    assert.equal(game.enemies.length, 1);
+    assert.equal(game.gold, 0);
 });


### PR DESCRIPTION
## Summary
- track tower color and base damage on projectiles
- apply 1x/0.4x damage multiplier based on matching colors
- test reduced damage for mismatched colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a063e4148323a1a6040bc18bf4c5