### PR TITLE
feat: expand HUD with gameplay tips

### DIFF
--- a/docs/Tasks/Tasks_Prototype_3.txt
+++ b/docs/Tasks/Tasks_Prototype_3.txt
@@ -19,5 +19,5 @@ Prototype 3 — Task List
     Wave 3+: introduce tanks.
     Later waves: mixed swarms and tanks, increasing randomness in colors (up to 50/50 mix).
 
-015 | TODO | Update HUD: Lives, Gold, Wave X/10, cooldown indicator, tip text “Tap slot to build. Tap tower to switch.”
+015 | DONE | Update HUD: Lives, Gold, Wave X/10, cooldown indicator, tip text “Tap slot to build. Tap tower to switch.”
 016 | TODO | Balance constants: BUILD_COST=10, Lives=10, SwitchCooldown=2s (3s for L2), Damage multipliers (1.0 / 0.4), adjust HP/speed for swarm and tank enemies.

--- a/src/index.html
+++ b/src/index.html
@@ -9,11 +9,12 @@
         <div id="hud">
             <span id="lives">Lives: 10</span>
             <span id="gold">Gold: 20</span>
-            <span id="wave">Wave: 1/5</span>
+            <span id="wave">Wave: 1/10</span>
             <span id="cooldown">Switch: Ready</span>
             <span id="status"></span>
             <button id="nextWave">Next Wave</button>
             <button id="restart">Restart</button>
+            <span id="tip">Tap slot to build. Tap tower to switch.</span>
         </div>
         <canvas id="game" width="800" height="450"></canvas>
         <script type="module" src="main.js"></script>

--- a/src/style.css
+++ b/src/style.css
@@ -5,8 +5,13 @@ body {
 
 #hud {
     display: flex;
+    flex-wrap: wrap;
     gap: 10px;
     align-items: center;
     padding: 10px;
     font-family: sans-serif;
+}
+
+#tip {
+    flex-basis: 100%;
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -14,6 +14,7 @@ function bindHUD(game) {
     game.waveEl = document.getElementById('wave');
     game.cooldownEl = document.getElementById('cooldown');
     game.statusEl = document.getElementById('status');
+    game.tipEl = document.getElementById('tip');
     game.nextWaveBtn = document.getElementById('nextWave');
     game.restartBtn = document.getElementById('restart');
 }

--- a/test/hudTip.test.js
+++ b/test/hudTip.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { bindUI } from '../src/ui.js';
+
+test('bindUI attaches tip element with text', () => {
+  const elements = {};
+  const ids = ['lives','gold','wave','cooldown','status','nextWave','restart','tip'];
+  for (const id of ids) {
+    elements[id] = { textContent: '', addEventListener: () => {} };
+  }
+  elements['tip'].textContent = 'Tap slot to build. Tap tower to switch.';
+  const doc = {
+    getElementById: id => elements[id]
+  };
+  const game = {
+    canvas: { addEventListener: () => {}, getBoundingClientRect: () => ({ left: 0, top: 0 }) },
+    towers: [],
+    grid: [],
+    lives: 5,
+    gold: 20,
+    wave: 1,
+    maxWaves: 10,
+    switchCooldown: 0,
+    towerCost: 10
+  };
+  global.document = doc;
+  bindUI(game);
+  assert.equal(game.tipEl.textContent, 'Tap slot to build. Tap tower to switch.');
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- show gameplay tip in HUD and wire up to Game UI
- style HUD to wrap and reserve space for tip text
- mark task 15 as complete and cover with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9cb2cd4d8832385b376c84f7bfdee