### PR TITLE
Add engine glow effect for enemy ships

### DIFF
--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -19,6 +19,7 @@ export default class Enemy {
     draw(ctx, assets) {
         const propertyName = `swarm_${this.color.charAt(0)}`;
         const sprite = assets[propertyName];
+        this.drawEngineGlow(ctx);
         ctx.drawImage(sprite, this.x, this.y, this.w, this.h);
 
         const barWidth = this.w;
@@ -32,6 +33,38 @@ export default class Enemy {
         ctx.fillRect(barX, barY, barWidth * (this.hp / this.maxHp), barHeight);
         ctx.strokeStyle = 'black';
         ctx.strokeRect(barX, barY, barWidth, barHeight);
+    }
+
+    drawEngineGlow(ctx) {
+        if (typeof ctx.save !== 'function' || typeof ctx.restore !== 'function') {
+            return;
+        }
+        if (typeof ctx.beginPath !== 'function' || typeof ctx.ellipse !== 'function') {
+            return;
+        }
+        if (typeof ctx.fill !== 'function') {
+            return;
+        }
+        const palette = this.getGlowPalette();
+        const glowCenterX = this.x + this.w / 2;
+        const glowCenterY = this.y + this.h + 4;
+        ctx.save();
+        ctx.globalAlpha = 0.9;
+        ctx.shadowColor = palette.shadow;
+        ctx.shadowBlur = 20;
+        ctx.fillStyle = palette.core;
+        ctx.beginPath();
+        ctx.ellipse(glowCenterX, glowCenterY, this.w * 0.25, this.h * 0.3, 0, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+    }
+
+    getGlowPalette() {
+        const palettes = {
+            red: { shadow: 'rgba(255, 96, 48, 0.7)', core: 'rgba(255, 220, 180, 0.9)' },
+            blue: { shadow: 'rgba(88, 152, 255, 0.7)', core: 'rgba(200, 232, 255, 0.9)' },
+        };
+        return palettes[this.color] ?? { shadow: 'rgba(255, 220, 120, 0.7)', core: 'rgba(255, 255, 200, 0.9)' };
     }
 
     isOutOfBounds(canvasHeight) {


### PR DESCRIPTION
## Summary
- add a blurred engine glow behind enemy ships before drawing their sprite
- guard the glow routine so it skips when the rendering context lacks advanced APIs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2774e7bc8323b53a469df0700d55