### PR TITLE
feat: show tower level and highlight upgrades

### DIFF
--- a/src/Tower.js
+++ b/src/Tower.js
@@ -37,5 +37,14 @@ export default class Tower {
 
         ctx.fillStyle = this.color;
         ctx.fillRect(this.x, this.y, this.w, this.h);
+
+        if (this.level > 1) {
+            ctx.strokeStyle = 'yellow';
+            ctx.strokeRect(this.x - 2, this.y - 2, this.w + 4, this.h + 4);
+        }
+
+        ctx.fillStyle = 'black';
+        ctx.font = '10px sans-serif';
+        ctx.fillText(String(this.level), this.x + this.w + 2, this.y + 10);
     }
 }

--- a/test/tower.test.js
+++ b/test/tower.test.js
@@ -36,6 +36,14 @@ test('level 2 tower has increased range and damage', () => {
     assert.ok(Math.abs(tower.damage - 1.8) < 1e-6);
 });
 
+test('draw shows tower level and highlight for upgrades', () => {
+    const tower = new Tower(50, 60, 'red', 2);
+    const ctx = makeFakeCtx();
+    tower.draw(ctx);
+    assert.ok(ctx.ops.some(op => op[0] === 'strokeRect' && op[1] === 48 && op[2] === 58 && op[3] === 44 && op[4] === 44));
+    assert.ok(ctx.ops.some(op => op[0] === 'fillText' && op[1] === '2'));
+});
+
 function makeFakeCtx() {
     const ops = [];
     return {
@@ -46,6 +54,9 @@ function makeFakeCtx() {
         stroke() { ops.push(['stroke']); },
         set fillStyle(v) { ops.push(['fillStyle', v]); },
         fillRect(x, y, w, h) { ops.push(['fillRect', x, y, w, h]); },
+        strokeRect(x, y, w, h) { ops.push(['strokeRect', x, y, w, h]); },
+        set font(v) { ops.push(['font', v]); },
+        fillText(t, x, y) { ops.push(['fillText', t, x, y]); },
     };
 }
 


### PR DESCRIPTION
## Summary
- draw yellow border around upgraded towers and display their level
- test drawing of level text and upgrade highlight

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa1d8728c483238c168c283f71dc3c