### PR TITLE
Add switch cooldown HUD indicator

### DIFF
--- a/docs/Tasks/Tasks_Prototype_3.txt
+++ b/docs/Tasks/Tasks_Prototype_3.txt
@@ -7,7 +7,7 @@ Prototype 3 — Task List
 005 | DONE | Add color property to towers. Default new tower = 'red'.
 006 | DONE | Implement color damage rules: if tower.color = enemy.color → 1.0× damage, else 0.4× damage.
 007 | DONE | Implement global switch cooldown system: one timer shared by all towers. Tap on a tower switches its color (red ↔ blue) only if cooldown = 0. Set cooldown = 2s.
-008 | TODO | Add HUD indicator for switch cooldown (“Switch ready” bar or simple text).
+008 | DONE | Add HUD indicator for switch cooldown (“Switch ready” bar or simple text).
 009 | TODO | Implement auto-merge mechanic at end of wave: scan slots left to right; if two adjacent towers have same color and same level, merge into one tower (level+1), free second slot. Do only one merge pass per wave.
 010 | TODO | Add Level 2 tower stats: +80% damage, +20% radius compared to Level 1.
 011 | TODO | Level 2 towers still switch color, but with global cooldown = 3s instead of 2s.

--- a/src/Game.js
+++ b/src/Game.js
@@ -1,5 +1,5 @@
 import Enemy, { TankEnemy } from './Enemy.js';
-import { updateHUD, endGame } from './ui.js';
+import { updateHUD, endGame, updateSwitchIndicator } from './ui.js';
 import { draw } from './render.js';
 import { moveProjectiles, handleProjectileHits } from './projectiles.js';
 
@@ -81,6 +81,7 @@ export default class Game {
         if (this.switchCooldown > 0) return false;
         tower.color = tower.color === 'red' ? 'blue' : 'red';
         this.switchCooldown = this.switchCooldownDuration;
+        updateSwitchIndicator(this);
         return true;
     }
 
@@ -162,6 +163,7 @@ export default class Game {
         const dt = this.calcDelta(timestamp);
         if (this.switchCooldown > 0) {
             this.switchCooldown = Math.max(0, this.switchCooldown - dt);
+            updateSwitchIndicator(this);
         }
         this.spawnEnemiesIfNeeded(dt);
         this.updateEnemies(dt);
@@ -189,6 +191,7 @@ export default class Game {
         this.statusEl.textContent = '';
         this.switchCooldown = 0;
         updateHUD(this);
+        updateSwitchIndicator(this);
     }
 
     restart() {

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,7 @@
             <span id="lives">Lives: 10</span>
             <span id="gold">Gold: 20</span>
             <span id="wave">Wave: 1/5</span>
+            <span id="cooldown">Switch: Ready</span>
             <span id="status"></span>
             <button id="nextWave">Next Wave</button>
             <button id="restart">Restart</button>

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,12 +5,14 @@ export function bindUI(game) {
     bindButtons(game);
     bindCanvasClick(game);
     updateHUD(game);
+    updateSwitchIndicator(game);
 }
 
 function bindHUD(game) {
     game.livesEl = document.getElementById('lives');
     game.goldEl = document.getElementById('gold');
     game.waveEl = document.getElementById('wave');
+    game.cooldownEl = document.getElementById('cooldown');
     game.statusEl = document.getElementById('status');
     game.nextWaveBtn = document.getElementById('nextWave');
     game.restartBtn = document.getElementById('restart');
@@ -50,6 +52,15 @@ export function updateHUD(game) {
     game.livesEl.textContent = `Lives: ${game.lives}`;
     game.goldEl.textContent = `Gold: ${game.gold}`;
     game.waveEl.textContent = `Wave: ${game.wave}/${game.maxWaves}`;
+}
+
+export function updateSwitchIndicator(game) {
+    if (!game.cooldownEl) return;
+    if (game.switchCooldown > 0) {
+        game.cooldownEl.textContent = `Switch: ${game.switchCooldown.toFixed(1)}s`;
+    } else {
+        game.cooldownEl.textContent = 'Switch: Ready';
+    }
 }
 
 export function endGame(game, text) {

--- a/test/cooldownIndicator.test.js
+++ b/test/cooldownIndicator.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Game from '../src/Game.js';
+import { updateSwitchIndicator } from '../src/ui.js';
+
+function makeFakeCanvas() {
+    return {
+        width: 800,
+        height: 450,
+        getContext: () => ({
+            fillRect: () => {},
+            clearRect: () => {},
+            beginPath: () => {},
+            arc: () => {},
+            fill: () => {},
+            stroke: () => {},
+            strokeRect: () => {},
+        }),
+    };
+}
+
+test('updateSwitchIndicator shows remaining cooldown or ready', () => {
+    const game = { switchCooldown: 1.234, cooldownEl: { textContent: '' } };
+    updateSwitchIndicator(game);
+    assert.equal(game.cooldownEl.textContent, 'Switch: 1.2s');
+    game.switchCooldown = 0;
+    updateSwitchIndicator(game);
+    assert.equal(game.cooldownEl.textContent, 'Switch: Ready');
+});
+
+test('Game.update refreshes cooldown indicator', () => {
+    const game = new Game(makeFakeCanvas());
+    game.cooldownEl = { textContent: '' };
+    game.switchCooldown = 1;
+    const originalRAF = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = () => {};
+    game.lastTime = 0;
+    game.update(1000);
+    globalThis.requestAnimationFrame = originalRAF;
+    assert.equal(game.cooldownEl.textContent, 'Switch: Ready');
+});


### PR DESCRIPTION
## Summary
- show global switch cooldown status in the HUD
- update UI and game logic to refresh cooldown indicator
- cover cooldown indicator with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9bec0b1cc8323ae4b81bf4f692285