### PR TITLE
Rotate enemy direction to top-down

### DIFF
--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -11,7 +11,7 @@ export default class Enemy {
     }
 
     update(dt) {
-        this.y -= this.speed * dt;
+        this.y += this.speed * dt;
     }
 
     draw(ctx) {
@@ -31,8 +31,8 @@ export default class Enemy {
         ctx.strokeRect(barX, barY, barWidth, barHeight);
     }
 
-    isOutOfBounds() {
-        return this.y + this.h <= 0;
+    isOutOfBounds(canvasHeight) {
+        return this.y >= canvasHeight;
     }
 }
 

--- a/src/Game.js
+++ b/src/Game.js
@@ -16,7 +16,7 @@ export default class Game {
         this.lastTime = 0;
         this.initStats();
         this.pathX = canvas.width / 2 - 15;
-        this.base = { x: this.pathX, y: 0, w: 40, h: 40 };
+        this.base = { x: this.pathX, y: canvas.height - 40, w: 40, h: 40 };
         this.createGrid();
         this.update = this.update.bind(this);
     }
@@ -61,10 +61,10 @@ export default class Game {
         this.grid = [];
         const leftX = this.pathX - 60;
         const rightX = this.pathX + 60;
-        const startY = 60;
+        const startY = this.canvas.height - 100;
         const step = 80;
         for (let i = 0; i < 5; i++) {
-            const y = startY + i * step;
+            const y = startY - i * step;
             this.grid.push({ x: leftX, y, w: 40, h: 40, occupied: false, highlight: 0 });
             this.grid.push({ x: rightX, y, w: 40, h: 40, occupied: false, highlight: 0 });
         }
@@ -95,7 +95,7 @@ export default class Game {
             const cfg = this.waveConfigs[this.wave - 1] ?? this.waveConfigs.at(-1);
             type = this.wave <= 2 ? 'swarm' : (Math.random() < cfg.tankChance ? 'tank' : 'swarm');
         }
-        const startY = this.canvas.height - 30;
+        const startY = 0;
         if (type === 'tank') {
             const color = this.getEnemyColor();
             this.enemies.push(new TankEnemy(hp * 5, color, this.pathX, startY));
@@ -105,7 +105,7 @@ export default class Game {
             const spacing = 40; // vertical offset to prevent overlap
             for (let i = 0; i < groupSize; i++) {
                 const color = this.getEnemyColor();
-                const y = startY - i * spacing;
+                const y = startY + i * spacing;
                 this.enemies.push(new SwarmEnemy(swarmHp, color, this.pathX, y));
             }
         } else {
@@ -162,14 +162,14 @@ export default class Game {
         for (let i = this.enemies.length - 1; i >= 0; i--) {
             const e = this.enemies[i];
             e.update(dt);
-            if (e.y <= this.base.y + this.base.h) {
+            if (e.y + e.h >= this.base.y) {
                 this.enemies.splice(i, 1);
                 this.lives -= 1;
                 updateHUD(this);
                 if (this.lives <= 0) {
                     endGame(this, 'LOSE');
                 }
-            } else if (e.isOutOfBounds()) {
+            } else if (e.isOutOfBounds(this.canvas.height)) {
                 this.enemies.splice(i, 1);
             }
         }

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -186,7 +186,7 @@ test('updateEnemies removes enemies reaching base and reduces lives', () => {
     const game = new Game(makeFakeCanvas());
     attachDomStubs(game);
     const enemy = {
-        y: game.base.y + game.base.h - 10,
+        y: game.base.y - 10,
         h: 20,
         update: () => {},
         isOutOfBounds: () => false,

--- a/test/enemy.test.js
+++ b/test/enemy.test.js
@@ -5,16 +5,16 @@ import Enemy, { TankEnemy, SwarmEnemy } from '../src/Enemy.js';
 test('update moves enemy based on dt and speed', () => {
     const enemy = new Enemy(3, 'red', 0, 100);
     enemy.update(0.5);
-    assert.equal(enemy.y, 50);
+    assert.equal(enemy.y, 150);
     enemy.update(0.25);
-    assert.equal(enemy.y, 25);
+    assert.equal(enemy.y, 175);
 });
 
 test('isOutOfBounds returns correct value', () => {
-    const enemy = new Enemy(3, 'red', 0, -30); // y + h = 0
-    assert.equal(enemy.isOutOfBounds(), true);
-    enemy.y = -29; // y + h = 1
-    assert.equal(enemy.isOutOfBounds(), false);
+    const enemy = new Enemy(3, 'red', 0, 800);
+    assert.equal(enemy.isOutOfBounds(800), true);
+    enemy.y = 799;
+    assert.equal(enemy.isOutOfBounds(800), false);
 });
 
 test('draw uses enemy color and health bar correctly', () => {

--- a/test/switchCooldown.test.js
+++ b/test/switchCooldown.test.js
@@ -26,7 +26,7 @@ test('switchTowerColor costs gold and respects global cooldown', () => {
     game.waveEl = { textContent: '' };
     const tower = new Tower(0, 0);
 
-    game.gold = 2;
+    game.gold = game.switchCost + 1;
     assert.equal(game.switchCooldown, 0);
     const first = game.switchTowerColor(tower);
     assert.equal(first, true);
@@ -52,7 +52,7 @@ test('switchTowerColor costs gold and respects global cooldown', () => {
     assert.equal(tower.color, 'blue');
     assert.equal(game.gold, 0);
 
-    game.gold = 1;
+    game.gold = game.switchCost;
     const fourth = game.switchTowerColor(tower);
     assert.equal(fourth, true);
     assert.equal(tower.color, 'red');


### PR DESCRIPTION
## Summary
- Move base to bottom of canvas
- Reverse enemy movement to spawn at top and travel downward
- Adjust tower grid and base hit logic
- Update tests for new orientation and switch cost setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae1c7b06fc8323b2544781a7f985d2