### PR TITLE
Move enemy engine glow rendering into effects module

### DIFF
--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -1,3 +1,5 @@
+import { drawEnemyEngineGlow } from './effects.js';
+
 export default class Enemy {
     constructor(maxHp, color, x, y, speedX, speedY) {
         this.x = x;
@@ -35,7 +37,7 @@ export default class Enemy {
     draw(ctx, assets) {
         const propertyName = `swarm_${this.color.charAt(0)}`;
         const sprite = assets[propertyName];
-        this.drawEngineGlow(ctx);
+        drawEnemyEngineGlow(ctx, this);
         ctx.drawImage(sprite, this.x, this.y, this.w, this.h);
 
         const barWidth = this.w;
@@ -49,81 +51,6 @@ export default class Enemy {
         ctx.fillRect(barX, barY, barWidth * (this.hp / this.maxHp), barHeight);
         ctx.strokeStyle = 'black';
         ctx.strokeRect(barX, barY, barWidth, barHeight);
-    }
-
-    drawEngineGlow(ctx) {
-        if (!this.canRenderGlow(ctx)) {
-            return;
-        }
-
-        const palette = this.getGlowPalette();
-        const anchorX = this.x + this.engineFlame.anchor.x + this.engineFlame.offset.x;
-        const anchorY = this.y + this.engineFlame.anchor.y + this.engineFlame.offset.y;
-        const now = typeof performance !== 'undefined' && typeof performance.now === 'function'
-            ? performance.now()
-            : Date.now();
-        const flicker = 0.75 + Math.sin(now / 180 + this.glowPhase) * 0.25;
-        const stretch = 1.15 + Math.sin(now / 260 + this.glowPhase * 0.6) * 0.2;
-
-        ctx.save();
-        ctx.globalCompositeOperation = 'lighter';
-
-        ctx.save();
-        ctx.translate(anchorX, anchorY);
-        ctx.rotate(this.engineFlame.angle);
-
-        // Soft halo hugging the ship's hull
-        ctx.save();
-        ctx.scale(1, 1.25 * stretch);
-        ctx.globalAlpha = 0.55;
-        const haloRadius = this.w * (0.38 + 0.07 * flicker);
-        const haloGradient = ctx.createRadialGradient(0, 0, haloRadius * 0.1, 0, 0, haloRadius);
-        haloGradient.addColorStop(0, palette.core);
-        haloGradient.addColorStop(0.4, palette.mid);
-        haloGradient.addColorStop(1, palette.halo);
-        ctx.fillStyle = haloGradient;
-        ctx.beginPath();
-        ctx.arc(0, 0, haloRadius, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.restore();
-
-        // Main flame body trailing behind the ship
-        ctx.save();
-        ctx.translate(0, -this.h * 0.05);
-        ctx.scale(1, stretch * 1.5);
-        ctx.globalAlpha = 0.7;
-        const flameHeight = this.h * (0.9 + 0.1 * flicker);
-        const flameGradient = ctx.createLinearGradient(0, 0, 0, -flameHeight);
-        flameGradient.addColorStop(0, palette.core);
-        flameGradient.addColorStop(0.25, palette.flare);
-        flameGradient.addColorStop(1, palette.trail);
-        ctx.fillStyle = flameGradient;
-        const flameWidth = this.w * (0.22 + 0.08 * flicker);
-        ctx.beginPath();
-        ctx.moveTo(0, 0);
-        ctx.quadraticCurveTo(flameWidth, -flameHeight * 0.35, 0, -flameHeight);
-        ctx.quadraticCurveTo(-flameWidth, -flameHeight * 0.35, 0, 0);
-        ctx.closePath();
-        ctx.fill();
-        ctx.restore();
-
-        // Bright sparkle at the exhaust center for a hot core
-        ctx.save();
-        ctx.translate(0, -this.h * 0.1);
-        ctx.scale(1, 1 + 0.3 * flicker);
-        ctx.globalAlpha = 0.9;
-        const sparkRadius = this.w * (0.16 + 0.05 * flicker);
-        const sparkGradient = ctx.createRadialGradient(0, 0, sparkRadius * 0.25, 0, 0, sparkRadius);
-        sparkGradient.addColorStop(0, palette.spark);
-        sparkGradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
-        ctx.fillStyle = sparkGradient;
-        ctx.beginPath();
-        ctx.arc(0, 0, sparkRadius, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.restore();
-
-        ctx.restore();
-        ctx.restore();
     }
 
     setEngineFlamePlacement({ anchorX, anchorY, offsetX, offsetY, angleDegrees }) {

--- a/src/effects.js
+++ b/src/effects.js
@@ -91,3 +91,81 @@ export function drawExplosions(ctx, explosions = []) {
 
     ctx.restore();
 }
+
+export function drawEnemyEngineGlow(ctx, enemy) {
+    if (!enemy || typeof enemy.canRenderGlow !== 'function' || !enemy.canRenderGlow(ctx)) {
+        return;
+    }
+
+    const palette = typeof enemy.getGlowPalette === 'function' ? enemy.getGlowPalette() : null;
+    if (!palette) {
+        return;
+    }
+    const anchorX = enemy.x + enemy.engineFlame.anchor.x + enemy.engineFlame.offset.x;
+    const anchorY = enemy.y + enemy.engineFlame.anchor.y + enemy.engineFlame.offset.y;
+    const now = typeof performance !== 'undefined' && typeof performance.now === 'function'
+        ? performance.now()
+        : Date.now();
+    const flicker = 0.75 + Math.sin(now / 180 + enemy.glowPhase) * 0.25;
+    const stretch = 1.15 + Math.sin(now / 260 + enemy.glowPhase * 0.6) * 0.2;
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+
+    ctx.save();
+    ctx.translate(anchorX, anchorY);
+    ctx.rotate(enemy.engineFlame.angle);
+
+    // Soft halo hugging the ship's hull
+    ctx.save();
+    ctx.scale(1, 1.25 * stretch);
+    ctx.globalAlpha = 0.55;
+    const haloRadius = enemy.w * (0.38 + 0.07 * flicker);
+    const haloGradient = ctx.createRadialGradient(0, 0, haloRadius * 0.1, 0, 0, haloRadius);
+    haloGradient.addColorStop(0, palette.core);
+    haloGradient.addColorStop(0.4, palette.mid);
+    haloGradient.addColorStop(1, palette.halo);
+    ctx.fillStyle = haloGradient;
+    ctx.beginPath();
+    ctx.arc(0, 0, haloRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    // Main flame body trailing behind the ship
+    ctx.save();
+    ctx.translate(0, -enemy.h * 0.05);
+    ctx.scale(1, stretch * 1.5);
+    ctx.globalAlpha = 0.7;
+    const flameHeight = enemy.h * (0.9 + 0.1 * flicker);
+    const flameGradient = ctx.createLinearGradient(0, 0, 0, -flameHeight);
+    flameGradient.addColorStop(0, palette.core);
+    flameGradient.addColorStop(0.25, palette.flare);
+    flameGradient.addColorStop(1, palette.trail);
+    ctx.fillStyle = flameGradient;
+    const flameWidth = enemy.w * (0.22 + 0.08 * flicker);
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.quadraticCurveTo(flameWidth, -flameHeight * 0.35, 0, -flameHeight);
+    ctx.quadraticCurveTo(-flameWidth, -flameHeight * 0.35, 0, 0);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+
+    // Bright sparkle at the exhaust center for a hot core
+    ctx.save();
+    ctx.translate(0, -enemy.h * 0.1);
+    ctx.scale(1, 1 + 0.3 * flicker);
+    ctx.globalAlpha = 0.9;
+    const sparkRadius = enemy.w * (0.16 + 0.05 * flicker);
+    const sparkGradient = ctx.createRadialGradient(0, 0, sparkRadius * 0.25, 0, 0, sparkRadius);
+    sparkGradient.addColorStop(0, palette.spark);
+    sparkGradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    ctx.fillStyle = sparkGradient;
+    ctx.beginPath();
+    ctx.arc(0, 0, sparkRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    ctx.restore();
+    ctx.restore();
+}


### PR DESCRIPTION
## Summary
- call a shared helper from Enemy.draw to render the engine glow
- add drawEnemyEngineGlow helper to effects.js so the effect lives with other visual helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d18789d5dc832392c19c7ac6a1d37e