### PR TITLE
Adjust mobile HUD sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -49,6 +49,26 @@ body {
     pointer-events: auto;
 }
 
+@media (max-width: 600px) {
+    #hud {
+        font-size: clamp(1.1rem, 4vw, 1.6rem);
+        gap: 12px;
+        padding: 14px;
+    }
+
+    #hud button {
+        font-size: 1em;
+        padding: 12px 20px;
+        min-height: 44px;
+        border-radius: 999px;
+    }
+
+    #crazyGamesUserAvatar {
+        width: 40px;
+        height: 40px;
+    }
+}
+
 canvas {
     display: block;
     background: #000;


### PR DESCRIPTION
## Summary
- increase HUD font sizing, spacing, and button tap targets for narrow screens
- bump profile avatar size inside the HUD on mobile to match the larger layout

## Testing
- Manual verification in mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68e25dcc16448323998ee3f26c01a2eb