### PR TITLE
Randomize enemy colors

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -80,28 +80,27 @@ export default class Game {
     }
 
     getEnemyColor() {
-        if (this.wave === 1) return 'red';
-        if (this.wave === 2) return 'blue';
-        const mix = Math.min(0.5, 0.1 * (this.wave - 2));
-        return Math.random() < mix ? 'blue' : 'red';
+        return Math.random() < 0.5 ? 'red' : 'blue';
     }
 
     spawnEnemy(type) {
         const hp = this.enemyHpPerWave[this.wave - 1] ?? this.enemyHpPerWave.at(-1);
-        const color = this.getEnemyColor();
         if (!type) {
             const cfg = this.waveConfigs[this.wave - 1] ?? this.waveConfigs.at(-1);
             type = this.wave <= 2 ? 'swarm' : (Math.random() < cfg.tankChance ? 'tank' : 'swarm');
         }
         if (type === 'tank') {
+            const color = this.getEnemyColor();
             this.enemies.push(new TankEnemy(hp * 5, color, this.pathY));
         } else if (type === 'swarm') {
             const groupSize = 3;
             const swarmHp = Math.max(1, Math.floor(hp / 2));
             for (let i = 0; i < groupSize; i++) {
+                const color = this.getEnemyColor();
                 this.enemies.push(new SwarmEnemy(swarmHp, color, this.pathY));
             }
         } else {
+            const color = this.getEnemyColor();
             this.enemies.push(new Enemy(hp, color, this.pathY));
         }
         this.spawned += 1;

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -88,11 +88,37 @@ test('spawnEnemy defaults to last hp for high wave', () => {
     const game = new Game(fakeCanvas);
     game.wave = game.enemyHpPerWave.length + 3;
 
-    game.spawnEnemy();
+    game.spawnEnemy('swarm');
 
     const enemy = game.enemies[0];
     const expectedHp = Math.max(1, Math.floor(game.enemyHpPerWave.at(-1) / 2));
     assert.equal(enemy.maxHp, expectedHp);
+});
+
+test('spawnEnemy assigns random color for each spawned enemy', () => {
+    const fakeCanvas = makeFakeCanvas();
+    const game = new Game(fakeCanvas);
+    const seq = [0.2, 0.8, 0.1]; // red, blue, red
+    const original = Math.random;
+    let i = 0;
+    Math.random = () => seq[i++];
+    try {
+        game.spawnEnemy('swarm');
+    } finally {
+        Math.random = original;
+    }
+    const colors = game.enemies.map(e => e.color);
+    assert.deepEqual(colors, ['red', 'blue', 'red']);
+});
+
+test('getEnemyColor picks red or blue based on Math.random', () => {
+    const game = new Game(makeFakeCanvas());
+    const original = Math.random;
+    Math.random = () => 0.3;
+    assert.equal(game.getEnemyColor(), 'red');
+    Math.random = () => 0.7;
+    assert.equal(game.getEnemyColor(), 'blue');
+    Math.random = original;
 });
 
 test('calcDelta returns delta time in seconds and updates lastTime', () => {


### PR DESCRIPTION
## Summary
- Ensure each enemy color is chosen randomly when spawning
- Add tests covering color randomization and color picker logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9ccacc64c83238db7e56e0e8b76d3