### PR TITLE
Register sound assets via loadAssets

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -8,7 +8,7 @@ import { createGameAudio } from './audio.js';
 import { updateExplosions } from './effects.js';
 
 class Game {
-    constructor(canvas, { width = 540, height = 960 } = {}) {
+    constructor(canvas, { width = 540, height = 960, assets = null } = {}) {
         this.canvas = canvas;
         this.logicalW = width;
         this.logicalH = height;
@@ -24,8 +24,25 @@ class Game {
         this.initStats();
         this.base = { x: this.logicalW, y: this.logicalH - 60, w: 40, h: 40 };
         this.createGrid();
+        this._assets = null;
         this.audio = createGameAudio();
+        if (assets) {
+            this.assets = assets;
+        }
         this.update = this.update.bind(this);
+    }
+
+    get assets() {
+        return this._assets;
+    }
+
+    set assets(value) {
+        this._assets = value;
+        if (value?.sounds) {
+            this.audio = createGameAudio(value.sounds);
+        } else {
+            this.audio = createGameAudio();
+        }
     }
 
     initStats() {

--- a/src/assets.js
+++ b/src/assets.js
@@ -1,16 +1,54 @@
-// assets.js
+import { createSound, isAudioSupported } from './audio.js';
+
+const IMAGE_SOURCES = {
+    bg: 'assets/bg_plats.png',
+    cell: 'assets/cell_cut.png',
+    tower_1r: 'assets/tower_1R.png',
+    tower_1b: 'assets/tower_1B.png',
+    tower_2r: 'assets/tower_2R.png',
+    tower_2b: 'assets/tower_2B.png',
+    tower_3r: 'assets/tower_3R.png',
+    tower_3b: 'assets/tower_3B.png',
+    swarm_r: 'assets/swarm_R.png',
+    swarm_b: 'assets/swarm_B.png'
+};
+
+const SOUND_OPTIONS = {
+    fire: {
+        src: ['assets/fire.wav'],
+        volume: 0.8,
+        preload: true
+    },
+    explosion: {
+        src: ['assets/explosion.wav'],
+        volume: 0.05,
+        preload: true
+    },
+    backgroundMusic: {
+        src: ['assets/background_music.mp3'],
+        volume: 0.25,
+        preload: true,
+        loop: true
+    }
+};
+
 export async function loadAssets() {
-    const bg = await loadImage('assets/bg_plats.png');
-    const cell = await loadImage('assets/cell_cut.png');
-    const tower_1r = await loadImage('assets/tower_1R.png');
-    const tower_1b = await loadImage('assets/tower_1B.png');
-    const tower_2r = await loadImage('assets/tower_2R.png');
-    const tower_2b = await loadImage('assets/tower_2B.png');
-    const tower_3r = await loadImage('assets/tower_3R.png');
-    const tower_3b = await loadImage('assets/tower_3B.png');
-    const swarm_r = await loadImage('assets/swarm_R.png');
-    const swarm_b = await loadImage('assets/swarm_B.png');
-    return {bg, cell, tower_1r, tower_1b, tower_2r, tower_2b, tower_3r, tower_3b, swarm_r, swarm_b};
+    const imageEntries = await Promise.all(
+        Object.entries(IMAGE_SOURCES).map(async ([key, url]) => [key, await loadImage(url)])
+    );
+    const images = Object.fromEntries(imageEntries);
+
+    let sounds = {};
+    if (isAudioSupported()) {
+        sounds = Object.fromEntries(
+            Object.entries(SOUND_OPTIONS).map(([key, options]) => [key, createSound(options)])
+        );
+    }
+
+    return {
+        ...images,
+        sounds
+    };
 }
 
 function loadImage(url) {

--- a/src/audio.js
+++ b/src/audio.js
@@ -46,46 +46,36 @@ export function createSound(options) {
     return new globalScope.Howl(options);
 }
 
-export function createGameAudio() {
+export function createGameAudio(sounds = {}) {
     if (!hasHowler()) {
         return NOOP_AUDIO;
     }
 
-    const fire = createSound({
-        src: ['assets/fire.wav'],
-        volume: 0.8,
-        preload: true
-    });
-
-    const explosion = createSound({
-        src: ['assets/explosion.wav'],
-        volume: 0.05,
-        preload: true
-    });
-
-    const backgroundMusic = createSound({
-        src: ['assets/background_music.mp3'],
-        volume: 0.25,
-        preload: true,
-        loop: true
-    });
+    const fire = sounds.fire ?? null;
+    const explosion = sounds.explosion ?? null;
+    const backgroundMusic = sounds.backgroundMusic ?? null;
 
     return {
         playFire() {
-            console.log('Playing fire sound');
-            fire.play();
+            if (fire) {
+                console.log('Playing fire sound');
+                fire.play();
+            }
         },
         playExplosion() {
-            console.log('Playing explosion sound');
-            explosion.play();
+            if (explosion) {
+                console.log('Playing explosion sound');
+                explosion.play();
+            }
         },
         playMusic() {
-            if (!backgroundMusic.playing()) {
+            if (backgroundMusic && typeof backgroundMusic.play === 'function' &&
+                typeof backgroundMusic.playing === 'function' && !backgroundMusic.playing()) {
                 backgroundMusic.play();
             }
         },
         stopMusic() {
-            if (backgroundMusic.playing()) {
+            if (backgroundMusic && typeof backgroundMusic.playing === 'function' && backgroundMusic.playing()) {
                 backgroundMusic.stop();
             }
         }


### PR DESCRIPTION
## Summary
- load both image and sound assets through `loadAssets`
- guard sound creation behind audio support checks and expose them on the assets bundle
- rework game audio helper to consume shared sound instances from the loaded assets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1824cdd8c832387cfd24482a94d0e