### PR TITLE
Show CrazyGames user info in HUD tip slot

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,6 @@
         <div id="gameContainer">
             <canvas id="game" width="450" height="800"></canvas>
             <div id="hud">
-                <div id="crazyGamesUser" class="user-info hidden">
-                    <img id="crazyGamesUserAvatar" alt="CrazyGames profile picture" />
-                    <span id="crazyGamesUsername"></span>
-                </div>
                 <div id="lives" class="lives" aria-label="Lives"></div>
                 <div id="energy" class="resource" aria-label="Energy">
                     <span class="resource-label">Energy:</span>
@@ -39,7 +35,10 @@
                 <span id="status"></span>
                 <button id="nextWave">Next Wave</button>
                 <button id="restart">Restart</button>
-                <span id="tip">Tap slot to build. Tap tower to switch (1 energy).</span>
+                <div id="crazyGamesUser" class="user-info hidden" aria-live="polite">
+                    <img id="crazyGamesUserAvatar" alt="CrazyGames profile picture" />
+                    <span id="crazyGamesUsername"></span>
+                </div>
             </div>
         </div>
         <script type="module" src="js/main.js"></script>

--- a/js/systems/ui.js
+++ b/js/systems/ui.js
@@ -50,7 +50,6 @@ function bindHUD(game) {
     game.waveEl = document.getElementById('wave');
     game.cooldownEl = document.getElementById('cooldown');
     game.statusEl = document.getElementById('status');
-    game.tipEl = document.getElementById('tip');
     game.nextWaveBtn = document.getElementById('nextWave');
     game.restartBtn = document.getElementById('restart');
     game.startOverlay = document.getElementById('startOverlay');

--- a/style.css
+++ b/style.css
@@ -125,6 +125,7 @@ canvas {
     align-items: center;
     gap: 8px;
     font-weight: 600;
+    flex-basis: 100%;
 }
 
 #crazyGamesUser.hidden {
@@ -138,10 +139,6 @@ canvas {
     object-fit: cover;
     background: #d1d5db;
     display: none;
-}
-
-#tip {
-    flex-basis: 100%;
 }
 
 .overlay {

--- a/test/hudTip.test.js
+++ b/test/hudTip.test.js
@@ -2,13 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { bindUI } from '../js/systems/ui.js';
 
-test('bindUI attaches tip element with text', () => {
+test('bindUI attaches core HUD elements without tip text', () => {
   const elements = {};
-  const ids = ['lives','energy','wave','cooldown','status','nextWave','restart','tip'];
+  const ids = ['lives','energy','wave','cooldown','status','nextWave','restart'];
   for (const id of ids) {
     elements[id] = { textContent: '', addEventListener: () => {} };
   }
-  elements['tip'].textContent = 'Tap slot to build. Tap tower to switch (1 energy).';
   const doc = {
     getElementById: id => elements[id]
   };
@@ -25,6 +24,8 @@ test('bindUI attaches tip element with text', () => {
   };
   global.document = doc;
   bindUI(game);
-  assert.equal(game.tipEl.textContent, 'Tap slot to build. Tap tower to switch (1 energy).');
+  assert.equal(game.livesEl, elements['lives']);
+  assert.equal(game.energyEl, elements['energy']);
+  assert.ok(!('tipEl' in game));
   delete global.document;
 });


### PR DESCRIPTION
## Summary
- replace the HUD tip text with the CrazyGames user avatar/name container so profile data displays in that position
- adjust styling and UI bindings to drop the obsolete tip element and keep layout intact
- update the HUD binding test to reflect the removed tip element

## Testing
- npm test *(fails: canvas context methods like setTransform/save are unavailable in the Node test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2eb6fd18c8323a117b66146d38ad2