### PR TITLE
Add tower placement feedback and audio

### DIFF
--- a/docs/Tasks/Tasks_Prototype_5
+++ b/docs/Tasks/Tasks_Prototype_5
@@ -1,7 +1,7 @@
 001 | DONE | Rebalance enemy HP and gold income so that all 10 waves are beatable but still challenging. | —  
 002 | DONE | Add start menu with “Start Game” button shown before first wave. | —
 003 | DONE | Add end screen (Win/Lose) with “Restart” button. | 002  
-004 | TODO | Add visual or sound feedback when placing a tower (flash on cell and SFX, I will add a sound file myself). | —  
+004 | DONE | Add visual or sound feedback when placing a tower (flash on cell and SFX, I will add a sound file myself). | —
 005 | TODO | Make the game look good on both PC and mobile devices. On any device it should be aligned to the screen, cover all of it or most of it. | —  
 006 | TODO | Add error SFX (will add sound file myself) when trying to build without enough gold. | 004  
 007 | TODO | Show CrazyGames interstitial ad on game over. | 003  

--- a/js/core/gameGrid.js
+++ b/js/core/gameGrid.js
@@ -24,7 +24,16 @@ class GameGrid {
     }
 
     createCell(x, y) {
-        return {x,y,w: this.cellWidth,h: this.cellHeight,occupied: false,highlight: 0,tower: null};
+        return {
+            x,
+            y,
+            w: this.cellWidth,
+            h: this.cellHeight,
+            occupied: false,
+            highlight: 0,
+            highlightColor: null,
+            tower: null
+        };
     }
 
     getAllCells() {
@@ -39,6 +48,7 @@ class GameGrid {
         this.forEachCell(cell => {
             cell.occupied = false;
             cell.highlight = 0;
+            cell.highlightColor = null;
             cell.tower = null;
         });
     }
@@ -47,6 +57,9 @@ class GameGrid {
         this.forEachCell(cell => {
             if (cell.highlight > 0) {
                 cell.highlight = Math.max(0, cell.highlight - dt);
+                if (cell.highlight === 0) {
+                    cell.highlightColor = null;
+                }
             }
         });
     }

--- a/js/core/render.js
+++ b/js/core/render.js
@@ -29,9 +29,10 @@ function drawGrid(game) {
 
         if (cell.highlight > 0) {
             const alpha = Math.min(1, cell.highlight * 3);
+            const color = cell.highlightColor ?? 'red';
             ctx.save();
             ctx.globalAlpha = alpha;
-            ctx.fillStyle = 'red';
+            ctx.fillStyle = color;
             ctx.fillRect(cell.x, cell.y, cell.w, cell.h);
             ctx.restore();
         }

--- a/js/systems/assets.js
+++ b/js/systems/assets.js
@@ -24,6 +24,11 @@ const SOUND_OPTIONS = {
         volume: 0.05,
         preload: true
     },
+    place: {
+        src: ['assets/place.wav'],
+        volume: 0.4,
+        preload: true
+    },
     backgroundMusic: {
         src: ['assets/background_music.mp3'],
         volume: 0.25,

--- a/js/systems/audio.js
+++ b/js/systems/audio.js
@@ -3,6 +3,7 @@ const globalScope = typeof globalThis !== 'undefined' ? globalThis : window;
 const NOOP_AUDIO = {
     playFire() {},
     playExplosion() {},
+    playPlace() {},
     playMusic() {},
     stopMusic() {}
 };
@@ -49,6 +50,7 @@ export function createGameAudio(sounds = {}) {
     const fire = sounds.fire ?? null;
     const explosion = sounds.explosion ?? null;
     const backgroundMusic = sounds.backgroundMusic ?? null;
+    const place = sounds.place ?? null;
 
     return {
         playFire() {
@@ -61,6 +63,11 @@ export function createGameAudio(sounds = {}) {
             if (explosion) {
                 console.log('Playing explosion sound');
                 explosion.play();
+            }
+        },
+        playPlace() {
+            if (place) {
+                place.play();
             }
         },
         playMusic() {

--- a/js/systems/ui.js
+++ b/js/systems/ui.js
@@ -129,7 +129,7 @@ function bindCanvasClick(game) {
     });
 }
 
-function tryShoot(game, cell) {
+export function tryShoot(game, cell) {
     if (!cell.occupied) {
         if (game.gold >= game.towerCost) {
             const tower = new Tower(cell.x, cell.y);
@@ -139,9 +139,13 @@ function tryShoot(game, cell) {
             cell.tower = tower;
             tower.cell = cell;
             game.gold -= game.towerCost;
+            cell.highlight = 0.5;
+            cell.highlightColor = 'rgba(255, 255, 255, 1)';
+            game.audio.playPlace();
             updateHUD(game);
         } else {
             cell.highlight = 0.3;
+            cell.highlightColor = 'rgba(248, 113, 113, 1)';
         }
     }
 }

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -113,7 +113,7 @@ test('spawnEnemy can create tank enemies', () => {
     assert.equal(game.enemies.length, 1);
     assert.ok(game.enemies[0] instanceof TankEnemy);
     assert.equal(game.spawned, 1);
-    assert.equal(game.enemies[0].maxHp, baseHp * 5);
+    assert.equal(game.enemies[0].maxHp, baseHp * 4);
 });
 
 test('spawnEnemy defaults to last hp for high wave', () => {
@@ -342,7 +342,7 @@ test('checkWaveCompletion triggers win on final wave', () => {
     game.spawned = game.enemiesPerWave;
     game.enemies = [];
     game.checkWaveCompletion();
-    assert.equal(game.statusEl.textContent, 'WIN');
+    assert.equal(game.statusEl.textContent, 'All waves cleared!');
     assert.equal(game.gameOver, true);
 });
 

--- a/test/gameGrid.test.js
+++ b/test/gameGrid.test.js
@@ -17,6 +17,7 @@ test('constructor builds grid with expected cell positions', () => {
         h: 24,
         occupied: false,
         highlight: 0,
+        highlightColor: null,
         tower: null,
     });
 
@@ -28,6 +29,7 @@ test('constructor builds grid with expected cell positions', () => {
         h: 24,
         occupied: false,
         highlight: 0,
+        highlightColor: null,
         tower: null,
     });
 });
@@ -48,8 +50,26 @@ test('createRow positions cells relative to origin', () => {
     const row = grid.createRow(origin, offsets);
 
     assert.deepEqual(row, [
-        { x: 110, y: 205, w: 30, h: 20, occupied: false, highlight: 0, tower: null },
-        { x: 95, y: 215, w: 30, h: 20, occupied: false, highlight: 0, tower: null },
+        {
+            x: 110,
+            y: 205,
+            w: 30,
+            h: 20,
+            occupied: false,
+            highlight: 0,
+            highlightColor: null,
+            tower: null
+        },
+        {
+            x: 95,
+            y: 215,
+            w: 30,
+            h: 20,
+            occupied: false,
+            highlight: 0,
+            highlightColor: null,
+            tower: null
+        },
     ]);
 });
 
@@ -85,12 +105,14 @@ test('resetCells clears occupancy, highlight and tower references', () => {
     const target = grid.topCells[0];
     target.occupied = true;
     target.highlight = 0.5;
+    target.highlightColor = 'red';
     target.tower = {};
 
     grid.resetCells();
 
     assert.equal(target.occupied, false);
     assert.equal(target.highlight, 0);
+    assert.equal(target.highlightColor, null);
     assert.equal(target.tower, null);
 });
 
@@ -99,10 +121,14 @@ test('fadeHighlights decreases highlight values but never below zero', () => {
     grid.topCells[0].highlight = 0.3;
     grid.topCells[1].highlight = 0.05;
     grid.topCells[2].highlight = 0;
+    grid.topCells[0].highlightColor = 'blue';
+    grid.topCells[1].highlightColor = 'green';
 
     grid.fadeHighlights(0.1);
 
     assert.ok(Math.abs(grid.topCells[0].highlight - 0.2) < 1e-6);
     assert.equal(grid.topCells[1].highlight, 0);
     assert.equal(grid.topCells[2].highlight, 0);
+    assert.equal(grid.topCells[0].highlightColor, 'blue');
+    assert.equal(grid.topCells[1].highlightColor, null);
 });

--- a/test/tower.test.js
+++ b/test/tower.test.js
@@ -43,7 +43,7 @@ test('level 2 tower increases stats and draws highlight', () => {
 
     tower.draw(ctx, assets);
 
-    assert.equal(tower.range, 144);
+    assert.equal(tower.range, 168);
     assert.ok(Math.abs(tower.damage - 1.8) < 1e-6);
     const strokeRectCall = ctx.ops.find(op => op[0] === 'strokeRect');
     assert.deepEqual(strokeRectCall, ['strokeRect', tower.x - 2, tower.y - 2, tower.w + 4, tower.h + 4]);

--- a/test/uiPlacementFeedback.test.js
+++ b/test/uiPlacementFeedback.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { tryShoot } from '../src/js/systems/ui.js';
+
+function makeGame({ gold }) {
+    const textStub = () => ({ textContent: '' });
+    return {
+        gold,
+        towerCost: 12,
+        towers: [],
+        audio: {
+            playPlaceCalls: 0,
+            playPlace() {
+                this.playPlaceCalls += 1;
+            }
+        },
+        lives: 5,
+        maxWaves: 10,
+        wave: 1,
+        livesEl: textStub(),
+        goldEl: textStub(),
+        waveEl: textStub(),
+    };
+}
+
+test('tryShoot flashes cell and plays audio on successful placement', () => {
+    const cell = { x: 10, y: 20, w: 40, h: 24, occupied: false, highlight: 0, highlightColor: null, tower: null };
+    const game = makeGame({ gold: 30 });
+
+    tryShoot(game, cell);
+
+    assert.equal(cell.occupied, true);
+    assert.ok(cell.tower);
+    assert.equal(cell.highlight > 0, true);
+    assert.equal(cell.highlightColor, 'rgba(255, 255, 255, 1)');
+    assert.equal(game.audio.playPlaceCalls, 1);
+    assert.equal(game.gold, 18);
+});
+
+test('tryShoot marks cell red without audio when gold is insufficient', () => {
+    const cell = { x: 10, y: 20, w: 40, h: 24, occupied: false, highlight: 0, highlightColor: null, tower: null };
+    const game = makeGame({ gold: 5 });
+
+    tryShoot(game, cell);
+
+    assert.equal(cell.occupied, false);
+    assert.equal(cell.highlight > 0, true);
+    assert.equal(cell.highlightColor, 'rgba(248, 113, 113, 1)');
+    assert.equal(game.audio.playPlaceCalls, 0);
+    assert.equal(game.gold, 5);
+});


### PR DESCRIPTION
## Summary
- add highlight color support to grid cells so placement and error flashes can be styled
- play a tower placement sound and trigger a bright flash when a tower is built
- cover the new placement feedback with tests and adjust existing expectations, and mark task 004 done

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d44325f8048323983d882c47c89684