### PR TITLE
Add grid coverage tests and cooldown update checks

### DIFF
--- a/test/gameGrid.test.js
+++ b/test/gameGrid.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import GameGrid from '../src/js/core/gameGrid.js';
+
+test('constructor builds grid with expected cell positions', () => {
+    const grid = new GameGrid();
+
+    assert.equal(grid.topCells.length, 6);
+    assert.equal(grid.bottomCells.length, 6);
+
+    const firstTop = grid.topCells[0];
+    assert.deepEqual(firstTop, {
+        x: 70,
+        y: 140,
+        w: 40,
+        h: 24,
+        occupied: false,
+        highlight: 0,
+        tower: null,
+    });
+
+    const firstBottom = grid.bottomCells[0];
+    assert.deepEqual(firstBottom, {
+        x: 80,
+        y: 480,
+        w: 40,
+        h: 24,
+        occupied: false,
+        highlight: 0,
+        tower: null,
+    });
+});
+
+test('createRow positions cells relative to origin', () => {
+    const grid = new GameGrid({
+        cellSize: { w: 30, h: 20 },
+        topOrigin: { x: 0, y: 0 },
+        bottomOrigin: { x: 0, y: 0 },
+    });
+
+    const origin = { x: 100, y: 200 };
+    const offsets = [
+        { x: 10, y: 5 },
+        { x: -5, y: 15 },
+    ];
+
+    const row = grid.createRow(origin, offsets);
+
+    assert.deepEqual(row, [
+        { x: 110, y: 205, w: 30, h: 20, occupied: false, highlight: 0, tower: null },
+        { x: 95, y: 215, w: 30, h: 20, occupied: false, highlight: 0, tower: null },
+    ]);
+});
+
+test('getAllCells returns top and bottom rows in order', () => {
+    const grid = new GameGrid();
+
+    const all = grid.getAllCells();
+
+    assert.equal(all.length, grid.topCells.length + grid.bottomCells.length);
+    assert.equal(all[0], grid.topCells[0]);
+    assert.equal(all[grid.topCells.length], grid.bottomCells[0]);
+});
+
+test('forEachCell iterates over every cell', () => {
+    const grid = new GameGrid();
+    const visited = new Set();
+
+    grid.forEachCell(cell => {
+        visited.add(cell);
+    });
+
+    assert.equal(visited.size, grid.topCells.length + grid.bottomCells.length);
+    for (const cell of grid.topCells) {
+        assert.ok(visited.has(cell));
+    }
+    for (const cell of grid.bottomCells) {
+        assert.ok(visited.has(cell));
+    }
+});
+
+test('resetCells clears occupancy, highlight and tower references', () => {
+    const grid = new GameGrid();
+    const target = grid.topCells[0];
+    target.occupied = true;
+    target.highlight = 0.5;
+    target.tower = {};
+
+    grid.resetCells();
+
+    assert.equal(target.occupied, false);
+    assert.equal(target.highlight, 0);
+    assert.equal(target.tower, null);
+});
+
+test('fadeHighlights decreases highlight values but never below zero', () => {
+    const grid = new GameGrid();
+    grid.topCells[0].highlight = 0.3;
+    grid.topCells[1].highlight = 0.05;
+    grid.topCells[2].highlight = 0;
+
+    grid.fadeHighlights(0.1);
+
+    assert.ok(Math.abs(grid.topCells[0].highlight - 0.2) < 1e-6);
+    assert.equal(grid.topCells[1].highlight, 0);
+    assert.equal(grid.topCells[2].highlight, 0);
+});

--- a/test/switchCooldown.test.js
+++ b/test/switchCooldown.test.js
@@ -74,3 +74,22 @@ test('switchTowerColor costs gold and respects global cooldown', () => {
     assert.equal(tower.color, 'red');
     assert.equal(game.gold, 0);
 });
+
+test('updateSwitchCooldown decreases timer and updates indicator', () => {
+    const game = new Game(makeFakeCanvas());
+    game.cooldownEl = { textContent: 'initial' };
+
+    game.switchCooldown = 0;
+    game.updateSwitchCooldown(0.2);
+    assert.equal(game.switchCooldown, 0);
+    assert.equal(game.cooldownEl.textContent, 'initial');
+
+    game.switchCooldown = 0.3;
+    game.updateSwitchCooldown(0.1);
+    assert.ok(Math.abs(game.switchCooldown - 0.2) < 1e-6);
+    assert.equal(game.cooldownEl.textContent, 'Switch: 0.2s');
+
+    game.updateSwitchCooldown(0.5);
+    assert.equal(game.switchCooldown, 0);
+    assert.equal(game.cooldownEl.textContent, 'Switch: Ready');
+});


### PR DESCRIPTION
## Summary
- add comprehensive unit tests for the GameGrid class covering all helper methods and state resets
- extend switch cooldown tests to verify timer reduction and HUD indicator updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1bc7c3cb88323b14ea010eb4ff9be