### PR TITLE
Refactor canvas click handling for readability

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -54,22 +54,27 @@ function bindCanvasClick(game) {
         }
 
         const cell = game.getAllCells().find(c => isInside(pos, c));
-        if (!cell) return;
-        if (!cell.occupied) {
-            if (game.gold >= game.towerCost) {
-                const tower = new Tower(cell.x, cell.y);
-                tower.alignToCell(cell);
-                game.towers.push(tower);
-                cell.occupied = true;
-                cell.tower = tower;
-                tower.cell = cell;
-                game.gold -= game.towerCost;
-                updateHUD(game);
-            } else {
-                cell.highlight = 0.3;
-            }
+        if (cell) {
+            tryShoot(game, cell);
         }
     });
+}
+
+function tryShoot(game, cell) {
+    if (!cell.occupied) {
+        if (game.gold >= game.towerCost) {
+            const tower = new Tower(cell.x, cell.y);
+            tower.alignToCell(cell);
+            game.towers.push(tower);
+            cell.occupied = true;
+            cell.tower = tower;
+            tower.cell = cell;
+            game.gold -= game.towerCost;
+            updateHUD(game);
+        } else {
+            cell.highlight = 0.3;
+        }
+    }
 }
 
 export function updateHUD(game) {


### PR DESCRIPTION
## Summary
- extract a tryShoot helper to manage tower placement logic beginning with an occupancy check
- simplify bindCanvasClick to delegate placement behavior and stay under the line limit

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d190cba12083239b0713a40fdc44bd