### PR TITLE
Add error SFX when tower build fails

### DIFF
--- a/docs/Tasks/Tasks_Prototype_5
+++ b/docs/Tasks/Tasks_Prototype_5
@@ -3,5 +3,5 @@
 003 | DONE | Add end screen (Win/Lose) with “Restart” button. | 002  
 004 | TODO | Add visual and sound feedback when placing a tower. Visual effect should be a flash on the tower or around the tower (not only on the cell, it should be altering the appearance of whole tower). For SFX I will add a sound file myself. | —  
 005 | TODO | Make the game look good on both PC and mobile devices. On any device it should be aligned to the screen, cover all of it or most of it. | —  
-006 | TODO | Add error SFX (will add sound file myself) when trying to build without enough gold. | 004  
+006 | DONE | Add error SFX (will add sound file myself) when trying to build without enough gold. | 004
 007 | TODO | Show CrazyGames interstitial ad on game over. | 003  

--- a/docs/Tasks/Tasks_Prototype_5
+++ b/docs/Tasks/Tasks_Prototype_5
@@ -1,7 +1,0 @@
-001 | DONE | Rebalance enemy HP and gold income so that all 10 waves are beatable but still challenging. | —  
-002 | DONE | Add start menu with “Start Game” button shown before first wave. | —
-003 | DONE | Add end screen (Win/Lose) with “Restart” button. | 002  
-004 | TODO | Add visual and sound feedback when placing a tower. Visual effect should be a flash on the tower or around the tower (not only on the cell, it should be altering the appearance of whole tower). For SFX I will add a sound file myself. | —  
-005 | TODO | Make the game look good on both PC and mobile devices. On any device it should be aligned to the screen, cover all of it or most of it. | —  
-006 | DONE | Add error SFX (will add sound file myself) when trying to build without enough gold. | 004
-007 | TODO | Show CrazyGames interstitial ad on game over. | 003  

--- a/docs/Tasks/Tasks_Prototype_5.txt
+++ b/docs/Tasks/Tasks_Prototype_5.txt
@@ -1,0 +1,8 @@
+001 | DONE | Rebalance enemy HP and gold income so that all 10 waves are beatable but still challenging. | —  
+002 | DONE | Add start menu with “Start Game” button shown before first wave. | —
+003 | DONE | Add end screen (Win/Lose) with “Restart” button. | 002  
+004 | TODO | Add visual and sound feedback when placing a tower. Visual effect should be a flash on the 
+    tower or around the tower (not only on the cell, it should be altering the appearance of whole tower). For SFX I will add a sound file myself. | —  
+005 | TODO | Make the game look good on both PC and mobile devices. On any device it should be aligned to the screen, cover all of it or most of it. | —  
+006 | DONE | Add error SFX (will add sound file myself) when trying to build without enough gold. | 004  
+007 | TODO | Fullfill Technical requirements from Crazy games Documentation | -

--- a/js/systems/assets.js
+++ b/js/systems/assets.js
@@ -24,6 +24,11 @@ const SOUND_OPTIONS = {
         volume: 0.05,
         preload: true
     },
+    error: {
+        src: ['assets/error.wav'],
+        volume: 0.5,
+        preload: true
+    },
     backgroundMusic: {
         src: ['assets/background_music.mp3'],
         volume: 0.25,

--- a/js/systems/audio.js
+++ b/js/systems/audio.js
@@ -4,7 +4,8 @@ const NOOP_AUDIO = {
     playFire() {},
     playExplosion() {},
     playMusic() {},
-    stopMusic() {}
+    stopMusic() {},
+    playError() {}
 };
 
 function hasHowler() {
@@ -49,6 +50,7 @@ export function createGameAudio(sounds = {}) {
     const fire = sounds.fire ?? null;
     const explosion = sounds.explosion ?? null;
     const backgroundMusic = sounds.backgroundMusic ?? null;
+    const error = sounds.error ?? null;
 
     return {
         playFire() {
@@ -72,6 +74,11 @@ export function createGameAudio(sounds = {}) {
         stopMusic() {
             if (backgroundMusic && typeof backgroundMusic.playing === 'function' && backgroundMusic.playing()) {
                 backgroundMusic.stop();
+            }
+        },
+        playError() {
+            if (error) {
+                error.play();
             }
         }
     };

--- a/js/systems/ui.js
+++ b/js/systems/ui.js
@@ -142,6 +142,9 @@ function tryShoot(game, cell) {
             updateHUD(game);
         } else {
             cell.highlight = 0.3;
+            if (typeof game.audio?.playError === 'function') {
+                game.audio.playError();
+            }
         }
     }
 }

--- a/test/audio.test.js
+++ b/test/audio.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createSound, getHowler, initializeAudio, isAudioSupported } from '../js/systems/audio.js';
+import { createGameAudio, createSound, getHowler, initializeAudio, isAudioSupported } from '../js/systems/audio.js';
 
 test('initializeAudio returns false when howler is missing', () => {
     const originalHowl = globalThis.Howl;
@@ -48,6 +48,36 @@ test('createSound uses the active Howl constructor', () => {
         assert.ok(sound instanceof FakeHowl);
         assert.deepEqual(sound.options, { src: ['sound.ogg'], loop: true });
         assert.equal(fakeHowler.autoSuspend, false);
+    } finally {
+        if (originalHowl) {
+            globalThis.Howl = originalHowl;
+        } else {
+            delete globalThis.Howl;
+        }
+        if (originalHowler) {
+            globalThis.Howler = originalHowler;
+        } else {
+            delete globalThis.Howler;
+        }
+    }
+});
+
+test('createGameAudio exposes playError when howler is available', () => {
+    class FakeHowl {}
+    const fakeHowler = {};
+
+    const originalHowl = globalThis.Howl;
+    const originalHowler = globalThis.Howler;
+    globalThis.Howl = FakeHowl;
+    globalThis.Howler = fakeHowler;
+
+    const errorSound = { played: false, play() { this.played = true; } };
+
+    try {
+        const audio = createGameAudio({ error: errorSound });
+        assert.equal(typeof audio.playError, 'function');
+        audio.playError();
+        assert.equal(errorSound.played, true);
     } finally {
         if (originalHowl) {
             globalThis.Howl = originalHowl;


### PR DESCRIPTION
## Summary
- add optional error audio channel to the game audio system and asset loader
- trigger the error sound whenever a player tries to build a tower without enough gold
- extend audio tests to cover the new error playback helper and mark task 6 as done

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b91b47248323af52a6abb7646288