### PR TITLE
Refine tower placement alignment

### DIFF
--- a/src/Tower.js
+++ b/src/Tower.js
@@ -1,3 +1,10 @@
+const DEFAULT_PLACEMENT_ANCHOR = Object.freeze({
+    // The anchor describes the fraction of the sprite width/height between the
+    // top-left corner and the point that should sit on the cell origin.
+    x: 0.25,
+    y: 0.8,
+});
+
 export default class Tower {
     constructor(x, y, color = 'red', level = 1) {
         this.x = x;
@@ -43,6 +50,32 @@ export default class Tower {
             x: this.x + this.w / 2,
             y: this.y + this.h / 2
         };
+    }
+
+    /**
+     * Aligns the tower so its sprite anchor sits on the provided cell.
+     * @param {{ x: number, y: number }} cell
+     */
+    alignToCell(cell) {
+        const offset = this.getPlacementOffset();
+        this.x = cell.x - offset.x;
+        this.y = cell.y - offset.y;
+    }
+
+    /**
+     * Computes the offset between the sprite origin and the visual anchor.
+     * @returns {{ x: number, y: number }}
+     */
+    getPlacementOffset() {
+        const anchor = Tower.getPlacementAnchor();
+        return {
+            x: this.w * anchor.x,
+            y: this.h * anchor.y,
+        };
+    }
+
+    static getPlacementAnchor() {
+        return DEFAULT_PLACEMENT_ANCHOR;
     }
 
     draw(ctx, assets) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -58,10 +58,7 @@ function bindCanvasClick(game) {
         if (!cell.occupied) {
             if (game.gold >= game.towerCost) {
                 const tower = new Tower(cell.x, cell.y);
-                // todo how can we fix magic numbers here? 
-                // It's done so that towers are placed visually in correct place at cell
-                tower.x -= tower.w / 4;
-                tower.y -= tower.h * 0.8;
+                tower.alignToCell(cell);
                 game.towers.push(tower);
                 cell.occupied = true;
                 cell.tower = tower;


### PR DESCRIPTION
## Summary
- add a documented placement anchor for tower sprites and helper methods to align towers with cells
- use the new alignment helper when placing towers from UI clicks to remove hard-coded offsets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d187203e388323b471d6ccf2dfe8db