### PR TITLE
Add start menu overlay before gameplay

### DIFF
--- a/docs/Tasks/Tasks_Prototype_5
+++ b/docs/Tasks/Tasks_Prototype_5
@@ -1,5 +1,5 @@
 001 | TODO | Rebalance enemy HP and gold income so that all 10 waves are beatable but still challenging. | —  
-002 | TODO | Add start menu with “Start Game” button shown before first wave. | —  
+002 | DONE | Add start menu with “Start Game” button shown before first wave. | —
 003 | TODO | Add end screen (Win/Lose) with “Restart” button. | 002  
 004 | TODO | Add visual or sound feedback when placing a tower (flash on cell or short SFX). | —  
 005 | TODO | Add error SFX when trying to build without enough gold. | 004  

--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.4/howler.min.js"></script>
     </head>
     <body>
+        <div id="startOverlay" class="overlay">
+            <div class="start-menu">
+                <h1>Minimal Tower Defense</h1>
+                <p>Protect the base from incoming waves of enemies.</p>
+                <button id="startGame">Start Game</button>
+            </div>
+        </div>
         <div id="hud">
             <span id="lives">Lives: 10</span>
             <span id="gold">Gold: 20</span>

--- a/js/core/Game.js
+++ b/js/core/Game.js
@@ -22,6 +22,7 @@ class Game {
         this.projectileRadius = 6;
         this.projectileSpawnInterval = 500;
         this.lastTime = 0;
+        this.hasStarted = false;
         this.initStats();
         this.base = { x: this.logicalW, y: this.logicalH - 60, w: 40, h: 40 };
         this.grid = new GameGrid();
@@ -182,6 +183,7 @@ class Game {
     }
 
     run() {
+        this.hasStarted = true;
         callCrazyGamesEvent('gameplayStart');
         this.audio.playMusic();
         this.lastTime = performance.now();

--- a/js/main.js
+++ b/js/main.js
@@ -36,5 +36,4 @@ bindUI(game);
 callCrazyGamesEvent('sdkGameLoadingStop');
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
-game.run();
 

--- a/js/systems/ui.js
+++ b/js/systems/ui.js
@@ -26,6 +26,7 @@ export function bindUI(game) {
     bindCanvasClick(game);
     updateHUD(game);
     updateSwitchIndicator(game);
+    setupStartMenu(game);
 }
 
 function bindHUD(game) {
@@ -37,11 +38,36 @@ function bindHUD(game) {
     game.tipEl = document.getElementById('tip');
     game.nextWaveBtn = document.getElementById('nextWave');
     game.restartBtn = document.getElementById('restart');
+    game.startOverlay = document.getElementById('startOverlay');
+    game.startBtn = document.getElementById('startGame');
 }
 
 function bindButtons(game) {
     game.nextWaveBtn.addEventListener('click', () => game.startWave());
     game.restartBtn.addEventListener('click', () => game.restart());
+    if (game.startBtn) {
+        game.startBtn.addEventListener('click', () => {
+            if (game.startOverlay) {
+                game.startOverlay.classList.add('hidden');
+            }
+            game.nextWaveBtn.disabled = false;
+            game.restartBtn.disabled = false;
+            if (!game.hasStarted) {
+                game.hasStarted = true;
+                game.run();
+            }
+        }, { once: true });
+    }
+}
+
+function setupStartMenu(game) {
+    if (!game.startOverlay)
+        return;
+    game.startOverlay.classList.remove('hidden');
+    if (game.nextWaveBtn)
+        game.nextWaveBtn.disabled = true;
+    if (game.restartBtn)
+        game.restartBtn.disabled = true;
 }
 
 function bindCanvasClick(game) {

--- a/style.css
+++ b/style.css
@@ -15,3 +15,53 @@ body {
 #tip {
     flex-basis: 100%;
 }
+
+.overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.65);
+    font-family: sans-serif;
+    z-index: 10;
+}
+
+.overlay.hidden {
+    display: none;
+}
+
+.start-menu {
+    background: #101820;
+    color: #fff;
+    padding: 24px 32px;
+    border-radius: 16px;
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+    text-align: center;
+    max-width: 320px;
+}
+
+.start-menu h1 {
+    margin: 0 0 12px;
+    font-size: 28px;
+}
+
+.start-menu p {
+    margin: 0 0 20px;
+    line-height: 1.4;
+}
+
+.start-menu button {
+    background: #ffb400;
+    color: #1b1b1b;
+    border: none;
+    border-radius: 999px;
+    padding: 12px 32px;
+    font-size: 18px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.start-menu button:hover {
+    background: #ffd266;
+}


### PR DESCRIPTION
## Summary
- add a full-screen start overlay with a Start Game button before the first wave
- gate the gameplay loop behind the start button and disable controls until play begins
- style the start menu and mark task 002 as complete in the prototype tracker

## Testing
- npm test *(fails: existing tests reference files under src/js that do not exist in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f9525f0c83239b8bb6e0c744e7ba