### PR TITLE
feat: add distinct tower shapes

### DIFF
--- a/src/Tower.js
+++ b/src/Tower.js
@@ -36,7 +36,7 @@ export default class Tower {
         ctx.stroke();
 
         ctx.fillStyle = this.color;
-        ctx.fillRect(this.x, this.y, this.w, this.h);
+        this.drawBody(ctx, c);
 
         if (this.level > 1) {
             ctx.strokeStyle = 'yellow';
@@ -46,5 +46,39 @@ export default class Tower {
         ctx.fillStyle = 'black';
         ctx.font = '10px sans-serif';
         ctx.fillText(String(this.level), this.x + this.w + 2, this.y + 10);
+    }
+
+    drawBody(ctx, c) {
+        const size = this.w / 2;
+        ctx.beginPath();
+
+        if (this.level === 1) {
+            ctx.moveTo(c.x, this.y);
+            ctx.lineTo(this.x, this.y + this.h);
+            ctx.lineTo(this.x + this.w, this.y + this.h);
+        } else if (this.level === 2) {
+            for (let i = 0; i < 6; i++) {
+                const angle = Math.PI / 3 * i - Math.PI / 6;
+                const x = c.x + size * Math.cos(angle);
+                const y = c.y + size * Math.sin(angle);
+                if (i === 0) ctx.moveTo(x, y);
+                else ctx.lineTo(x, y);
+            }
+        } else {
+            const spikes = 5;
+            const outer = size;
+            const inner = size / 2;
+            for (let i = 0; i < spikes * 2; i++) {
+                const r = i % 2 === 0 ? outer : inner;
+                const angle = (Math.PI / spikes) * i - Math.PI / 2;
+                const x = c.x + r * Math.cos(angle);
+                const y = c.y + r * Math.sin(angle);
+                if (i === 0) ctx.moveTo(x, y);
+                else ctx.lineTo(x, y);
+            }
+        }
+
+        ctx.closePath();
+        ctx.fill();
     }
 }

--- a/test/tower.test.js
+++ b/test/tower.test.js
@@ -27,7 +27,15 @@ test('draw draws range and tower body correctly', () => {
     assert.deepEqual(ctx.ops[2], ['strokeStyle', 'rgba(255,0,0,0.3)']);
     assert.deepEqual(ctx.ops[3], ['stroke']);
     assert.deepEqual(ctx.ops[4], ['fillStyle', 'red']);
-    assert.deepEqual(ctx.ops[5], ['fillRect', 50, 60, 40, 40]);
+    assert.deepEqual(ctx.ops[5], ['beginPath']);
+    assert.deepEqual(ctx.ops[6], ['moveTo', 70, 60]);
+    assert.deepEqual(ctx.ops[7], ['lineTo', 50, 100]);
+    assert.deepEqual(ctx.ops[8], ['lineTo', 90, 100]);
+    assert.deepEqual(ctx.ops[9], ['closePath']);
+    assert.deepEqual(ctx.ops[10], ['fill']);
+    assert.deepEqual(ctx.ops[11], ['fillStyle', 'black']);
+    assert.deepEqual(ctx.ops[12], ['font', '10px sans-serif']);
+    assert.deepEqual(ctx.ops[13], ['fillText', '1', 92, 70]);
 });
 
 test('level 2 tower has increased range and damage', () => {
@@ -36,10 +44,12 @@ test('level 2 tower has increased range and damage', () => {
     assert.ok(Math.abs(tower.damage - 1.8) < 1e-6);
 });
 
-test('draw shows tower level and highlight for upgrades', () => {
+test('level 2 tower draws hexagon body and shows level and highlight', () => {
     const tower = new Tower(50, 60, 'red', 2);
     const ctx = makeFakeCtx();
     tower.draw(ctx);
+    const lineTos = ctx.ops.filter(op => op[0] === 'lineTo');
+    assert.equal(lineTos.length, 5);
     assert.ok(ctx.ops.some(op => op[0] === 'strokeRect' && op[1] === 48 && op[2] === 58 && op[3] === 44 && op[4] === 44));
     assert.ok(ctx.ops.some(op => op[0] === 'fillText' && op[1] === '2'));
 });
@@ -50,10 +60,13 @@ function makeFakeCtx() {
         ops,
         beginPath() { ops.push(['beginPath']); },
         arc(x, y, r, s, e) { ops.push(['arc', x, y, r, s, e]); },
+        moveTo(x, y) { ops.push(['moveTo', x, y]); },
+        lineTo(x, y) { ops.push(['lineTo', x, y]); },
+        closePath() { ops.push(['closePath']); },
         set strokeStyle(v) { ops.push(['strokeStyle', v]); },
         stroke() { ops.push(['stroke']); },
         set fillStyle(v) { ops.push(['fillStyle', v]); },
-        fillRect(x, y, w, h) { ops.push(['fillRect', x, y, w, h]); },
+        fill() { ops.push(['fill']); },
         strokeRect(x, y, w, h) { ops.push(['strokeRect', x, y, w, h]); },
         set font(v) { ops.push(['font', v]); },
         fillText(t, x, y) { ops.push(['fillText', t, x, y]); },


### PR DESCRIPTION
## Summary
- draw triangle towers for level 1, hexagons for level 2, and stars beyond
- update tower tests for new shape rendering

## Testing
- `npm test` *(fails: checkWaveCompletion merges adjacent towers of same color and level, hitEnemy deals reduced damage when colors differ)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2459f8d48323a48ac0bb6358c20f