### PR TITLE
Disable CrazyGames integration on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8" />
         <title>Minimal Tower Defense</title>
         <link rel="stylesheet" href="style.css" />
-        <script src="https://sdk.crazygames.com/crazygames-sdk-v3.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.4/howler.min.js"></script>
     </head>
     <body>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { callCrazyGamesEvent, checkCrazyGamesIntegration, crazyGamesWorks, initializeCrazyGamesIntegration } from './systems/crazyGamesIntegration.js';
+import { callCrazyGamesEvent, crazyGamesIntegrationAllowed, crazyGamesWorks, initializeCrazyGamesIntegration } from './systems/crazyGamesIntegration.js';
 import Game from './core/Game.js';
 import { bindUI } from './systems/ui.js';
 import { loadAssets } from './systems/assets.js';
@@ -26,41 +26,48 @@ function resizeCanvas() {
 
 const LOGICAL_W = 540;
 const LOGICAL_H = 960;
-await initializeCrazyGamesIntegration();
-let user = null;
-try {
-    user = await getCrazyGamesUser();
-} catch (error) {
-    console.warn("Failed to fetch CrazyGames user", error);
-}
-if (user) {
-    console.log("Logged in as:", user.username);
-    const userContainer = document.getElementById('crazyGamesUser');
-    const usernameEl = document.getElementById('crazyGamesUsername');
-    const avatarEl = document.getElementById('crazyGamesUserAvatar');
-    if (usernameEl) {
-        usernameEl.textContent = user.username ?? 'CrazyGames Player';
+
+if (crazyGamesIntegrationAllowed) {
+    await initializeCrazyGamesIntegration();
+    let user = null;
+    try {
+        user = await getCrazyGamesUser();
+    } catch (error) {
+        console.warn("Failed to fetch CrazyGames user", error);
     }
-    if (avatarEl) {
-        if (user.profilePictureUrl) {
-            avatarEl.src = user.profilePictureUrl;
-            avatarEl.style.display = 'block';
-        } else {
-            avatarEl.style.display = 'none';
+    if (user) {
+        console.log("Logged in as:", user.username);
+        const userContainer = document.getElementById('crazyGamesUser');
+        const usernameEl = document.getElementById('crazyGamesUsername');
+        const avatarEl = document.getElementById('crazyGamesUserAvatar');
+        if (usernameEl) {
+            usernameEl.textContent = user.username ?? 'CrazyGames Player';
+        }
+        if (avatarEl) {
+            if (user.profilePictureUrl) {
+                avatarEl.src = user.profilePictureUrl;
+                avatarEl.style.display = 'block';
+            } else {
+                avatarEl.style.display = 'none';
+            }
+        }
+        if (userContainer) {
+            userContainer.classList.remove('hidden');
         }
     }
-    if (userContainer) {
-        userContainer.classList.remove('hidden');
-    }
+    console.log("CrazyGames integration kinda finished..");
+    callCrazyGamesEvent('sdkGameLoadingStart');
+} else {
+    console.log('CrazyGames integration disabled for this host.');
 }
-console.log("CrazyGames integration kinda finished..");
-callCrazyGamesEvent('sdkGameLoadingStart');
 initializeAudio();
 const canvas = document.getElementById('game');
 const assets = await loadAssets();
 const game = new Game(canvas, { width: LOGICAL_W, height: LOGICAL_H, assets });
 bindUI(game);
-callCrazyGamesEvent('sdkGameLoadingStop');
+if (crazyGamesIntegrationAllowed) {
+    callCrazyGamesEvent('sdkGameLoadingStop');
+}
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
 

--- a/js/systems/crazyGamesIntegration.js
+++ b/js/systems/crazyGamesIntegration.js
@@ -1,5 +1,35 @@
 export let crazyGamesWorks = false;
 
+const blockedCrazyGamesHosts = new Set([
+    'pavelonishenko.github.io',
+]);
+
+function getNormalizedHost() {
+    if (typeof window === 'undefined') {
+        return '';
+    }
+    const rawHost = window.location?.hostname || '';
+    return rawHost.trim().toLowerCase();
+}
+
+function isGithubPagesHost(host) {
+    return host.endsWith('.github.io');
+}
+
+export const crazyGamesIntegrationAllowed = (() => {
+    const host = getNormalizedHost();
+    if (!host) {
+        return true;
+    }
+    if (blockedCrazyGamesHosts.has(host)) {
+        return false;
+    }
+    if (isGithubPagesHost(host)) {
+        return false;
+    }
+    return true;
+})();
+
 export const crazyMap = {
   sdkGameLoadingStart: "loadingStart",
   sdkGameLoadingStop: "loadingStop",
@@ -7,9 +37,54 @@ export const crazyMap = {
   gameplayStop: "gameplayStop"
 };
 
+let crazyGamesSdkPromise = null;
+
+function ensureCrazyGamesSdkLoaded() {
+    if (!crazyGamesIntegrationAllowed) {
+        return Promise.resolve(false);
+    }
+    if (window.CrazyGames?.SDK) {
+        return Promise.resolve(true);
+    }
+    if (!crazyGamesSdkPromise) {
+        crazyGamesSdkPromise = new Promise(resolve => {
+            const handleResult = (success) => {
+                resolve(Boolean(success));
+            };
+
+            const existingScript = document.querySelector('script[data-crazygames-sdk]');
+            if (existingScript) {
+                if (existingScript.dataset.crazygamesSdkLoaded === 'true') {
+                    handleResult(true);
+                    return;
+                }
+                const state = existingScript.readyState;
+                if (state === 'complete' || state === 'loaded') {
+                    handleResult(true);
+                    return;
+                }
+                existingScript.addEventListener('load', () => handleResult(true), { once: true });
+                existingScript.addEventListener('error', () => handleResult(false), { once: true });
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.src = 'https://sdk.crazygames.com/crazygames-sdk-v3.js';
+            script.async = true;
+            script.dataset.crazygamesSdk = 'true';
+            script.addEventListener('load', () => {
+                script.dataset.crazygamesSdkLoaded = 'true';
+                handleResult(true);
+            }, { once: true });
+            script.addEventListener('error', () => handleResult(false), { once: true });
+            document.head.appendChild(script);
+        });
+    }
+    return crazyGamesSdkPromise;
+}
+
 export function callCrazyGamesEvent(fnName) {
-    if (!crazyGamesWorks) {
-        console.log(`CrazyGames integration not working, skipping [${fnName}] event.`);
+    if (!crazyGamesIntegrationAllowed || !crazyGamesWorks) {
         return;
     }
     try {
@@ -23,6 +98,16 @@ export function callCrazyGamesEvent(fnName) {
 }
 
 export async function initializeCrazyGamesIntegration() {
+    crazyGamesWorks = false;
+    if (!crazyGamesIntegrationAllowed) {
+        return;
+    }
+
+    const sdkLoaded = await ensureCrazyGamesSdkLoaded();
+    if (!sdkLoaded || !window.CrazyGames?.SDK) {
+        return;
+    }
+
     preventDefaultMouseBehabior();
     console.log("Calling CrazyGames SDK init...");
     await window.CrazyGames.SDK.init();
@@ -31,7 +116,7 @@ export async function initializeCrazyGamesIntegration() {
     if (integrationWorks) {
         crazyGamesWorks = true;
         console.log("CrazyGames integration initialized.");
-    } 
+    }
 }
 
 function preventDefaultMouseBehabior() {
@@ -46,6 +131,9 @@ function preventDefaultMouseBehabior() {
 }
 
 export function checkCrazyGamesIntegration() {
+    if (!crazyGamesIntegrationAllowed) {
+        return false;
+    }
     console.log(`Environment: ${window.CrazyGames?.SDK?.environment}`);
     if (window.CrazyGames?.SDK?.environment === 'disabled') {
         console.warn('CrazyGames SDK is disabled on this domain.');


### PR DESCRIPTION
## Summary
- block CrazyGames integration whenever the game runs from a github.io host
- dynamically load the CrazyGames SDK only when permitted and no-op all CrazyGames hooks otherwise
- remove the static CrazyGames SDK script tag from the HTML shell

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e242019f7883239dd114a87f3bad9a