### PR TITLE
feat: add level 2 tower stats

### DIFF
--- a/docs/Tasks/Tasks_Prototype_3.txt
+++ b/docs/Tasks/Tasks_Prototype_3.txt
@@ -9,7 +9,7 @@ Prototype 3 — Task List
 007 | DONE | Implement global switch cooldown system: one timer shared by all towers. Tap on a tower switches its color (red ↔ blue) only if cooldown = 0. Set cooldown = 2s.
 008 | DONE | Add HUD indicator for switch cooldown (“Switch ready” bar or simple text).
 009 | DONE | Implement auto-merge mechanic at end of wave: scan slots left to right; if two adjacent towers have same color and same level, merge into one tower (level+1), free second slot. Do only one merge pass per wave.
-010 | TODO | Add Level 2 tower stats: +80% damage, +20% radius compared to Level 1.
+010 | DONE | Add Level 2 tower stats: +80% damage, +20% radius compared to Level 1.
 011 | TODO | Level 2 towers still switch color, but with global cooldown = 3s instead of 2s.
 012 | TODO | Add Swarm enemy type: low HP, high speed. Spawns in groups.
 013 | DONE | Add Tank enemy type: very high HP, slow speed. Spawns in smaller numbers.

--- a/src/Game.js
+++ b/src/Game.js
@@ -62,7 +62,7 @@ export default class Game {
             vx: Math.cos(angle) * this.projectileSpeed,
             vy: Math.sin(angle) * this.projectileSpeed,
             color: tower.color,
-            damage: 1
+            damage: tower.damage
         });
     }
 
@@ -160,6 +160,7 @@ export default class Game {
                     const tb = this.getTowerAt(b);
                     if (ta && tb && ta.color === tb.color && ta.level === tb.level) {
                         ta.level += 1;
+                        ta.updateStats();
                         this.towers = this.towers.filter(t => t !== tb);
                         b.occupied = false;
                         i += 1;

--- a/src/Tower.js
+++ b/src/Tower.js
@@ -4,10 +4,19 @@ export default class Tower {
         this.y = y;
         this.w = 40;
         this.h = 40;
-        this.range = 120;
+        this.baseRange = 120;
+        this.baseDamage = 1;
         this.lastShot = 0;
         this.color = color;
         this.level = level;
+        this.updateStats();
+    }
+
+    updateStats() {
+        const rangeMultiplier = 1 + 0.2 * (this.level - 1);
+        const damageMultiplier = 1 + 0.8 * (this.level - 1);
+        this.range = this.baseRange * rangeMultiplier;
+        this.damage = this.baseDamage * damageMultiplier;
     }
 
     center() {

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -45,6 +45,17 @@ test('spawnProjectile main', () => {
     assert.equal(projectile.damage, 1);
 });
 
+test('spawnProjectile uses tower damage', () => {
+    const fakeCanvas = makeFakeCanvas();
+    const game = new Game(fakeCanvas);
+    const tower = new Tower(100, 200, 'red', 2);
+
+    game.spawnProjectile(0, tower);
+
+    assert.equal(game.projectiles[0].damage, tower.damage);
+    assert.ok(Math.abs(game.projectiles[0].damage - 1.8) < 1e-6);
+});
+
 test('spawnEnemy main', () => {
     const fakeCanvas = makeFakeCanvas();
     const game = new Game(fakeCanvas);

--- a/test/tower.test.js
+++ b/test/tower.test.js
@@ -30,6 +30,12 @@ test('draw draws range and tower body correctly', () => {
     assert.deepEqual(ctx.ops[5], ['fillRect', 50, 60, 40, 40]);
 });
 
+test('level 2 tower has increased range and damage', () => {
+    const tower = new Tower(0, 0, 'red', 2);
+    assert.equal(tower.range, 144);
+    assert.ok(Math.abs(tower.damage - 1.8) < 1e-6);
+});
+
 function makeFakeCtx() {
     const ops = [];
     return {


### PR DESCRIPTION
## Summary
- enhance towers with level-based damage and range boosts
- update projectile spawning and merging logic to respect tower level
- test level 2 stats and projectile damage propagation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9c60b42608323a6903855d739a353