### PR TITLE
Delay game start until first canvas tap

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -64,6 +64,35 @@ callCrazyGamesEvent('sdkGameLoadingStop');
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
 
+const startEvents = 'PointerEvent' in window ? ['pointerdown'] : ['mousedown', 'touchstart'];
+
+const startGameOnce = () => {
+    if (game.hasStarted) {
+        cleanupStartListeners();
+        return;
+    }
+
+    if (game.startOverlay) {
+        game.startOverlay.classList.add('hidden');
+    }
+    if (game.nextWaveBtn) {
+        game.nextWaveBtn.disabled = false;
+    }
+    if (game.restartBtn) {
+        game.restartBtn.disabled = false;
+    }
+
+    game.run();
+    game.audio?.playMusic?.();
+    cleanupStartListeners();
+};
+
+function cleanupStartListeners() {
+    startEvents.forEach(evt => canvas.removeEventListener(evt, startGameOnce));
+}
+
+startEvents.forEach(evt => canvas.addEventListener(evt, startGameOnce, { passive: true }));
+
 async function getCrazyGamesUser() {
     const available = window.CrazyGames?.SDK?.user?.isUserAccountAvailable;
     console.log("User account system available?", available);


### PR DESCRIPTION
## Summary
- wait for the player's first tap or click on the canvas before starting gameplay
- hide the start overlay, enable controls, and trigger music playback from the gesture
- clean up the temporary gesture listener once the game has begun to keep later clicks normal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e01ff273bc83238da379766c6f68c5