### PR TITLE
Make canvas fill viewport and scale background

### DIFF
--- a/js/core/Game.js
+++ b/js/core/Game.js
@@ -17,6 +17,7 @@ class Game {
         this.logicalW = width;
         this.logicalH = height;
         this.ctx = canvas.getContext('2d');
+        this.viewport = { scale: 1, offsetX: 0, offsetY: 0, dpr: 1 };
         this.enemies = [];
         this.towers = [];
         this.projectiles = [];

--- a/js/core/render.js
+++ b/js/core/render.js
@@ -2,12 +2,22 @@ import { drawExplosions } from '../systems/effects.js';
 
 export function draw(game) {
     const ctx = game.ctx;
+    const { scale = 1, offsetX = 0, offsetY = 0 } = game.viewport ?? {};
+
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.clearRect(0, 0, game.canvas.width, game.canvas.height);
+    ctx.restore();
+
+    ctx.save();
+    ctx.setTransform(scale, 0, 0, scale, offsetX, offsetY);
 
     drawBase(game);
     drawPlatforms(game);
     drawGrid(game);
     drawEntities(game);
+
+    ctx.restore();
 }
 
 function drawBase(game) {

--- a/js/main.js
+++ b/js/main.js
@@ -7,21 +7,14 @@ import { initializeAudio } from './systems/audio.js';
 function resizeCanvas() {
     const vw = window.innerWidth;
     const vh = window.innerHeight;
-    const aspect = 9 / 16;
-    let targetW, targetH;
-    if (vw / vh > aspect) {
-        targetH = vh;
-        targetW = vh * aspect;
-    } else {
-        targetW = vw;
-        targetH = vw / aspect;
-    }
-    canvas.style.width = `${targetW}px`;
-    canvas.style.height = `${targetH}px`;
+
+    canvas.style.width = `${vw}px`;
+    canvas.style.height = `${vh}px`;
 
     canvas.width = LOGICAL_W;
     canvas.height = LOGICAL_H;
     canvas.style.backgroundColor = '#000';
+    canvas.style.backgroundSize = 'cover';
 }
 
 const LOGICAL_W = 540;

--- a/js/systems/ui.js
+++ b/js/systems/ui.js
@@ -6,12 +6,23 @@ const HEART_EMPTY_SRC = 'assets/heart_empty.png';
 
 function getMousePos(canvas, e) {
     const rect = canvas.getBoundingClientRect();
-    // Map from CSS pixels to canvas logical coordinates for precise hit testing
     const scaleX = canvas.width / rect.width;
     const scaleY = canvas.height / rect.height;
+    const canvasX = (e.clientX - rect.left) * scaleX;
+    const canvasY = (e.clientY - rect.top) * scaleY;
+
+    const transform = canvas.viewportTransform;
+    if (transform) {
+        const { scale = 1, offsetX = 0, offsetY = 0 } = transform;
+        return {
+            x: (canvasX - offsetX) / scale,
+            y: (canvasY - offsetY) / scale,
+        };
+    }
+
     return {
-        x: (e.clientX - rect.left) * scaleX,
-        y: (e.clientY - rect.top) * scaleY,
+        x: canvasX,
+        y: canvasY,
     };
 }
 

--- a/style.css
+++ b/style.css
@@ -86,6 +86,8 @@ body {
 
 canvas {
     display: block;
+    width: 100vw;
+    height: 100vh;
     background-color: #000;
     background-image: url('assets/bg_anim.gif');
     background-position: center;


### PR DESCRIPTION
## Summary
- update the resize handler so the game canvas always matches the browser viewport dimensions
- ensure the canvas element fills the viewport in CSS while keeping the animated background covering the surface

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d9a5ed408323a577dac420b2d237