### PR TITLE
Add dynamic enemy color probability shift

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -52,6 +52,8 @@ export default class Game {
         this.shootingInterval = 500;
         this.switchCooldownDuration = 0.5;
         this.switchCooldown = 0;
+        this.colorProbStart = 0.5;
+        this.colorProbEnd = 0.5;
     }
 
     createGrid() {
@@ -80,7 +82,10 @@ export default class Game {
     }
 
     getEnemyColor() {
-        return Math.random() < 0.5 ? 'red' : 'blue';
+        const denom = this.enemiesPerWave - 1;
+        const progress = denom > 0 ? this.spawned / denom : 1;
+        const p = this.colorProbStart + (this.colorProbEnd - this.colorProbStart) * progress;
+        return Math.random() < p ? 'red' : 'blue';
     }
 
     spawnEnemy(type) {
@@ -127,6 +132,10 @@ export default class Game {
         this.enemies = [];
         this.spawned = 0;
         this.spawnTimer = 0;
+        do {
+            this.colorProbStart = Math.random();
+            this.colorProbEnd = Math.random();
+        } while (Math.abs(this.colorProbStart - this.colorProbEnd) <= 0.35);
         this.spawnEnemy();
     }
 

--- a/src/projectiles.js
+++ b/src/projectiles.js
@@ -11,7 +11,7 @@ export function hitEnemy(game, p, index) {
     for (let j = game.enemies.length - 1; j >= 0; j--) {
         const e = game.enemies[j];
         if (p.x >= e.x && p.x <= e.x + e.w && p.y >= e.y && p.y <= e.y + e.h) {
-            const multiplier = p.color === e.color ? 1 : 0.1;
+            const multiplier = p.color === e.color ? 1 : 0.4;
             const damage = (p.damage ?? 1) * multiplier;
             e.hp -= damage;
             game.projectiles.splice(index, 1);

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -121,6 +121,42 @@ test('getEnemyColor picks red or blue based on Math.random', () => {
     Math.random = original;
 });
 
+test('startWave picks distinct color probabilities A and B', () => {
+    const game = new Game(makeFakeCanvas());
+    attachDomStubs(game);
+    const seq = [0.1, 0.4, 0.2, 0.8, 0.1, 0.9, 0.2];
+    const original = Math.random;
+    let i = 0;
+    Math.random = () => seq[i++];
+    try {
+        game.startWave();
+    } finally {
+        Math.random = original;
+    }
+    assert.equal(game.colorProbStart, 0.2);
+    assert.equal(game.colorProbEnd, 0.8);
+    assert.ok(Math.abs(game.colorProbStart - game.colorProbEnd) > 0.35);
+});
+
+test('getEnemyColor probability shifts linearly across wave', () => {
+    const game = new Game(makeFakeCanvas());
+    game.enemiesPerWave = 4;
+    game.spawned = 0;
+    game.colorProbStart = 0.2;
+    game.colorProbEnd = 0.8;
+    const seq = [0.1, 0.5, 0.55, 0.9];
+    const original = Math.random;
+    let i = 0;
+    Math.random = () => seq[i++];
+    const colors = [];
+    for (let j = 0; j < 4; j++) {
+        colors.push(game.getEnemyColor());
+        game.spawned += 1;
+    }
+    Math.random = original;
+    assert.deepEqual(colors, ['red', 'blue', 'red', 'blue']);
+});
+
 test('calcDelta returns delta time in seconds and updates lastTime', () => {
     const game = new Game(makeFakeCanvas());
     game.lastTime = 1000;
@@ -180,7 +216,7 @@ test('checkWaveCompletion merges adjacent towers of same color and level', () =>
     const game = new Game(makeFakeCanvas());
     attachDomStubs(game);
     const cellA = game.grid[0];
-    const cellB = game.grid[1];
+    const cellB = game.grid[2];
     const t1 = new Tower(cellA.x, cellA.y, 'red');
     const t2 = new Tower(cellB.x, cellB.y, 'red');
     game.towers.push(t1, t2);


### PR DESCRIPTION
## Summary
- Vary enemy color spawn chance linearly from random start and end values per wave
- Store and update probabilities when a wave begins
- Fix mismatched-color projectile damage multiplier and adjust tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa250375a08323a7af652576a9a916