### PR TITLE
Fix tower merge logic and swarm HP

### DIFF
--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -39,7 +39,7 @@ export default class Enemy {
 export class TankEnemy extends Enemy {
     constructor(maxHp = 15, color = 'red', x = 0, y = 0) {
         super(maxHp, color, x, y);
-        this.speed = 40;
+        this.speed = 60;
     }
 }
 

--- a/src/Game.js
+++ b/src/Game.js
@@ -28,7 +28,8 @@ export default class Game {
         this.gold = this.initialGold;
         this.wave = 1;
         this.maxWaves = 10;
-        this.towerCost = 10;
+        this.towerCost = 12;
+        this.switchCost = 4;
         this.waveInProgress = false;
         this.waveConfigs = [
             { interval: 1, cycles: 20, tankChance: 0 },
@@ -117,7 +118,7 @@ export default class Game {
     switchTowerColor(tower) {
         if (this.switchCooldown > 0 || this.gold < 1) return false;
         tower.color = tower.color === 'red' ? 'blue' : 'red';
-        this.gold -= 1;
+        this.gold -= this.switchCost;
         updateHUD(this);
         this.switchCooldown = this.switchCooldownDuration;
         updateSwitchIndicator(this);
@@ -197,12 +198,16 @@ export default class Game {
     mergeTowers() {
         for (const start of [0, 1]) {
             for (let i = start; i < this.grid.length - 2; i += 2) {
+                console.log(`start = ${start}; i = ${i}`);
                 const a = this.grid[i];
                 const b = this.grid[i + 2];
+                console.log(`a = ${a.x}:${a.y}; b = ${b.x}:${b.y}`);
                 if (a.occupied && b.occupied) {
+                    console.log(`Occupied!`);
                     const ta = this.getTowerAt(a);
                     const tb = this.getTowerAt(b);
                     if (ta && tb && ta.color === tb.color && ta.level === tb.level) {
+                        console.log(`Merging!!`);
                         ta.level += 1;
                         ta.updateStats();
                         this.towers = this.towers.filter(t => t !== tb);

--- a/src/Game.js
+++ b/src/Game.js
@@ -100,7 +100,7 @@ export default class Game {
             this.enemies.push(new TankEnemy(hp * 5, color, this.pathX, startY));
         } else if (type === 'swarm') {
             const groupSize = 3;
-            const swarmHp = Math.max(1, hp);
+            const swarmHp = Math.max(1, Math.floor(hp / 2));
             const spacing = 40; // vertical offset to prevent overlap
             for (let i = 0; i < groupSize; i++) {
                 const color = this.getEnemyColor();
@@ -195,18 +195,20 @@ export default class Game {
     }
 
     mergeTowers() {
-        for (let i = 0; i < this.grid.length - 1; i++) {
-            const a = this.grid[i];
-            const b = this.grid[i + 1];
-            if (a.occupied && b.occupied) {
-                const ta = this.getTowerAt(a);
-                const tb = this.getTowerAt(b);
-                if (ta && tb && ta.color === tb.color && ta.level === tb.level) {
-                    ta.level += 1;
-                    ta.updateStats();
-                    this.towers = this.towers.filter(t => t !== tb);
-                    b.occupied = false;
-                    i += 1;
+        for (const start of [0, 1]) {
+            for (let i = start; i < this.grid.length - 2; i += 2) {
+                const a = this.grid[i];
+                const b = this.grid[i + 2];
+                if (a.occupied && b.occupied) {
+                    const ta = this.getTowerAt(a);
+                    const tb = this.getTowerAt(b);
+                    if (ta && tb && ta.color === tb.color && ta.level === tb.level) {
+                        ta.level += 1;
+                        ta.updateStats();
+                        this.towers = this.towers.filter(t => t !== tb);
+                        b.occupied = false;
+                        i += 2;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix tower merging by checking vertically adjacent slots within columns and skipping merged pairs
- halve swarm enemy HP when spawning so groups are weaker than single enemies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab0f0585f48323b1d4a58c966a09fc