### PR TITLE
Sort entity rendering by depth

### DIFF
--- a/js/core/render.js
+++ b/js/core/render.js
@@ -59,13 +59,41 @@ function drawGrid(game) {
 }
 
 export function drawEntities(game) {
-    game.towers.forEach(t => t.draw(game.ctx, game.assets));
-    game.enemies.forEach(e => e.draw(game.ctx, game.assets));
-    game.ctx.fillStyle = 'black';
+    const ctx = game.ctx;
+    const assets = game.assets;
+
+    const layeredEntities = [];
+
+    for (const tower of game.towers) {
+        layeredEntities.push({
+            sortKey: computeSortKey(tower),
+            draw: () => tower.draw(ctx, assets),
+        });
+    }
+
+    for (const enemy of game.enemies) {
+        layeredEntities.push({
+            sortKey: computeSortKey(enemy),
+            draw: () => enemy.draw(ctx, assets),
+        });
+    }
+
+    layeredEntities
+        .sort((a, b) => a.sortKey - b.sortKey)
+        .forEach(layer => layer.draw());
+
+    ctx.fillStyle = 'black';
     game.projectiles.forEach(p => {
-        game.ctx.beginPath();
-        game.ctx.arc(p.x, p.y, game.projectileRadius, 0, Math.PI * 2);
-        game.ctx.fill();
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, game.projectileRadius, 0, Math.PI * 2);
+        ctx.fill();
     });
-    drawExplosions(game.ctx, game.explosions ?? []);
+
+    drawExplosions(ctx, game.explosions ?? []);
+}
+
+function computeSortKey(entity) {
+    const y = typeof entity.y === 'number' ? entity.y : 0;
+    const height = typeof entity.h === 'number' ? entity.h : 0;
+    return y + height;
 }

--- a/test/enemy.test.js
+++ b/test/enemy.test.js
@@ -27,13 +27,13 @@ test('draw uses sprites and health bar proportions', () => {
 
     enemy.draw(ctx, assets);
 
-    assert.deepEqual(ctx.ops[0], ['drawImage', assets.swarm_b, 0, 50, 45, 45]);
+    assert.deepEqual(ctx.ops[0], ['drawImage', assets.swarm_b, 0, 50, 80, 80]);
     assert.deepEqual(ctx.ops[1], ['fillStyle', 'red']);
-    assert.deepEqual(ctx.ops[2], ['fillRect', 0, 44, 45, 4]);
+    assert.deepEqual(ctx.ops[2], ['fillRect', 0, 44, 80, 4]);
     assert.deepEqual(ctx.ops[3], ['fillStyle', 'green']);
-    assert.deepEqual(ctx.ops[4], ['fillRect', 0, 44, 22.5, 4]);
+    assert.deepEqual(ctx.ops[4], ['fillRect', 0, 44, 40, 4]);
     assert.deepEqual(ctx.ops[5], ['strokeStyle', 'black']);
-    assert.deepEqual(ctx.ops[6], ['strokeRect', 0, 44, 45, 4]);
+    assert.deepEqual(ctx.ops[6], ['strokeRect', 0, 44, 80, 4]);
 });
 
 test('tank enemy has more hp and slower advance than swarm', () => {


### PR DESCRIPTION
## Summary
- sort towers and enemies by their screen depth so sprites overlap correctly
- update enemy rendering test to reflect the current sprite dimensions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5729e54608323a8e61d3b0f600e2a