### PR TITLE
Replace gold HUD with energy display

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,13 +29,17 @@
                     <span id="crazyGamesUsername"></span>
                 </div>
                 <div id="lives" class="lives" aria-label="Lives"></div>
-                <span id="gold">Gold: 20</span>
+                <div id="energy" class="resource" aria-label="Energy">
+                    <span class="resource-label">Energy:</span>
+                    <span class="resource-value">20</span>
+                    <img class="resource-icon" src="assets/energy_sign.png" alt="" aria-hidden="true" />
+                </div>
                 <span id="wave">Wave: 1/10</span>
                 <span id="cooldown">Switch: Ready</span>
                 <span id="status"></span>
                 <button id="nextWave">Next Wave</button>
                 <button id="restart">Restart</button>
-                <span id="tip">Tap slot to build. Tap tower to switch (1 gold).</span>
+                <span id="tip">Tap slot to build. Tap tower to switch (1 energy).</span>
             </div>
         </div>
         <script type="module" src="js/main.js"></script>

--- a/js/core/Game.js
+++ b/js/core/Game.js
@@ -56,9 +56,9 @@ class Game {
 
     initStats() {
         this.initialLives = 5;
-        this.initialGold = 50;
+        this.initialEnergy = 50;
         this.lives = this.initialLives;
-        this.gold = this.initialGold;
+        this.energy = this.initialEnergy;
         this.wave = 1;
         this.maxWaves = 10;
         this.towerCost = 12;
@@ -103,7 +103,8 @@ class Game {
         const targetWave = clamp(toInt(savedState.wave, 1), 1, this.maxWaves);
 
         this.lives = clamp(toInt(savedState.lives, this.initialLives), 0, 99);
-        this.gold = clamp(toInt(savedState.gold, this.initialGold), 0, 9999);
+        const savedEnergy = savedState.energy ?? savedState.gold;
+        this.energy = clamp(toInt(savedEnergy, this.initialEnergy), 0, 9999);
         this.wave = targetWave;
         this.waveInProgress = false;
         this.spawned = 0;
@@ -192,7 +193,7 @@ class Game {
         return {
             version: 1,
             lives: this.lives,
-            gold: this.gold,
+            energy: this.energy,
             wave: this.wave,
             towers: towerState
         };
@@ -270,10 +271,10 @@ class Game {
     }
 
     switchTowerColor(tower) {
-        if (this.switchCooldown > 0 || this.gold < this.switchCost) 
+        if (this.switchCooldown > 0 || this.energy < this.switchCost)
             return false;
         tower.color = tower.color === 'red' ? 'blue' : 'red';
-        this.gold -= this.switchCost;
+        this.energy -= this.switchCost;
         updateHUD(this);
         this.switchCooldown = this.switchCooldownDuration;
         updateSwitchIndicator(this);
@@ -317,7 +318,7 @@ class Game {
 
     resetState() {
         this.lives = this.initialLives;
-        this.gold = this.initialGold;
+        this.energy = this.initialEnergy;
         this.wave = 1;
         this.towers = [];
         this.enemies = [];

--- a/js/core/gameWaves.js
+++ b/js/core/gameWaves.js
@@ -69,7 +69,7 @@ export const waveActions = {
                 this.nextWaveBtn.disabled = false;
             }
             this.wave += 1;
-            this.gold += 3;
+            this.energy += 3;
             updateHUD(this);
         }
     }

--- a/js/core/projectiles.js
+++ b/js/core/projectiles.js
@@ -21,7 +21,7 @@ export function hitEnemy(game, projectile, index) {
 
     if (enemy.hp <= 0) {
         game.enemies.splice(enemyIndex, 1);
-        game.gold += 1;
+        game.energy += 1;
         updateHUD(game);
     }
 

--- a/js/systems/ui.js
+++ b/js/systems/ui.js
@@ -35,7 +35,7 @@ export function bindUI(game) {
 
 function bindHUD(game) {
     game.livesEl = document.getElementById('lives');
-    game.goldEl = document.getElementById('gold');
+    game.energyEl = document.getElementById('energy');
     game.waveEl = document.getElementById('wave');
     game.cooldownEl = document.getElementById('cooldown');
     game.statusEl = document.getElementById('status');
@@ -134,7 +134,7 @@ function bindCanvasClick(game) {
 
 function tryShoot(game, cell) {
     if (!cell.occupied) {
-        if (game.gold >= game.towerCost) {
+        if (game.energy >= game.towerCost) {
             const tower = new Tower(cell.x, cell.y);
             tower.alignToCell(cell);
             tower.triggerPlacementFlash();
@@ -142,7 +142,7 @@ function tryShoot(game, cell) {
             cell.occupied = true;
             cell.tower = tower;
             tower.cell = cell;
-            game.gold -= game.towerCost;
+            game.energy -= game.towerCost;
             updateHUD(game);
             if (game.audio && typeof game.audio.playPlacement === 'function') {
                 game.audio.playPlacement();
@@ -158,7 +158,7 @@ function tryShoot(game, cell) {
 
 export function updateHUD(game) {
     renderLives(game);
-    game.goldEl.textContent = `Gold: ${game.gold}`;
+    renderEnergy(game);
     game.waveEl.textContent = `Wave: ${game.wave}/${game.maxWaves}`;
     if (typeof game.persistState === 'function') {
         game.persistState();
@@ -212,6 +212,49 @@ export function updateSwitchIndicator(game) {
         game.switchCooldown > 0
             ? `Switch: ${game.switchCooldown.toFixed(1)}s`
             : 'Switch: Ready';
+}
+
+function renderEnergy(game) {
+    if (!game.energyEl)
+        return;
+    const amount = Number.isFinite(game.energy) ? game.energy : 0;
+    const canRender = typeof document !== 'undefined'
+        && typeof document.createElement === 'function'
+        && typeof game.energyEl.replaceChildren === 'function';
+    if (canRender) {
+        const fragment = typeof document.createDocumentFragment === 'function'
+            ? document.createDocumentFragment()
+            : null;
+        const label = document.createElement('span');
+        label.className = 'resource-label';
+        label.textContent = 'Energy:';
+        const value = document.createElement('span');
+        value.className = 'resource-value';
+        value.textContent = `${amount}`;
+        const icon = document.createElement('img');
+        icon.className = 'resource-icon';
+        icon.src = 'assets/energy_sign.png';
+        icon.alt = '';
+        icon.setAttribute('aria-hidden', 'true');
+        if (fragment) {
+            fragment.appendChild(label);
+            fragment.appendChild(value);
+            fragment.appendChild(icon);
+            game.energyEl.replaceChildren(fragment);
+        }
+        else {
+            game.energyEl.replaceChildren(label, value, icon);
+        }
+        if (typeof game.energyEl.setAttribute === 'function') {
+            game.energyEl.setAttribute('aria-label', `Energy: ${amount}`);
+        }
+    }
+    else {
+        game.energyEl.textContent = `Energy: ${amount}`;
+        if (typeof game.energyEl.setAttribute === 'function') {
+            game.energyEl.setAttribute('aria-label', `Energy: ${amount}`);
+        }
+    }
 }
 
 export function endGame(game, text) {

--- a/style.css
+++ b/style.css
@@ -51,6 +51,31 @@ body {
     gap: 6px;
 }
 
+#energy {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+}
+
+.resource-label {
+    letter-spacing: 0.02em;
+}
+
+.resource-value {
+    color: #ffe066;
+    font-weight: 700;
+    text-shadow: 0 0 6px rgba(255, 224, 102, 0.65);
+}
+
+.resource-icon {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
+    image-rendering: pixelated;
+    filter: drop-shadow(0 0 4px rgba(255, 224, 102, 0.55));
+}
+
 .life-heart {
     width: 24px;
     height: 24px;

--- a/test/Game.test.js
+++ b/test/Game.test.js
@@ -38,7 +38,7 @@ function makeFakeCanvas() {
 
 function attachDomStubs(game) {
     game.livesEl = { textContent: '' };
-    game.goldEl = { textContent: '' };
+    game.energyEl = { textContent: '' };
     game.waveEl = { textContent: '' };
     game.statusEl = { textContent: '', style: {} };
     game.nextWaveBtn = { disabled: false };
@@ -300,7 +300,7 @@ test('updateEnemies removes enemies reaching base and reduces lives', () => {
     assert.equal(game.lives, livesBefore - 1);
 });
 
-test('checkWaveCompletion increments wave and gold', () => {
+test('checkWaveCompletion increments wave and energy', () => {
     const game = new Game(makeFakeCanvas());
     attachDomStubs(game);
     game.waveInProgress = true;
@@ -310,7 +310,7 @@ test('checkWaveCompletion increments wave and gold', () => {
     game.checkWaveCompletion();
     assert.equal(game.waveInProgress, false);
     assert.equal(game.wave, 2);
-    assert.equal(game.gold, game.initialGold + 3);
+    assert.equal(game.energy, game.initialEnergy + 3);
     assert.equal(game.nextWaveBtn.disabled, false);
 });
 
@@ -350,7 +350,7 @@ test('resetState restores initial game values', () => {
     const game = new Game(makeFakeCanvas());
     attachDomStubs(game);
     game.lives = 1;
-    game.gold = 0;
+    game.energy = 0;
     game.wave = 3;
     game.towers.push({});
     game.enemies.push({});
@@ -364,7 +364,7 @@ test('resetState restores initial game values', () => {
     game.statusEl.textContent = 'status';
     game.resetState();
     assert.equal(game.lives, game.initialLives);
-    assert.equal(game.gold, game.initialGold);
+    assert.equal(game.energy, game.initialEnergy);
     assert.equal(game.wave, 1);
     assert.equal(game.towers.length, 0);
     assert.equal(game.enemies.length, 0);

--- a/test/hudTip.test.js
+++ b/test/hudTip.test.js
@@ -4,11 +4,11 @@ import { bindUI } from '../js/systems/ui.js';
 
 test('bindUI attaches tip element with text', () => {
   const elements = {};
-  const ids = ['lives','gold','wave','cooldown','status','nextWave','restart','tip'];
+  const ids = ['lives','energy','wave','cooldown','status','nextWave','restart','tip'];
   for (const id of ids) {
     elements[id] = { textContent: '', addEventListener: () => {} };
   }
-  elements['tip'].textContent = 'Tap slot to build. Tap tower to switch (1 gold).';
+  elements['tip'].textContent = 'Tap slot to build. Tap tower to switch (1 energy).';
   const doc = {
     getElementById: id => elements[id]
   };
@@ -17,7 +17,7 @@ test('bindUI attaches tip element with text', () => {
     towers: [],
     grid: [],
     lives: 5,
-    gold: 20,
+    energy: 20,
     wave: 1,
     maxWaves: 10,
     switchCooldown: 0,
@@ -25,6 +25,6 @@ test('bindUI attaches tip element with text', () => {
   };
   global.document = doc;
   bindUI(game);
-  assert.equal(game.tipEl.textContent, 'Tap slot to build. Tap tower to switch (1 gold).');
+  assert.equal(game.tipEl.textContent, 'Tap slot to build. Tap tower to switch (1 energy).');
   delete global.document;
 });

--- a/test/projectiles.test.js
+++ b/test/projectiles.test.js
@@ -8,12 +8,12 @@ function makeGame() {
         enemies: [],
         explosions: [],
         canvas: { width: 450, height: 800 },
-        gold: 0,
+        energy: 0,
         wave: 1,
         maxWaves: 5,
         lives: 3,
         livesEl: { textContent: '' },
-        goldEl: { textContent: '' },
+        energyEl: { textContent: '' },
         waveEl: { textContent: '' },
     };
 }
@@ -42,12 +42,12 @@ test('hitEnemy damages enemy and removes projectile when enemy survives', () => 
     assert.equal(enemy.hp, 1);
     assert.equal(game.projectiles.length, 0);
     assert.equal(game.enemies.length, 1);
-    assert.equal(game.gold, 0);
+    assert.equal(game.energy, 0);
     assert.equal(game.explosions.length, 1);
     assert.ok(game.explosions[0].particles.length > 0);
 });
 
-test('hitEnemy removes enemy and updates gold when enemy dies', () => {
+test('hitEnemy removes enemy and updates energy when enemy dies', () => {
     const game = makeGame();
     const enemy = { x: 10, y: 10, w: 20, h: 20, hp: 1, color: 'red' };
     const projectile = { x: 15, y: 15, color: 'red', damage: 1 };
@@ -59,8 +59,8 @@ test('hitEnemy removes enemy and updates gold when enemy dies', () => {
     assert.equal(result, true);
     assert.equal(game.projectiles.length, 0);
     assert.equal(game.enemies.length, 0);
-    assert.equal(game.gold, 1);
-    assert.equal(game.goldEl.textContent, 'Gold: 1');
+    assert.equal(game.energy, 1);
+    assert.equal(game.energyEl.textContent, 'Energy: 1');
     assert.equal(game.explosions.length, 1);
 });
 
@@ -78,7 +78,7 @@ test('handleProjectileHits removes offscreen and hit projectiles', () => {
     assert.equal(game.projectiles.length, 1);
     assert.deepEqual(game.projectiles[0], pMiss);
     assert.equal(game.enemies.length, 0);
-    assert.equal(game.gold, 1);
+    assert.equal(game.energy, 1);
     assert.equal(game.explosions.length, 1);
 });
 
@@ -95,6 +95,6 @@ test('hitEnemy deals reduced damage when colors differ', () => {
     assert.ok(Math.abs(enemy.hp - 0.6) < 1e-6);
     assert.equal(game.projectiles.length, 0);
     assert.equal(game.enemies.length, 1);
-    assert.equal(game.gold, 0);
+    assert.equal(game.energy, 0);
     assert.equal(game.explosions.length, 1);
 });

--- a/test/switchCooldown.test.js
+++ b/test/switchCooldown.test.js
@@ -32,28 +32,28 @@ function makeAssets() {
     });
 }
 
-test('switchTowerColor costs gold and respects global cooldown', () => {
+test('switchTowerColor costs energy and respects global cooldown', () => {
     const game = new Game(makeFakeCanvas());
     game.livesEl = { textContent: '' };
-    game.goldEl = { textContent: '' };
+    game.energyEl = { textContent: '' };
     game.waveEl = { textContent: '' };
     game.cooldownEl = { textContent: '' };
     game.nextWaveBtn = { disabled: false };
     game.assets = makeAssets();
     const tower = new Tower(0, 0);
 
-    game.gold = game.switchCost + 1;
+    game.energy = game.switchCost + 1;
     assert.equal(game.switchCooldown, 0);
     const first = game.switchTowerColor(tower);
     assert.equal(first, true);
     assert.equal(tower.color, 'blue');
-    assert.equal(game.gold, 1);
+    assert.equal(game.energy, 1);
     assert.equal(game.switchCooldown, game.switchCooldownDuration);
 
     const second = game.switchTowerColor(tower);
     assert.equal(second, false);
     assert.equal(tower.color, 'blue');
-    assert.equal(game.gold, 1);
+    assert.equal(game.energy, 1);
 
     const originalRAF = globalThis.requestAnimationFrame;
     globalThis.requestAnimationFrame = () => {};
@@ -62,17 +62,17 @@ test('switchTowerColor costs gold and respects global cooldown', () => {
     globalThis.requestAnimationFrame = originalRAF;
     assert.equal(game.switchCooldown, 0);
 
-    game.gold = 0;
+    game.energy = 0;
     const third = game.switchTowerColor(tower);
     assert.equal(third, false);
     assert.equal(tower.color, 'blue');
-    assert.equal(game.gold, 0);
+    assert.equal(game.energy, 0);
 
-    game.gold = game.switchCost;
+    game.energy = game.switchCost;
     const fourth = game.switchTowerColor(tower);
     assert.equal(fourth, true);
     assert.equal(tower.color, 'red');
-    assert.equal(game.gold, 0);
+    assert.equal(game.energy, 0);
 });
 
 test('updateSwitchCooldown decreases timer and updates indicator', () => {


### PR DESCRIPTION
## Summary
- replace the HUD gold label with a new energy display that shows the icon and yellow styling
- rename game state and HUD logic from gold to energy, including persistence and reward updates
- update automated tests to expect the new energy terminology and formatting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2d378849083239499f1e6ac9bcf25