### PR TITLE
Balance gameplay and improve targeting

### DIFF
--- a/docs/WinningStrategy.md
+++ b/docs/WinningStrategy.md
@@ -1,0 +1,11 @@
+# Winning Strategy
+
+To survive all waves:
+
+1. **Build early** – Spend your starting gold on five towers before the first wave. Place them so they cover both lanes.
+2. **Match colors** – Enemies take full damage from projectiles of the same color. Switch tower colors when waves change.
+3. **Merge wisely** – After each wave, adjacent towers of the same color and level merge into stronger ones. Plan your placements to merge and upgrade.
+4. **Focus fire** – Target tanks with upgraded towers while swarms are handled by multiple basic towers.
+5. **Stay reactive** – Watch cooldowns and switch colors to counter mixed enemy colors.
+
+Playing with these tactics should allow you to defeat waves with a good chance of success.

--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -4,7 +4,7 @@ export default class Enemy {
         this.y = y;
         this.w = 30;
         this.h = 30;
-        this.speed = 100;
+        this.speed = 40;
         this.maxHp = maxHp;
         this.hp = this.maxHp;
         this.color = color;
@@ -39,13 +39,13 @@ export default class Enemy {
 export class TankEnemy extends Enemy {
     constructor(maxHp = 15) {
         super(maxHp);
-        this.speed = 40;
+        this.speed = 25;
     }
 }
 
 export class SwarmEnemy extends Enemy {
     constructor(maxHp = 1, color = 'red', y = 365) {
         super(maxHp, color, y);
-        this.speed = 160;
+        this.speed = 50;
     }
 }

--- a/src/Game.js
+++ b/src/Game.js
@@ -22,8 +22,8 @@ export default class Game {
     }
 
     initStats() {
-        this.initialLives = 5;
-        this.initialGold = 20;
+        this.initialLives = 10;
+        this.initialGold = 50;
         this.lives = this.initialLives;
         this.gold = this.initialGold;
         this.wave = 1;
@@ -67,7 +67,7 @@ export default class Game {
         }
     }
 
-    spawnProjectile(angle, tower) {
+    spawnProjectile(angle, tower, target = null) {
         const c = tower.center();
         this.projectiles.push({
             x: c.x,
@@ -75,7 +75,8 @@ export default class Game {
             vx: Math.cos(angle) * this.projectileSpeed,
             vy: Math.sin(angle) * this.projectileSpeed,
             color: tower.color,
-            damage: tower.damage
+            damage: tower.damage,
+            target,
         });
     }
 
@@ -168,7 +169,7 @@ export default class Game {
                 const dx = enemyCenter.x - towerCenter.x;
                 const dy = enemyCenter.y - towerCenter.y;
                 if (Math.hypot(dx, dy) <= tower.range && timestamp - tower.lastShot >= this.projectileSpawnInterval) {
-                    this.spawnProjectile(Math.atan2(dy, dx), tower);
+                    this.spawnProjectile(Math.atan2(dy, dx), tower, target);
                     tower.lastShot = timestamp;
                     break;
                 }

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
     <body>
         <div id="hud">
             <span id="lives">Lives: 10</span>
-            <span id="gold">Gold: 20</span>
+            <span id="gold">Gold: 50</span>
             <span id="wave">Wave: 1/10</span>
             <span id="cooldown">Switch: Ready</span>
             <span id="status"></span>

--- a/src/projectiles.js
+++ b/src/projectiles.js
@@ -2,6 +2,17 @@ import { updateHUD } from './ui.js';
 
 export function moveProjectiles(game, dt) {
     for (const p of game.projectiles) {
+        if (p.target && game.enemies.includes(p.target)) {
+            const enemyCenter = {
+                x: p.target.x + p.target.w / 2,
+                y: p.target.y + p.target.h / 2,
+            };
+            const dx = enemyCenter.x - p.x;
+            const dy = enemyCenter.y - p.y;
+            const dist = Math.hypot(dx, dy) || 1;
+            p.vx = (dx / dist) * game.projectileSpeed;
+            p.vy = (dy / dist) * game.projectileSpeed;
+        }
         p.x += p.vx * dt;
         p.y += p.vy * dt;
     }

--- a/test/enemy.test.js
+++ b/test/enemy.test.js
@@ -5,9 +5,9 @@ import Enemy, { TankEnemy, SwarmEnemy } from '../src/Enemy.js';
 test('update moves enemy based on dt and speed', () => {
     const enemy = new Enemy();
     enemy.update(0.5);
-    assert.equal(enemy.x, 50);
+    assert.equal(enemy.x, 20);
     enemy.update(0.25);
-    assert.equal(enemy.x, 75);
+    assert.equal(enemy.x, 30);
 });
 
 test('isOutOfBounds returns correct value', () => {

--- a/test/projectiles.test.js
+++ b/test/projectiles.test.js
@@ -7,6 +7,7 @@ function makeGame() {
         projectiles: [],
         enemies: [],
         canvas: { width: 800, height: 600 },
+        projectileSpeed: 800,
         gold: 0,
         wave: 1,
         maxWaves: 5,
@@ -26,6 +27,18 @@ test('moveProjectiles updates positions', () => {
 
     assert.deepEqual(game.projectiles[0], { x: 5, y: 0, vx: 10, vy: 0 });
     assert.deepEqual(game.projectiles[1], { x: 40, y: 55, vx: -20, vy: 10 });
+});
+
+test('moveProjectiles homes towards target when provided', () => {
+    const game = makeGame();
+    const target = { x: 100, y: -5, w: 10, h: 10 };
+    game.enemies.push(target);
+    game.projectiles.push({ x: 0, y: 0, vx: 0, vy: 0, target });
+
+    moveProjectiles(game, 0.5);
+
+    assert.ok(game.projectiles[0].x > 0);
+    assert.equal(game.projectiles[0].y, 0);
 });
 
 test('hitEnemy damages enemy and removes projectile when enemy survives', () => {


### PR DESCRIPTION
## Summary
- Slow enemy movement to lengthen path and balance waves
- Add homing projectiles and boost starting resources for fairer play
- Document winning strategy for players

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9d2fb9a1c8323a188bc063d8b4739