### PR TITLE
Implement tower building with slot highlight

### DIFF
--- a/docs/Tasks/Tasks_Prototype_3.txt
+++ b/docs/Tasks/Tasks_Prototype_3.txt
@@ -2,7 +2,7 @@ Prototype 3 — Task List
 
 001 | DONE | Remove build mode toggle and highlighting logic from Prototype 2. Tapping an empty slot should always mean build attempt.
 002 | DONE | Replace grid system with fixed tower slots. Arrange ~10 slots total: 5 on top row and 5 on bottom row, flanking the straight enemy path. Show empty slots as outlined circles or squares.
-003 | TODO | Implement tower building: tap empty slot to place Level 1 tower (cost 10). If not enough gold, ignore and briefly highlight slot.
+003 | DONE | Implement tower building: tap empty slot to place Level 1 tower (cost 10). If not enough gold, ignore and briefly highlight slot.
 004 | DONE | Add color property to enemies: 'red' or 'blue'. Show by filling their sprite/rectangle.
 005 | DONE | Add color property to towers. Default new tower = 'red'.
 006 | DONE | Implement color damage rules: if tower.color = enemy.color → 1.0× damage, else 0.4× damage.

--- a/src/Game.js
+++ b/src/Game.js
@@ -47,8 +47,8 @@ export default class Game {
         const step = 140;
         for (let i = 0; i < 5; i++) {
             const x = startX + i * step;
-            this.grid.push({ x, y: topY, w: 40, h: 40, occupied: false });
-            this.grid.push({ x, y: bottomY, w: 40, h: 40, occupied: false });
+            this.grid.push({ x, y: topY, w: 40, h: 40, occupied: false, highlight: 0 });
+            this.grid.push({ x, y: bottomY, w: 40, h: 40, occupied: false, highlight: 0 });
         }
     }
 
@@ -156,6 +156,11 @@ export default class Game {
         this.towerAttacks(timestamp);
         moveProjectiles(this, dt);
         handleProjectileHits(this);
+        this.grid.forEach(cell => {
+            if (cell.highlight > 0) {
+                cell.highlight = Math.max(0, cell.highlight - dt);
+            }
+        });
         this.checkWaveCompletion();
         draw(this);
         if (!this.gameOver) requestAnimationFrame(this.update);
@@ -170,7 +175,10 @@ export default class Game {
         this.projectiles = [];
         this.waveInProgress = false;
         this.nextWaveBtn.disabled = false;
-        this.grid.forEach(cell => (cell.occupied = false));
+        this.grid.forEach(cell => {
+            cell.occupied = false;
+            cell.highlight = 0;
+        });
         this.spawned = 0;
         this.spawnTimer = 0;
         this.gameOver = false;

--- a/src/Tower.js
+++ b/src/Tower.js
@@ -7,6 +7,7 @@ export default class Tower {
         this.range = 120;
         this.lastShot = 0;
         this.color = color;
+        this.level = 1;
     }
 
     center() {

--- a/src/render.js
+++ b/src/render.js
@@ -23,13 +23,13 @@ function drawBase(game) {
 
 function drawGrid(game) {
     const ctx = game.ctx;
-    ctx.strokeStyle = 'rgba(0,0,0,0.3)';
     game.grid.forEach(cell => {
         if (!cell.occupied) {
             const cx = cell.x + cell.w / 2;
             const cy = cell.y + cell.h / 2;
             ctx.beginPath();
             ctx.arc(cx, cy, cell.w / 2, 0, Math.PI * 2);
+            ctx.strokeStyle = cell.highlight > 0 ? 'red' : 'rgba(0,0,0,0.3)';
             ctx.stroke();
         }
     });

--- a/src/ui.js
+++ b/src/ui.js
@@ -28,11 +28,15 @@ function bindCanvasClick(game) {
         const my = e.clientY - rect.top;
         for (const cell of game.grid) {
             if (mx >= cell.x && mx <= cell.x + cell.w && my >= cell.y && my <= cell.y + cell.h) {
-                if (game.gold >= game.towerCost && !cell.occupied) {
-                    game.towers.push(new Tower(cell.x, cell.y));
-                    cell.occupied = true;
-                    game.gold -= game.towerCost;
-                    updateHUD(game);
+                if (!cell.occupied) {
+                    if (game.gold >= game.towerCost) {
+                        game.towers.push(new Tower(cell.x, cell.y));
+                        cell.occupied = true;
+                        game.gold -= game.towerCost;
+                        updateHUD(game);
+                    } else {
+                        cell.highlight = 0.3;
+                    }
                 }
                 break;
             }

--- a/test/tower.test.js
+++ b/test/tower.test.js
@@ -13,6 +13,11 @@ test('constructor sets default color to red', () => {
     assert.equal(tower.color, 'red');
 });
 
+test('constructor sets level to 1', () => {
+    const tower = new Tower(0, 0);
+    assert.equal(tower.level, 1);
+});
+
 test('draw draws range and tower body correctly', () => {
     const tower = new Tower(50, 60);
     const ctx = makeFakeCtx();


### PR DESCRIPTION
## Summary
- Allow placing Level 1 towers by clicking empty slots, spending gold and updating HUD
- Highlight slots in red briefly when tower purchase fails due to insufficient gold
- Track tower level and grid highlight state for future upgrades

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9bdda65a88323b56c245d2b7e7b0f