### PR TITLE
Integrate howler.js audio library

### DIFF
--- a/docs/Tasks/Tasks_Prototype_4.txt
+++ b/docs/Tasks/Tasks_Prototype_4.txt
@@ -7,6 +7,6 @@
 005 | TODO | Add simple cyclic animation to tower crystals (pulsating glow, sine-based). | 003
 006 | TODO | Add basic ship animation (light flicker or 2–3 frame cycle). | 001
 
-007 | TODO | Integrate howler.js audio library. | —
+007 | DONE | Integrate howler.js audio library. | —
 008 | TODO | Add SFX for tower firing and projectile explosion. | 007, 003, 004
 009 | TODO | Add background music loop. | 007

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,0 +1,35 @@
+const globalScope = typeof globalThis !== 'undefined' ? globalThis : window;
+
+function hasHowler() {
+    return Boolean(globalScope && globalScope.Howl && globalScope.Howler);
+}
+
+export function isAudioSupported() {
+    return hasHowler();
+}
+
+export function initializeAudio({ volume = null, autoSuspend = false } = {}) {
+    if (!hasHowler()) {
+        console.warn('Howler.js library is not available. Audio features are disabled.');
+        return false;
+    }
+    const howler = globalScope.Howler;
+    if (typeof autoSuspend === 'boolean') {
+        howler.autoSuspend = autoSuspend;
+    }
+    if (typeof volume === 'number') {
+        howler.volume(volume);
+    }
+    return true;
+}
+
+export function getHowler() {
+    return hasHowler() ? globalScope.Howler : null;
+}
+
+export function createSound(options) {
+    if (!hasHowler()) {
+        throw new Error('Howler.js is not loaded');
+    }
+    return new globalScope.Howl(options);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
         <title>Minimal Tower Defense</title>
         <link rel="stylesheet" href="style.css" />
         <script src="https://sdk.crazygames.com/crazygames-sdk-v3.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.4/howler.min.js"></script>
     </head>
     <body>
         <div id="hud">

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import { callCrazyGamesEvent, checkCrazyGamesIntegration, initializeCrazyGamesIn
 import Game from './Game.js';
 import { bindUI } from './ui.js';
 import { loadAssets } from './assets.js';
+import { initializeAudio } from './audio.js';
 
 function resizeCanvas() {
     const vw = window.innerWidth;
@@ -28,6 +29,8 @@ const LOGICAL_H = 960;
 await initializeCrazyGamesIntegration();
 console.log("CrazyGames integration kinda finished..");
 callCrazyGamesEvent('sdkGameLoadingStart');
+
+initializeAudio();
 
 const canvas = document.getElementById('game');
 console.log("Canvas element:", canvas);

--- a/test/audio.test.js
+++ b/test/audio.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createSound, getHowler, initializeAudio, isAudioSupported } from '../src/audio.js';
+
+test('initializeAudio returns false when howler is missing', () => {
+    const originalHowl = globalThis.Howl;
+    const originalHowler = globalThis.Howler;
+    delete globalThis.Howl;
+    delete globalThis.Howler;
+
+    assert.equal(isAudioSupported(), false);
+    assert.equal(initializeAudio(), false);
+    assert.equal(getHowler(), null);
+
+    if (originalHowl) {
+        globalThis.Howl = originalHowl;
+    } else {
+        delete globalThis.Howl;
+    }
+    if (originalHowler) {
+        globalThis.Howler = originalHowler;
+    } else {
+        delete globalThis.Howler;
+    }
+});
+
+test('createSound uses the active Howl constructor', () => {
+    class FakeHowl {
+        constructor(options) {
+            this.options = options;
+        }
+    }
+    const fakeHowler = {
+        autoSuspend: true,
+        volume: () => {}
+    };
+
+    const originalHowl = globalThis.Howl;
+    const originalHowler = globalThis.Howler;
+    globalThis.Howl = FakeHowl;
+    globalThis.Howler = fakeHowler;
+
+    try {
+        assert.equal(isAudioSupported(), true);
+        assert.equal(initializeAudio(), true);
+        const sound = createSound({ src: ['sound.ogg'], loop: true });
+        assert.ok(sound instanceof FakeHowl);
+        assert.deepEqual(sound.options, { src: ['sound.ogg'], loop: true });
+        assert.equal(fakeHowler.autoSuspend, false);
+    } finally {
+        if (originalHowl) {
+            globalThis.Howl = originalHowl;
+        } else {
+            delete globalThis.Howl;
+        }
+        if (originalHowler) {
+            globalThis.Howler = originalHowler;
+        } else {
+            delete globalThis.Howler;
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- load howler.js via CDN and expose reusable helpers through a new audio module
- initialize the audio layer during game startup to prepare for upcoming sound work
- cover the audio utilities with unit tests and mark the integration task as complete

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf279735a08323a9da629a91f9d7e1