### PR TITLE
Switch game to vertical orientation

### DIFF
--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -1,6 +1,6 @@
 export default class Enemy {
-    constructor(maxHp = 3, color = 'red', y = 365) {
-        this.x = 0;
+    constructor(maxHp = 3, color = 'red', x = 0, y = 0) {
+        this.x = x;
         this.y = y;
         this.w = 30;
         this.h = 30;
@@ -11,7 +11,7 @@ export default class Enemy {
     }
 
     update(dt) {
-        this.x += this.speed * dt;
+        this.y -= this.speed * dt;
     }
 
     draw(ctx) {
@@ -31,21 +31,21 @@ export default class Enemy {
         ctx.strokeRect(barX, barY, barWidth, barHeight);
     }
 
-    isOutOfBounds(width) {
-        return this.x + this.w >= width;
+    isOutOfBounds() {
+        return this.y + this.h <= 0;
     }
 }
 
 export class TankEnemy extends Enemy {
-    constructor(maxHp = 15) {
-        super(maxHp);
+    constructor(maxHp = 15, color = 'red', x = 0, y = 0) {
+        super(maxHp, color, x, y);
         this.speed = 40;
     }
 }
 
 export class SwarmEnemy extends Enemy {
-    constructor(maxHp = 1, color = 'red', y = 365) {
-        super(maxHp, color, y);
+    constructor(maxHp = 1, color = 'red', x = 0, y = 0) {
+        super(maxHp, color, x, y);
         this.speed = 160;
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
             <button id="restart">Restart</button>
             <span id="tip">Tap slot to build. Tap tower to switch.</span>
         </div>
-        <canvas id="game" width="800" height="450"></canvas>
+        <canvas id="game" width="450" height="800"></canvas>
         <script type="module" src="main.js"></script>
     </body>
 </html>

--- a/src/render.js
+++ b/src/render.js
@@ -10,9 +10,9 @@ export function draw(game) {
 function drawGround(game) {
     const ctx = game.ctx;
     ctx.fillStyle = '#888';
-    const pathHeight = 20;
-    const y = game.pathY + (30 - pathHeight) / 2;
-    ctx.fillRect(0, y, game.canvas.width, pathHeight);
+    const pathWidth = 20;
+    const x = game.pathX + (30 - pathWidth) / 2;
+    ctx.fillRect(x, 0, pathWidth, game.canvas.height);
 }
 
 function drawBase(game) {

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -6,8 +6,8 @@ import { TankEnemy, SwarmEnemy } from '../src/Enemy.js';
 
 function makeFakeCanvas() {
     return {
-        width: 800,
-        height: 450,
+        width: 450,
+        height: 800,
         getContext: () => ({
             fillRect: () => {},
             clearRect: () => {},
@@ -150,8 +150,8 @@ test('updateEnemies removes enemies reaching base and reduces lives', () => {
     const game = new Game(makeFakeCanvas());
     attachDomStubs(game);
     const enemy = {
-        x: game.base.x - 10,
-        w: 20,
+        y: game.base.y + game.base.h - 10,
+        h: 20,
         update: () => {},
         isOutOfBounds: () => false,
     };

--- a/test/cooldownIndicator.test.js
+++ b/test/cooldownIndicator.test.js
@@ -5,8 +5,8 @@ import { updateSwitchIndicator } from '../src/ui.js';
 
 function makeFakeCanvas() {
     return {
-        width: 800,
-        height: 450,
+        width: 450,
+        height: 800,
         getContext: () => ({
             fillRect: () => {},
             clearRect: () => {},

--- a/test/enemy.test.js
+++ b/test/enemy.test.js
@@ -3,39 +3,38 @@ import assert from 'node:assert/strict';
 import Enemy, { TankEnemy, SwarmEnemy } from '../src/Enemy.js';
 
 test('update moves enemy based on dt and speed', () => {
-    const enemy = new Enemy();
+    const enemy = new Enemy(3, 'red', 0, 100);
     enemy.update(0.5);
-    assert.equal(enemy.x, 50);
+    assert.equal(enemy.y, 50);
     enemy.update(0.25);
-    assert.equal(enemy.x, 75);
+    assert.equal(enemy.y, 25);
 });
 
 test('isOutOfBounds returns correct value', () => {
-    const enemy = new Enemy();
-    enemy.x = 770; // x + w = 800
-    assert.equal(enemy.isOutOfBounds(800), true);
-    enemy.x = 769; // x + w = 799
-    assert.equal(enemy.isOutOfBounds(800), false);
+    const enemy = new Enemy(3, 'red', 0, -30); // y + h = 0
+    assert.equal(enemy.isOutOfBounds(), true);
+    enemy.y = -29; // y + h = 1
+    assert.equal(enemy.isOutOfBounds(), false);
 });
 
 test('draw uses enemy color and health bar correctly', () => {
-    const enemy = new Enemy(10, 'blue');
+    const enemy = new Enemy(10, 'blue', 0, 50);
     enemy.hp = 5; // half health
     const ctx = makeFakeCtx();
     enemy.draw(ctx);
 
     // body
     assert.deepEqual(ctx.ops[0], ['fillStyle', 'blue']);
-    assert.deepEqual(ctx.ops[1], ['fillRect', 0, 365, 30, 30]);
+    assert.deepEqual(ctx.ops[1], ['fillRect', 0, 50, 30, 30]);
     // health bar background
     assert.deepEqual(ctx.ops[2], ['fillStyle', 'red']);
-    assert.deepEqual(ctx.ops[3], ['fillRect', 0, 359, 30, 4]);
+    assert.deepEqual(ctx.ops[3], ['fillRect', 0, 44, 30, 4]);
     // health bar current hp
     assert.deepEqual(ctx.ops[4], ['fillStyle', 'green']);
-    assert.deepEqual(ctx.ops[5], ['fillRect', 0, 359, 15, 4]);
+    assert.deepEqual(ctx.ops[5], ['fillRect', 0, 44, 15, 4]);
     // border
     assert.deepEqual(ctx.ops[6], ['strokeStyle', 'black']);
-    assert.deepEqual(ctx.ops[7], ['strokeRect', 0, 359, 30, 4]);
+    assert.deepEqual(ctx.ops[7], ['strokeRect', 0, 44, 30, 4]);
 });
 
 test('tank enemy has higher hp and slower speed', () => {

--- a/test/projectiles.test.js
+++ b/test/projectiles.test.js
@@ -6,7 +6,7 @@ function makeGame() {
     return {
         projectiles: [],
         enemies: [],
-        canvas: { width: 800, height: 600 },
+        canvas: { width: 450, height: 800 },
         gold: 0,
         wave: 1,
         maxWaves: 5,

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -57,7 +57,7 @@ test('draw clears canvas, draws entities and projectiles', () => {
     const projectile = { x: 25, y: 35 };
     const game = {
         ctx,
-        canvas: { width: 800, height: 450 },
+        canvas: { width: 450, height: 800 },
         base: { x: 0, y: 0, w: 0, h: 0 },
         grid: [],
         towers: [tower],
@@ -68,7 +68,7 @@ test('draw clears canvas, draws entities and projectiles', () => {
 
     draw(game);
 
-    assert.ok(ctx.ops.some(op => op[0] === 'clearRect' && op[1] === 0 && op[2] === 0 && op[3] === 800 && op[4] === 450));
+    assert.ok(ctx.ops.some(op => op[0] === 'clearRect' && op[1] === 0 && op[2] === 0 && op[3] === 450 && op[4] === 800));
     assert.ok(towerCalled);
     assert.ok(enemyCalled);
     const twoPi = Math.PI * 2;

--- a/test/switchCooldown.test.js
+++ b/test/switchCooldown.test.js
@@ -5,8 +5,8 @@ import Tower from '../src/Tower.js';
 
 function makeFakeCanvas() {
     return {
-        width: 800,
-        height: 450,
+        width: 450,
+        height: 800,
         getContext: () => ({
             fillRect: () => {},
             clearRect: () => {},


### PR DESCRIPTION
## Summary
- Orient canvas and gameplay vertically for mobile-style portrait mode.
- Reposition path, base, grid, and enemy spawning to suit bottom-to-top movement.
- Update tests and rendering logic for vertical orientation.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa15cc23b48323a59b3510df696e78