### PR TITLE
Add coverage for CrazyGames integration and data store

### DIFF
--- a/test/crazyGamesIntegration.test.js
+++ b/test/crazyGamesIntegration.test.js
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+const moduleUrl = pathToFileURL(resolve('js/systems/crazyGamesIntegration.js')).href;
+let importCounter = 0;
+
+async function importFresh(env = {}) {
+    delete global.window;
+    delete global.document;
+    delete globalThis.CrazyGames;
+
+    if ('window' in env) {
+        global.window = env.window;
+    }
+    if ('document' in env) {
+        global.document = env.document;
+    }
+    if ('CrazyGames' in env) {
+        globalThis.CrazyGames = env.CrazyGames;
+    }
+
+    const freshModule = await import(`${moduleUrl}?v=${importCounter++}`);
+    return freshModule;
+}
+
+test('crazyGamesIntegrationAllowed defaults to true without window', async () => {
+    const mod = await importFresh();
+    assert.equal(mod.crazyGamesIntegrationAllowed, true);
+});
+
+test('crazyGamesIntegrationAllowed blocks known hosts and GitHub pages', async () => {
+    const blockedWindow = { location: { hostname: 'pavelonishenko.github.io' } };
+    let mod = await importFresh({ window: blockedWindow });
+    assert.equal(mod.crazyGamesIntegrationAllowed, false, 'explicitly blocked host');
+
+    const githubWindow = { location: { hostname: 'example.github.io' } };
+    mod = await importFresh({ window: githubWindow });
+    assert.equal(mod.crazyGamesIntegrationAllowed, false, 'github pages host is blocked');
+});
+
+test('callCrazyGamesEvent respects crazyGamesWorks and crazyGamesIntegrationAllowed flags', async () => {
+    const windowStub = { location: { hostname: 'example.com' } };
+    const mod = await importFresh({ window: windowStub });
+
+    // With crazyGamesWorks false, the SDK should not be called even if provided.
+    let called = false;
+    global.window.CrazyGames = { SDK: { game: { loadingStart: () => { called = true; } } } };
+    mod.callCrazyGamesEvent('sdkGameLoadingStart');
+    assert.equal(called, false);
+
+    // Re-import with proper CrazyGames SDK setup and initialize integration.
+    const listeners = new Map();
+    const readyWindow = {
+        location: { hostname: 'example.com' },
+        addEventListener: (type, listener) => {
+            listeners.set(type, listener);
+        },
+        CrazyGames: {
+            SDK: {
+                environment: 'production',
+                init: async () => {
+                    readyWindow.initCalls = (readyWindow.initCalls ?? 0) + 1;
+                },
+                game: {
+                    loadingStart: () => {
+                        readyWindow.eventCalls = (readyWindow.eventCalls ?? 0) + 1;
+                    },
+                },
+            },
+        },
+    };
+
+    const initializedModule = await importFresh({ window: readyWindow });
+    await initializedModule.initializeCrazyGamesIntegration();
+    assert.equal(initializedModule.crazyGamesWorks, true);
+    initializedModule.callCrazyGamesEvent('sdkGameLoadingStart');
+    assert.equal(readyWindow.eventCalls, 1);
+    assert.equal(readyWindow.initCalls, 1);
+    assert.ok(listeners.has('wheel'));
+    assert.ok(listeners.has('keydown'));
+});
+
+test('checkCrazyGamesIntegration logs and toggles crazyGamesWorks for disabled SDK', async () => {
+    const disabledWindow = {
+        location: { hostname: 'example.com' },
+        addEventListener: () => {},
+        CrazyGames: {
+            SDK: {
+                environment: 'disabled',
+                init: async () => {},
+                game: {},
+            },
+        },
+    };
+    const mod = await importFresh({ window: disabledWindow });
+    const result = mod.checkCrazyGamesIntegration();
+    assert.equal(result, false);
+    assert.equal(mod.crazyGamesWorks, false);
+});

--- a/test/dataStore.test.js
+++ b/test/dataStore.test.js
@@ -1,0 +1,67 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadGameState, saveGameState, clearGameState } from '../js/systems/dataStore.js';
+
+function createDataClient(overrides = {}) {
+    const store = new Map();
+    return {
+        store,
+        getItem: overrides.getItem ?? ((key) => store.get(key) ?? null),
+        setItem: overrides.setItem ?? ((key, value) => {
+            store.set(key, value);
+        }),
+        removeItem: overrides.removeItem ?? ((key) => {
+            store.delete(key);
+        }),
+    };
+}
+
+beforeEach(() => {
+    delete globalThis.CrazyGames;
+});
+
+test('loadGameState returns null when CrazyGames data client is missing', () => {
+    assert.equal(loadGameState(), null);
+});
+
+test('loadGameState parses stored JSON payload', () => {
+    const client = createDataClient();
+    client.setItem('towerDefenseGameState', JSON.stringify({ wave: 3 }));
+    globalThis.CrazyGames = { SDK: { data: client } };
+    assert.deepEqual(loadGameState(), { wave: 3 });
+});
+
+test('loadGameState swallows JSON errors and returns null', () => {
+    const client = createDataClient({ getItem: () => 'not-json' });
+    globalThis.CrazyGames = { SDK: { data: client } };
+    assert.equal(loadGameState(), null);
+});
+
+test('saveGameState writes JSON string payload when client is available', () => {
+    const client = createDataClient();
+    globalThis.CrazyGames = { SDK: { data: client } };
+    const result = saveGameState({ wave: 5, lives: 2 });
+    assert.equal(result, true);
+    assert.deepEqual(JSON.parse(client.store.get('towerDefenseGameState')), { wave: 5, lives: 2 });
+});
+
+test('saveGameState returns false when serialization fails', () => {
+    const client = createDataClient({ setItem: () => { throw new Error('boom'); } });
+    globalThis.CrazyGames = { SDK: { data: client } };
+    assert.equal(saveGameState({ foo: 'bar' }), false);
+});
+
+test('clearGameState removes persisted value and reports outcome', () => {
+    const client = createDataClient();
+    client.setItem('towerDefenseGameState', JSON.stringify({ wave: 9 }));
+    globalThis.CrazyGames = { SDK: { data: client } };
+    assert.equal(clearGameState(), true);
+    assert.equal(client.store.has('towerDefenseGameState'), false);
+});
+
+test('clearGameState returns false when client throws', () => {
+    const client = createDataClient({ removeItem: () => { throw new Error('nope'); } });
+    globalThis.CrazyGames = { SDK: { data: client } };
+    assert.equal(clearGameState(), false);
+});


### PR DESCRIPTION
## Summary
- add targeted tests for CrazyGames integration behaviors, including host filtering, initialization, and event dispatch
- exercise CrazyGames data persistence helpers for load, save, and clear scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e57823c1588323ba231a9e904a34f3