### PR TITLE
Replace lives text with heart icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                     <img id="crazyGamesUserAvatar" alt="CrazyGames profile picture" />
                     <span id="crazyGamesUsername"></span>
                 </div>
-                <span id="lives">Lives: 10</span>
+                <div id="lives" class="lives" aria-label="Lives"></div>
                 <span id="gold">Gold: 20</span>
                 <span id="wave">Wave: 1/10</span>
                 <span id="cooldown">Switch: Ready</span>

--- a/style.css
+++ b/style.css
@@ -45,6 +45,21 @@ body {
     z-index: 2;
 }
 
+#lives {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.life-heart {
+    width: 24px;
+    height: 24px;
+    object-fit: contain;
+    image-rendering: pixelated;
+    filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.4));
+    user-select: none;
+}
+
 #hud button {
     pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- replace the HUD lives text with a heart container that updates icons based on remaining health
- add heart styling for the HUD and ensure accessibility labels are kept in sync
- update the HUD logic to render icons in the browser while falling back to text when the DOM is unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2c62900908323b2c4c1a382b50a1b