### PR TITLE
Fix tower merging logic and update tests

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -6,7 +6,7 @@ import { waveActions } from './gameWaves.js';
 import { callCrazyGamesEvent } from './crazyGamesIntegration.js';
 
 class Game {
-    constructor(canvas, { width = 540, height = 960 }) {
+    constructor(canvas, { width = 540, height = 960 } = {}) {
         this.canvas = canvas;
         this.logicalW = width;
         this.logicalH = height;
@@ -65,7 +65,7 @@ class Game {
     }
 
     createCell(x, y) {
-        return { x, y, w: 40, h: 24, occupied: false, highlight: 0 };
+        return { x, y, w: 40, h: 24, occupied: false, highlight: 0, tower: null };
     }
 
     createGrid() {
@@ -130,10 +130,7 @@ class Game {
     }
 
     getTowerAt(cell) {
-        return this.towers.find(t => {
-                console.log(`Comparing tower at ${t.x},${t.y} with cell at ${cell.x},${cell.y}`);
-                return Math.abs(t.x - cell.x) < 90 && Math.abs(t.y - cell.y) < 90;
-            } );
+        return cell?.tower ?? null;
     }
 
     update(timestamp) {
@@ -173,6 +170,7 @@ class Game {
         this.getAllCells().forEach(cell => {
             cell.occupied = false;
             cell.highlight = 0;
+            cell.tower = null;
         });
         this.spawned = 0;
         this.spawnTimer = 0;

--- a/src/gameWaves.js
+++ b/src/gameWaves.js
@@ -22,22 +22,24 @@ export const waveActions = {
         for (let i = 0; i < row.length - 1; i++) {
             const a = row[i];
             const b = row[i + 1];
-            if (a.occupied && b.occupied) {
-                // todo remove console
-                console.log(`a and b coords: ${a.x} ${a.y} and ${b.x} ${b.y}`);
-                // todo need some solution to connect cells to towers. Store them connected and easily retrieve the corresponding one.
-                const ta = this.getTowerAt(a);
-                const tb = this.getTowerAt(b);
-                // todo remove console
-                console.log(`ta and tb: ${ta} ${tb}`);
-                console.log(`ta and tb color and level: ${ta.color} ${tb.color} ${ta.level} ${tb.level}`);
-                if (ta && tb && ta.color === tb.color && ta.level === tb.level) {
-                    ta.level += 1;
-                    ta.updateStats();
-                    this.towers = this.towers.filter(t => t !== tb);
-                    b.occupied = false;
-                    i++; 
+            if (!a.occupied || !b.occupied) continue;
+
+            const ta = this.getTowerAt(a);
+            const tb = this.getTowerAt(b);
+            if (!ta || !tb) continue;
+
+            if (ta.color === tb.color && ta.level === tb.level) {
+                a.tower = ta;
+                ta.level += 1;
+                ta.updateStats();
+                this.towers = this.towers.filter(t => t !== tb);
+                if (tb.cell) {
+                    tb.cell.tower = null;
+                    tb.cell = null;
                 }
+                b.occupied = false;
+                b.tower = null;
+                i++;
             }
         }
     },

--- a/src/ui.js
+++ b/src/ui.js
@@ -64,6 +64,8 @@ function bindCanvasClick(game) {
                 tower.y -= tower.h * 0.8;
                 game.towers.push(tower);
                 cell.occupied = true;
+                cell.tower = tower;
+                tower.cell = cell;
                 game.gold -= game.towerCost;
                 updateHUD(game);
             } else {

--- a/test/cooldownIndicator.test.js
+++ b/test/cooldownIndicator.test.js
@@ -15,8 +15,21 @@ function makeFakeCanvas() {
             fill: () => {},
             stroke: () => {},
             strokeRect: () => {},
+            drawImage: () => {},
+            fillText: () => {},
         }),
     };
+}
+
+function makeAssets() {
+    return new Proxy({ cell: {} }, {
+        get(target, prop) {
+            if (!(prop in target)) {
+                target[prop] = {};
+            }
+            return target[prop];
+        }
+    });
 }
 
 test('updateSwitchIndicator shows remaining cooldown or ready', () => {
@@ -31,6 +44,7 @@ test('updateSwitchIndicator shows remaining cooldown or ready', () => {
 test('Game.update refreshes cooldown indicator', () => {
     const game = new Game(makeFakeCanvas());
     game.cooldownEl = { textContent: '' };
+    game.assets = makeAssets();
     game.switchCooldown = 1;
     const originalRAF = globalThis.requestAnimationFrame;
     globalThis.requestAnimationFrame = () => {};

--- a/test/enemy.test.js
+++ b/test/enemy.test.js
@@ -2,62 +2,62 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import Enemy, { TankEnemy, SwarmEnemy } from '../src/Enemy.js';
 
-test('update moves enemy based on dt and speed', () => {
-    const enemy = new Enemy(3, 'red', 0, 100, 100);
+test('update moves enemy based on dt and both speed components', () => {
+    const enemy = new Enemy(3, 'red', 0, 100, 120, 80);
     enemy.update(0.5);
-    assert.equal(enemy.y, 150);
+    assert.equal(enemy.x, 60);
+    assert.equal(enemy.y, 140);
     enemy.update(0.25);
-    assert.equal(enemy.y, 175);
+    assert.equal(enemy.x, 90);
+    assert.equal(enemy.y, 160);
 });
 
 test('isOutOfBounds returns correct value', () => {
-    const enemy = new Enemy(3, 'red', 0, 800);
+    const enemy = new Enemy(3, 'red', 0, 800, 0, 0);
     assert.equal(enemy.isOutOfBounds(800), true);
     enemy.y = 799;
     assert.equal(enemy.isOutOfBounds(800), false);
 });
 
-test('draw uses enemy color and health bar correctly', () => {
-    const enemy = new Enemy(10, 'blue', 0, 50);
+test('draw uses sprites and health bar proportions', () => {
+    const enemy = new Enemy(10, 'blue', 0, 50, 0, 0);
     enemy.hp = 5; // half health
     const ctx = makeFakeCtx();
-    enemy.draw(ctx);
+    const assets = { swarm_b: {} };
 
-    // body
-    assert.deepEqual(ctx.ops[0], ['fillStyle', 'blue']);
-    assert.deepEqual(ctx.ops[1], ['fillRect', 0, 50, 30, 30]);
-    // health bar background
-    assert.deepEqual(ctx.ops[2], ['fillStyle', 'red']);
-    assert.deepEqual(ctx.ops[3], ['fillRect', 0, 44, 30, 4]);
-    // health bar current hp
-    assert.deepEqual(ctx.ops[4], ['fillStyle', 'green']);
-    assert.deepEqual(ctx.ops[5], ['fillRect', 0, 44, 15, 4]);
-    // border
-    assert.deepEqual(ctx.ops[6], ['strokeStyle', 'black']);
-    assert.deepEqual(ctx.ops[7], ['strokeRect', 0, 44, 30, 4]);
+    enemy.draw(ctx, assets);
+
+    assert.deepEqual(ctx.ops[0], ['drawImage', assets.swarm_b, 0, 50, 30, 30]);
+    assert.deepEqual(ctx.ops[1], ['fillStyle', 'red']);
+    assert.deepEqual(ctx.ops[2], ['fillRect', 0, 44, 30, 4]);
+    assert.deepEqual(ctx.ops[3], ['fillStyle', 'green']);
+    assert.deepEqual(ctx.ops[4], ['fillRect', 0, 44, 15, 4]);
+    assert.deepEqual(ctx.ops[5], ['strokeStyle', 'black']);
+    assert.deepEqual(ctx.ops[6], ['strokeRect', 0, 44, 30, 4]);
 });
 
-test('tank enemy has higher hp and slower speed', () => {
+test('tank enemy has more hp and slower advance than swarm', () => {
     const tank = new TankEnemy();
-    const base = new SwarmEnemy();
-    assert.ok(tank.maxHp > base.maxHp);
-    assert.ok(tank.speed < base.speed);
+    const swarm = new SwarmEnemy();
+    assert.ok(tank.maxHp > swarm.maxHp);
+    assert.ok(tank.speedY < swarm.speedY);
 });
 
-test('swarm enemy has lower hp and faster speed', () => {
+test('swarm enemy has less hp and moves faster than tank', () => {
     const swarm = new SwarmEnemy();
-    const base = new TankEnemy();
-    assert.ok(swarm.maxHp < base.maxHp);
-    assert.ok(swarm.speed > base.speed);
+    const tank = new TankEnemy();
+    assert.ok(swarm.maxHp < tank.maxHp);
+    assert.ok(swarm.speedY > tank.speedY);
 });
 
 function makeFakeCtx() {
     const ops = [];
     return {
         ops,
+        drawImage(img, x, y, w, h) { ops.push(['drawImage', img, x, y, w, h]); },
         set fillStyle(v) { ops.push(['fillStyle', v]); },
-        set strokeStyle(v) { ops.push(['strokeStyle', v]); },
         fillRect(x, y, w, h) { ops.push(['fillRect', x, y, w, h]); },
+        set strokeStyle(v) { ops.push(['strokeStyle', v]); },
         strokeRect(x, y, w, h) { ops.push(['strokeRect', x, y, w, h]); },
     };
 }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -14,6 +14,7 @@ function makeFakeCtx() {
         beginPath() { ops.push(['beginPath']); },
         arc(x, y, r, s, e) { ops.push(['arc', x, y, r, s, e]); },
         fill() { ops.push(['fill']); },
+        drawImage(img, x, y, w, h) { ops.push(['drawImage', img, x, y, w, h]); },
     };
 }
 
@@ -21,18 +22,19 @@ test('drawEntities draws towers, enemies and projectiles', () => {
     const ctx = makeFakeCtx();
     let towerCalls = 0;
     let enemyCalls = 0;
+    const assets = {};
     const towers = [
-        { draw: c => { assert.equal(c, ctx); towerCalls++; } },
-        { draw: c => { assert.equal(c, ctx); towerCalls++; } },
+        { draw: (c, a) => { assert.equal(c, ctx); assert.equal(a, assets); towerCalls++; } },
+        { draw: (c, a) => { assert.equal(c, ctx); assert.equal(a, assets); towerCalls++; } },
     ];
     const enemies = [
-        { draw: c => { assert.equal(c, ctx); enemyCalls++; } },
+        { draw: (c, a) => { assert.equal(c, ctx); assert.equal(a, assets); enemyCalls++; } },
     ];
     const projectiles = [
         { x: 5, y: 6 },
         { x: 15, y: 26 },
     ];
-    const game = { ctx, towers, enemies, projectiles, projectileRadius: 3 };
+    const game = { ctx, towers, enemies, projectiles, projectileRadius: 3, assets };
 
     drawEntities(game);
 
@@ -48,30 +50,35 @@ test('drawEntities draws towers, enemies and projectiles', () => {
     );
 });
 
-test('draw clears canvas, draws entities and projectiles', () => {
+test('draw clears canvas, draws grid and entities', () => {
     const ctx = makeFakeCtx();
     let towerCalled = false;
     let enemyCalled = false;
     const tower = { draw: () => { towerCalled = true; } };
     const enemy = { draw: () => { enemyCalled = true; } };
     const projectile = { x: 25, y: 35 };
+    const cellSprite = {};
     const game = {
         ctx,
         canvas: { width: 450, height: 800 },
-        base: { x: 0, y: 0, w: 0, h: 0 },
-        grid: [],
+        logicalW: 540,
+        logicalH: 960,
+        base: { x: 10, y: 20, w: 30, h: 40 },
+        getAllCells: () => ([{ x: 1, y: 2, w: 3, h: 4, occupied: false }]),
         towers: [tower],
         enemies: [enemy],
         projectiles: [projectile],
         projectileRadius: 4,
+        assets: { cell: cellSprite },
     };
 
     draw(game);
 
     assert.ok(ctx.ops.some(op => op[0] === 'clearRect' && op[1] === 0 && op[2] === 0 && op[3] === 450 && op[4] === 800));
+    assert.ok(ctx.ops.some(op => op[0] === 'fillRect' && op[1] === 10 && op[2] === 20 && op[3] === 30 && op[4] === 40));
+    assert.ok(ctx.ops.some(op => op[0] === 'drawImage' && op[1] === cellSprite));
     assert.ok(towerCalled);
     assert.ok(enemyCalled);
     const twoPi = Math.PI * 2;
     assert.ok(ctx.ops.some(op => op[0] === 'arc' && op[1] === 25 && op[2] === 35 && op[3] === 4 && op[4] === 0 && op[5] === twoPi));
 });
-

--- a/test/switchCooldown.test.js
+++ b/test/switchCooldown.test.js
@@ -15,8 +15,21 @@ function makeFakeCanvas() {
             fill: () => {},
             stroke: () => {},
             strokeRect: () => {},
+            drawImage: () => {},
+            fillText: () => {},
         }),
     };
+}
+
+function makeAssets() {
+    return new Proxy({ cell: {} }, {
+        get(target, prop) {
+            if (!(prop in target)) {
+                target[prop] = {};
+            }
+            return target[prop];
+        }
+    });
 }
 
 test('switchTowerColor costs gold and respects global cooldown', () => {
@@ -24,6 +37,9 @@ test('switchTowerColor costs gold and respects global cooldown', () => {
     game.livesEl = { textContent: '' };
     game.goldEl = { textContent: '' };
     game.waveEl = { textContent: '' };
+    game.cooldownEl = { textContent: '' };
+    game.nextWaveBtn = { disabled: false };
+    game.assets = makeAssets();
     const tower = new Tower(0, 0);
 
     game.gold = game.switchCost + 1;

--- a/test/tower.test.js
+++ b/test/tower.test.js
@@ -5,7 +5,7 @@ import Tower from '../src/Tower.js';
 test('center returns tower midpoint', () => {
     const tower = new Tower(10, 20);
     const c = tower.center();
-    assert.deepEqual(c, { x: 30, y: 40 });
+    assert.deepEqual(c, { x: 40, y: 65 });
 });
 
 test('constructor sets default color to red', () => {
@@ -18,40 +18,37 @@ test('constructor sets level to 1', () => {
     assert.equal(tower.level, 1);
 });
 
-test('draw draws range and tower body correctly', () => {
+test('draw renders range circle, sprite and level text', () => {
     const tower = new Tower(50, 60);
     const ctx = makeFakeCtx();
-    tower.draw(ctx);
+    const sprite = {};
+    const assets = { tower_1r: sprite };
+
+    tower.draw(ctx, assets);
+
     assert.deepEqual(ctx.ops[0], ['beginPath']);
-    assert.deepEqual(ctx.ops[1], ['arc', 70, 80, 120, 0, Math.PI * 2]);
+    assert.deepEqual(ctx.ops[1], ['arc', 80, 105, tower.range, 0, Math.PI * 2]);
     assert.deepEqual(ctx.ops[2], ['strokeStyle', 'rgba(255,0,0,0.3)']);
     assert.deepEqual(ctx.ops[3], ['stroke']);
-    assert.deepEqual(ctx.ops[4], ['fillStyle', 'red']);
-    assert.deepEqual(ctx.ops[5], ['beginPath']);
-    assert.deepEqual(ctx.ops[6], ['moveTo', 70, 60]);
-    assert.deepEqual(ctx.ops[7], ['lineTo', 50, 100]);
-    assert.deepEqual(ctx.ops[8], ['lineTo', 90, 100]);
-    assert.deepEqual(ctx.ops[9], ['closePath']);
-    assert.deepEqual(ctx.ops[10], ['fill']);
-    assert.deepEqual(ctx.ops[11], ['fillStyle', 'black']);
-    assert.deepEqual(ctx.ops[12], ['font', '10px sans-serif']);
-    assert.deepEqual(ctx.ops[13], ['fillText', '1', 92, 70]);
+    assert.deepEqual(ctx.ops.find(op => op[0] === 'drawImage'), ['drawImage', sprite, tower.x, tower.y, tower.w, tower.h]);
+    const fillTextCall = ctx.ops.find(op => op[0] === 'fillText');
+    assert.deepEqual(fillTextCall, ['fillText', '1', tower.x + tower.w + 2, tower.y + 10]);
 });
 
-test('level 2 tower has increased range and damage', () => {
-    const tower = new Tower(0, 0, 'red', 2);
+test('level 2 tower increases stats and draws highlight', () => {
+    const tower = new Tower(50, 60, 'blue', 2);
+    const ctx = makeFakeCtx();
+    const sprite = {};
+    const assets = { tower_2b: sprite };
+
+    tower.draw(ctx, assets);
+
     assert.equal(tower.range, 144);
     assert.ok(Math.abs(tower.damage - 1.8) < 1e-6);
-});
-
-test('level 2 tower draws hexagon body and shows level and highlight', () => {
-    const tower = new Tower(50, 60, 'red', 2);
-    const ctx = makeFakeCtx();
-    tower.draw(ctx);
-    const lineTos = ctx.ops.filter(op => op[0] === 'lineTo');
-    assert.equal(lineTos.length, 5);
-    assert.ok(ctx.ops.some(op => op[0] === 'strokeRect' && op[1] === 48 && op[2] === 58 && op[3] === 44 && op[4] === 44));
-    assert.ok(ctx.ops.some(op => op[0] === 'fillText' && op[1] === '2'));
+    const strokeRectCall = ctx.ops.find(op => op[0] === 'strokeRect');
+    assert.deepEqual(strokeRectCall, ['strokeRect', tower.x - 2, tower.y - 2, tower.w + 4, tower.h + 4]);
+    const arcCall = ctx.ops[1];
+    assert.deepEqual(arcCall, ['arc', 80, 105, tower.range, 0, Math.PI * 2]);
 });
 
 function makeFakeCtx() {
@@ -60,16 +57,12 @@ function makeFakeCtx() {
         ops,
         beginPath() { ops.push(['beginPath']); },
         arc(x, y, r, s, e) { ops.push(['arc', x, y, r, s, e]); },
-        moveTo(x, y) { ops.push(['moveTo', x, y]); },
-        lineTo(x, y) { ops.push(['lineTo', x, y]); },
-        closePath() { ops.push(['closePath']); },
         set strokeStyle(v) { ops.push(['strokeStyle', v]); },
         stroke() { ops.push(['stroke']); },
         set fillStyle(v) { ops.push(['fillStyle', v]); },
-        fill() { ops.push(['fill']); },
+        drawImage(img, x, y, w, h) { ops.push(['drawImage', img, x, y, w, h]); },
         strokeRect(x, y, w, h) { ops.push(['strokeRect', x, y, w, h]); },
         set font(v) { ops.push(['font', v]); },
-        fillText(t, x, y) { ops.push(['fillText', t, x, y]); },
+        fillText(text, x, y) { ops.push(['fillText', text, x, y]); },
     };
 }
-


### PR DESCRIPTION
## Summary
- track tower references directly on cells and simplify lookups
- update merge logic to produce correct upgraded towers and clear merged slots
- refresh unit tests to reflect sprite-based rendering and asset requirements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd8c8b47c8323a44b3daee8045c1b