### PR TITLE
Display CrazyGames user info in HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
             </div>
         </div>
         <div id="hud">
+            <div id="crazyGamesUser" class="user-info hidden">
+                <img id="crazyGamesUserAvatar" alt="CrazyGames profile picture" />
+                <span id="crazyGamesUsername"></span>
+            </div>
             <span id="lives">Lives: 10</span>
             <span id="gold">Gold: 20</span>
             <span id="wave">Wave: 1/10</span>

--- a/js/main.js
+++ b/js/main.js
@@ -26,9 +26,31 @@ function resizeCanvas() {
 const LOGICAL_W = 540;
 const LOGICAL_H = 960;
 await initializeCrazyGamesIntegration();
-const user = await getCrazyGamesUser();
+let user = null;
+try {
+    user = await getCrazyGamesUser();
+} catch (error) {
+    console.warn("Failed to fetch CrazyGames user", error);
+}
 if (user) {
     console.log("Logged in as:", user.username);
+    const userContainer = document.getElementById('crazyGamesUser');
+    const usernameEl = document.getElementById('crazyGamesUsername');
+    const avatarEl = document.getElementById('crazyGamesUserAvatar');
+    if (usernameEl) {
+        usernameEl.textContent = user.username ?? 'CrazyGames Player';
+    }
+    if (avatarEl) {
+        if (user.profilePictureUrl) {
+            avatarEl.src = user.profilePictureUrl;
+            avatarEl.style.display = 'block';
+        } else {
+            avatarEl.style.display = 'none';
+        }
+    }
+    if (userContainer) {
+        userContainer.classList.remove('hidden');
+    }
 }
 console.log("CrazyGames integration kinda finished..");
 callCrazyGamesEvent('sdkGameLoadingStart');
@@ -44,10 +66,15 @@ window.addEventListener('resize', resizeCanvas);
 async function getCrazyGamesUser() {
     const available = window.CrazyGames?.SDK?.user?.isUserAccountAvailable;
     console.log("User account system available?", available);
-    if (available) {
+    if (!available) {
+        return null;
+    }
+    try {
         const user = await window.CrazyGames.SDK.user.getUser();
         console.log("User info:", user);
         return { username: user.username, profilePictureUrl: user.profilePictureUrl };
+    } catch (error) {
+        console.warn("CrazyGames SDK getUser failed", error);
+        return null;
     }
-    return Promise.reject();
 }

--- a/style.css
+++ b/style.css
@@ -16,6 +16,26 @@ body {
     font-family: sans-serif;
 }
 
+#crazyGamesUser {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+}
+
+#crazyGamesUser.hidden {
+    display: none;
+}
+
+#crazyGamesUserAvatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: #d1d5db;
+    display: none;
+}
+
 #tip {
     flex-basis: 100%;
 }


### PR DESCRIPTION
## Summary
- add a CrazyGames user panel to the HUD with slots for the avatar and username
- populate the HUD panel when the CrazyGames user is available and handle SDK failures gracefully
- style the user panel so the avatar and username align with existing HUD elements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dadffe451083239ff1bd9493371371