### PR TITLE
RGFN: make stats resizable and village/combat/rumors panels draggable

### DIFF
--- a/rgfn_game/docs/systems/hud-panels.md
+++ b/rgfn_game/docs/systems/hud-panels.md
@@ -500,3 +500,43 @@ The `Quests` panel (`#quests-panel`) now mirrors the desktop resize behavior of 
    - drag behavior should remain unchanged.
 5. Reduce viewport below `920px`:
    - resize affordance should disappear for quests (and still for log).
+
+## Stats panel resize + draggable action micro-panels (April 8, 2026)
+
+### What changed
+
+- `Stats` HUD window (`#stats-panel`) is now desktop-resizable via native CSS corner resize (`resize: both`).
+- Three high-frequency action clusters are now individually draggable on desktop:
+  - `Village Actions` (`#village-actions`)
+  - `Combat Actions` (`#battle-actions`)
+  - `Village Rumors` (`#village-rumors-section`)
+- These clusters receive lightweight runtime window headers with a drag handle title and use the same pointer-drag model as HUD floating windows (CSS transform offsets driven by JS updates).
+
+### Implementation notes
+
+- Runtime hookup lives in `GameUiActionPanelController` (bound from `GameUiEventBinder`):
+  - `decorate()` finds target elements by ID and decorates each once.
+  - `createHeader()` prepends a drag-handle-only header (`.panel-window-header.panel-window-header-aux`).
+  - `applySeed()` computes first visible placement and stores offsets in `data-offset-x/y`.
+- Drag updates use:
+  - `--panel-offset-x`
+  - `--panel-offset-y`
+  - plus temporary `.panel-dragging` for cursor feedback.
+- CSS class `.aux-draggable-panel` provides out-of-flow desktop behavior (`position: fixed; top: 0; left: 0; transform: translate(...)`) while preserving pointer interactivity.
+- Mobile fallback (`max-width: 920px`) explicitly resets `.aux-draggable-panel` to in-flow static positioning and disables `Stats` resizing (`resize: none`) to avoid stacked-layout overlap.
+
+### Why this is useful
+
+- `Stats` can now be expanded when inspecting long derived formulas and stat blocks without forcing global zoom/font changes.
+- Action-heavy play loops (battle turns, village shopping/dialogue loops) can be spatially arranged by the player to reduce panel travel and visual occlusion over the map.
+- Rumor handling can be detached from village sell/buy controls, which improves readability during dialogue-heavy quest routing.
+
+### QA checklist
+
+1. Open HUD `Stats` panel and verify desktop corner resize works in both axes.
+2. Enter village mode and drag `Village Actions` panel by its new header.
+3. Drag `Village Rumors` panel independently and confirm interaction buttons/selects still work after moving.
+4. Enter battle and drag `Combat Actions`; verify battle buttons remain clickable.
+5. Switch viewport below `920px`:
+   - action panels should return to normal in-flow stacked layout;
+   - `Stats` should no longer be resizable.

--- a/rgfn_game/docs/systems/hud-panels.md
+++ b/rgfn_game/docs/systems/hud-panels.md
@@ -522,7 +522,7 @@ The `Quests` panel (`#quests-panel`) now mirrors the desktop resize behavior of 
   - `--panel-offset-x`
   - `--panel-offset-y`
   - plus temporary `.panel-dragging` for cursor feedback.
-- CSS class `.aux-draggable-panel` provides out-of-flow desktop behavior (`position: fixed; top: 0; left: 0; transform: translate(...)`) while preserving pointer interactivity.
+- CSS class `.aux-draggable-panel` provides out-of-flow desktop behavior (`position: fixed`) while pointer drag updates `left/top` directly for independent movement.
 - Mobile fallback (`max-width: 920px`) explicitly resets `.aux-draggable-panel` to in-flow static positioning and disables `Stats` resizing (`resize: none`) to avoid stacked-layout overlap.
 
 ### Why this is useful
@@ -540,3 +540,28 @@ The `Quests` panel (`#quests-panel`) now mirrors the desktop resize behavior of 
 5. Switch viewport below `920px`:
    - action panels should return to normal in-flow stacked layout;
    - `Stats` should no longer be resizable.
+
+## Follow-up fix: independent village/combat/rumor dragging + remove empty village shell (April 8, 2026, patch #2)
+
+### Problem observed
+
+- `Village Rumors` could appear to drag together with `Village Actions`.
+- Root cause: both were nested and used transform-based fixed dragging; transformed parent geometry influenced child fixed positioning.
+- The outer `Village` shell (title-only panel) could remain as an empty visual block after action panels were moved out, which added noise without gameplay value.
+
+### Fix applied
+
+- `GameUiActionPanelController` now drives auxiliary drag position with **`left` + `top`** (fixed positioning) instead of CSS transform offsets.
+  - This keeps nested auxiliary panels independent in drag behavior.
+  - `Village Actions`, `Combat Actions`, and `Village Rumors` now move separately as expected.
+- Desktop `#village-sidebar` shell is intentionally stripped of visual chrome (`border/background/shadow/padding` removed; width collapsed) so players only see actionable floating panels.
+- The standalone village shell is hidden on desktop via CSS (collapsed width + no panel chrome + hidden overflow), so the old `Village: <name>` header is no longer visible to players.
+
+### Regression checklist
+
+1. Enter village mode.
+2. Drag `Village Actions` and verify `Village Rumors` does not move with it.
+3. Drag `Village Rumors` and verify `Village Actions` remains where it was.
+4. Enter combat mode and drag `Combat Actions` independently.
+5. On desktop, confirm there is no empty `Village: ...` panel shell left behind.
+6. On mobile (`<=920px`), confirm fallback stacked flow still works.

--- a/rgfn_game/docs/systems/hud-panels.md
+++ b/rgfn_game/docs/systems/hud-panels.md
@@ -565,3 +565,34 @@ The `Quests` panel (`#quests-panel`) now mirrors the desktop resize behavior of 
 4. Enter combat mode and drag `Combat Actions` independently.
 5. On desktop, confirm there is no empty `Village: ...` panel shell left behind.
 6. On mobile (`<=920px`), confirm fallback stacked flow still works.
+
+## Follow-up fix #3: keep combat actions attached to combat panel + restore village panel visibility (April 11, 2026)
+
+### Player-reported issues
+
+1. `Combat Actions` became detached from the main combat panel and could be dragged independently, which is not desired UX.
+2. In village mode, `Village Actions` and `Village Rumors` could fail to appear after entering a village.
+
+### Root causes
+
+- `battle-actions` was mistakenly included in auxiliary draggable panel decoration, turning a sub-section of combat UI into a separate floating panel.
+- Village action panels start hidden and become visible later; one-time spawn seeding could run before measurable geometry existed (`width/height = 0`), leaving no usable `left/top` position.
+
+### Final behavior
+
+- `Combat Actions` is no longer decorated as an auxiliary draggable panel and therefore remains part of the regular combat sidebar.
+- Auxiliary village panels now seed position reliably when they become visible:
+  - Added class-attribute visibility observer.
+  - Added delayed seed retries (animation-frame attempts) until measurable geometry exists or retry budget is exhausted.
+
+### QA checklist
+
+1. Enter combat:
+   - Verify `Combat Actions` stays inside combat panel and moves together with the combat sidebar behavior.
+2. Enter village:
+   - Verify `Village Actions` appears.
+   - Verify `Village Rumors` appears.
+3. Drag `Village Actions`:
+   - `Village Rumors` remains independent.
+4. Exit/re-enter village:
+   - both village panels remain visible and usable.

--- a/rgfn_game/js/systems/game/ui/GameUiActionPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiActionPanelController.ts
@@ -1,0 +1,117 @@
+type ActionPanelConfig = {
+    elementId: string;
+    title: string;
+    offsetX: number;
+    offsetY: number;
+};
+
+export default class GameUiActionPanelController {
+    private static readonly ACTION_PANELS: ActionPanelConfig[] = [
+        { elementId: 'village-actions', title: 'Village Actions', offsetX: 0, offsetY: 0 },
+        { elementId: 'battle-actions', title: 'Combat Actions', offsetX: 18, offsetY: 18 },
+        { elementId: 'village-rumors-section', title: 'Village Rumors', offsetX: 36, offsetY: 36 },
+    ];
+    private nextZIndex = 8;
+
+    public bind(): void {
+        GameUiActionPanelController.ACTION_PANELS.forEach((config) => this.decorate(config));
+    }
+
+    private decorate(config: ActionPanelConfig): void {
+        const panel = document.getElementById(config.elementId);
+        if (!panel || panel.querySelector('.panel-window-header')) {
+            return;
+        }
+
+        panel.classList.add('aux-draggable-panel');
+        panel.prepend(this.createHeader(config.title));
+        this.seedPosition(panel, config);
+        this.bindDrag(panel);
+    }
+
+    private createHeader(title: string): HTMLElement {
+        const header = document.createElement('div');
+        header.className = 'panel-window-header panel-window-header-aux';
+        const handle = document.createElement('div');
+        handle.className = 'panel-drag-handle';
+        handle.textContent = title;
+        handle.title = 'Drag to move panel';
+        header.append(handle);
+        return header;
+    }
+
+    private seedPosition(panel: HTMLElement, config: ActionPanelConfig): void {
+        requestAnimationFrame(() => this.applySeed(panel, config));
+    }
+
+    private applySeed(panel: HTMLElement, config: ActionPanelConfig): void {
+        if (panel.dataset.spawnPositioned === 'true') {
+            return;
+        }
+
+        const rect = panel.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) {
+            return;
+        }
+
+        const offsetX = rect.left + config.offsetX;
+        const offsetY = rect.top + config.offsetY;
+        panel.dataset.offsetX = String(offsetX);
+        panel.dataset.offsetY = String(offsetY);
+        panel.dataset.spawnPositioned = 'true';
+        panel.style.setProperty('--panel-offset-x', `${offsetX}px`);
+        panel.style.setProperty('--panel-offset-y', `${offsetY}px`);
+    }
+
+    private bindDrag(panel: HTMLElement): void {
+        const dragHandle = panel.querySelector('.panel-drag-handle');
+        if (!(dragHandle instanceof HTMLElement)) {
+            return;
+        }
+
+        dragHandle.addEventListener('pointerdown', (event) => this.handlePointerDown(event, panel, dragHandle));
+    }
+
+    private handlePointerDown(event: PointerEvent, panel: HTMLElement, dragHandle: HTMLElement): void {
+        if (event.button !== 0) {
+            return;
+        }
+
+        event.preventDefault();
+        dragHandle.setPointerCapture(event.pointerId);
+        this.startDragging(panel);
+        const dragState = this.buildDragState(event, panel);
+        const onMove = (moveEvent: PointerEvent): void => this.handlePointerMove(moveEvent, panel, dragState);
+        const stop = (): void => this.stopDrag(panel, dragHandle, onMove, stop);
+        dragHandle.addEventListener('pointermove', onMove);
+        dragHandle.addEventListener('pointerup', stop);
+        dragHandle.addEventListener('pointercancel', stop);
+    }
+
+    private startDragging(panel: HTMLElement): void {
+        panel.style.zIndex = String(this.nextZIndex++);
+        panel.classList.add('panel-dragging');
+    }
+
+    private buildDragState(event: PointerEvent, panel: HTMLElement): { startX: number; startY: number; baseX: number; baseY: number } {
+        const baseX = Number.parseFloat(panel.dataset.offsetX ?? '0') || 0;
+        const baseY = Number.parseFloat(panel.dataset.offsetY ?? '0') || 0;
+        return { startX: event.clientX, startY: event.clientY, baseX, baseY };
+    }
+
+    private handlePointerMove(event: PointerEvent, panel: HTMLElement, dragState: { startX: number; startY: number; baseX: number; baseY: number }): void {
+        const offsetX = dragState.baseX + (event.clientX - dragState.startX);
+        const offsetY = dragState.baseY + (event.clientY - dragState.startY);
+        panel.dataset.offsetX = String(offsetX);
+        panel.dataset.offsetY = String(offsetY);
+        panel.style.setProperty('--panel-offset-x', `${offsetX}px`);
+        panel.style.setProperty('--panel-offset-y', `${offsetY}px`);
+    }
+
+    private stopDrag(panel: HTMLElement, dragHandle: HTMLElement, onMove: (event: PointerEvent) => void, stop: () => void): void {
+        panel.classList.remove('panel-dragging');
+        dragHandle.removeEventListener('pointermove', onMove);
+        dragHandle.removeEventListener('pointerup', stop);
+        dragHandle.removeEventListener('pointercancel', stop);
+    }
+}

--- a/rgfn_game/js/systems/game/ui/GameUiActionPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiActionPanelController.ts
@@ -8,7 +8,6 @@ type ActionPanelConfig = {
 export default class GameUiActionPanelController {
     private static readonly ACTION_PANELS: ActionPanelConfig[] = [
         { elementId: 'village-actions', title: 'Village Actions', offsetX: 0, offsetY: 0 },
-        { elementId: 'battle-actions', title: 'Combat Actions', offsetX: 18, offsetY: 18 },
         { elementId: 'village-rumors-section', title: 'Village Rumors', offsetX: 36, offsetY: 36 },
     ];
     private nextZIndex = 8;
@@ -26,6 +25,7 @@ export default class GameUiActionPanelController {
         panel.classList.add('aux-draggable-panel');
         panel.prepend(this.createHeader(config.title));
         this.seedPosition(panel, config);
+        this.bindVisibilitySeed(panel, config);
         this.bindDrag(panel);
     }
 
@@ -41,16 +41,26 @@ export default class GameUiActionPanelController {
     }
 
     private seedPosition(panel: HTMLElement, config: ActionPanelConfig): void {
-        requestAnimationFrame(() => this.applySeed(panel, config));
+        this.scheduleSeed(panel, config, 0);
     }
 
-    private applySeed(panel: HTMLElement, config: ActionPanelConfig): void {
+    private bindVisibilitySeed(panel: HTMLElement, config: ActionPanelConfig): void {
+        const observer = new MutationObserver(() => this.seedPosition(panel, config));
+        observer.observe(panel, { attributes: true, attributeFilter: ['class'] });
+    }
+
+    private scheduleSeed(panel: HTMLElement, config: ActionPanelConfig, attempt: number): void {
+        requestAnimationFrame(() => this.applySeed(panel, config, attempt));
+    }
+
+    private applySeed(panel: HTMLElement, config: ActionPanelConfig, attempt: number): void {
         if (panel.dataset.spawnPositioned === 'true') {
             return;
         }
 
         const rect = panel.getBoundingClientRect();
         if (rect.width <= 0 || rect.height <= 0) {
+            this.retrySeedIfNeeded(panel, config, attempt);
             return;
         }
 
@@ -61,6 +71,14 @@ export default class GameUiActionPanelController {
         panel.dataset.spawnPositioned = 'true';
         panel.style.left = `${offsetX}px`;
         panel.style.top = `${offsetY}px`;
+    }
+
+    private retrySeedIfNeeded(panel: HTMLElement, config: ActionPanelConfig, attempt: number): void {
+        if (attempt >= 24) {
+            return;
+        }
+
+        this.scheduleSeed(panel, config, attempt + 1);
     }
 
     private bindDrag(panel: HTMLElement): void {

--- a/rgfn_game/js/systems/game/ui/GameUiActionPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiActionPanelController.ts
@@ -59,8 +59,8 @@ export default class GameUiActionPanelController {
         panel.dataset.offsetX = String(offsetX);
         panel.dataset.offsetY = String(offsetY);
         panel.dataset.spawnPositioned = 'true';
-        panel.style.setProperty('--panel-offset-x', `${offsetX}px`);
-        panel.style.setProperty('--panel-offset-y', `${offsetY}px`);
+        panel.style.left = `${offsetX}px`;
+        panel.style.top = `${offsetY}px`;
     }
 
     private bindDrag(panel: HTMLElement): void {
@@ -104,8 +104,8 @@ export default class GameUiActionPanelController {
         const offsetY = dragState.baseY + (event.clientY - dragState.startY);
         panel.dataset.offsetX = String(offsetX);
         panel.dataset.offsetY = String(offsetY);
-        panel.style.setProperty('--panel-offset-x', `${offsetX}px`);
-        panel.style.setProperty('--panel-offset-y', `${offsetY}px`);
+        panel.style.left = `${offsetX}px`;
+        panel.style.top = `${offsetY}px`;
     }
 
     private stopDrag(panel: HTMLElement, dragHandle: HTMLElement, onMove: (event: PointerEvent) => void, stop: () => void): void {

--- a/rgfn_game/js/systems/game/ui/GameUiEventBinder.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiEventBinder.ts
@@ -4,12 +4,14 @@ import { BattleUI, DeveloperUI, HudElements, VillageUI, WorldUI } from './GameUi
 import GameUiPrimaryEventBinder from './GameUiPrimaryEventBinder.js';
 import GameUiHudPanelController from './GameUiHudPanelController.js';
 import GameUiDevStatBinder from './GameUiDevStatBinder.js';
+import GameUiActionPanelController from './GameUiActionPanelController.js';
 import { GameUiEventCallbacks } from './GameUiEventBinderTypes.js';
 
 export default class GameUiEventBinder {
     private primaryEventBinder: GameUiPrimaryEventBinder;
     private panelController: GameUiHudPanelController;
     private devStatBinder: GameUiDevStatBinder;
+    private actionPanelController: GameUiActionPanelController;
 
     constructor(
         canvas: HTMLCanvasElement,
@@ -22,22 +24,38 @@ export default class GameUiEventBinder {
         developerEventController: DeveloperEventController,
         callbacks: GameUiEventCallbacks,
     ) {
-        this.primaryEventBinder = new GameUiPrimaryEventBinder(
-            canvas,
-            hudElements,
-            worldUI,
-            battleUI,
-            villageUI,
-            villageActionsController,
-            callbacks,
-        );
-        this.panelController = new GameUiHudPanelController(hudElements, callbacks);
-        this.devStatBinder = new GameUiDevStatBinder(hudElements, developerUI, developerEventController, callbacks);
+        this.primaryEventBinder = this.createPrimaryEventBinder(canvas, hudElements, worldUI, battleUI, villageUI, villageActionsController, callbacks);
+        this.panelController = this.createHudPanelController(hudElements, callbacks);
+        this.devStatBinder = this.createDevStatBinder(hudElements, developerUI, developerEventController, callbacks);
+        this.actionPanelController = new GameUiActionPanelController();
     }
 
     public bind(villageNameProvider: () => string): void {
         this.primaryEventBinder.bind(villageNameProvider);
         this.devStatBinder.bind();
         this.panelController.bind();
+        this.actionPanelController.bind();
     }
+
+    private createPrimaryEventBinder = (
+        canvas: HTMLCanvasElement,
+        hudElements: HudElements,
+        worldUI: WorldUI,
+        battleUI: BattleUI,
+        villageUI: VillageUI,
+        villageActionsController: VillageActionsController,
+        callbacks: GameUiEventCallbacks,
+    ): GameUiPrimaryEventBinder =>
+        new GameUiPrimaryEventBinder(canvas, hudElements, worldUI, battleUI, villageUI, villageActionsController, callbacks);
+
+    private createHudPanelController = (hudElements: HudElements, callbacks: GameUiEventCallbacks): GameUiHudPanelController =>
+        new GameUiHudPanelController(hudElements, callbacks);
+
+    private createDevStatBinder = (
+        hudElements: HudElements,
+        developerUI: DeveloperUI,
+        developerEventController: DeveloperEventController,
+        callbacks: GameUiEventCallbacks,
+    ): GameUiDevStatBinder =>
+        new GameUiDevStatBinder(hudElements, developerUI, developerEventController, callbacks);
 }

--- a/rgfn_game/style.css
+++ b/rgfn_game/style.css
@@ -330,9 +330,8 @@ h1 {
 
 .aux-draggable-panel {
     position: fixed;
-    top: 0;
-    left: 0;
-    transform: translate(var(--panel-offset-x, 0px), var(--panel-offset-y, 0px));
+    top: auto;
+    left: auto;
     margin: 0;
     z-index: 8;
     width: min(320px, calc(100vw - 32px));
@@ -403,6 +402,21 @@ h1 {
     max-height: none;
     overflow: visible;
 }
+
+@media (min-width: 921px) {
+    #village-sidebar {
+        width: 0;
+        min-width: 0;
+        padding: 0;
+        gap: 0;
+        border: 0;
+        background: transparent;
+        box-shadow: none;
+        backdrop-filter: none;
+        overflow: hidden;
+    }
+}
+
 #game-log-container {
     width: min(340px, calc(100vw - 48px));
     max-width: calc(100vw - 32px);

--- a/rgfn_game/style.css
+++ b/rgfn_game/style.css
@@ -328,6 +328,18 @@ h1 {
     margin: 0;
 }
 
+.aux-draggable-panel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    transform: translate(var(--panel-offset-x, 0px), var(--panel-offset-y, 0px));
+    margin: 0;
+    z-index: 8;
+    width: min(320px, calc(100vw - 32px));
+    max-width: calc(100vw - 32px);
+    pointer-events: auto;
+}
+
 .panel-window-header {
     display: flex;
     align-items: center;
@@ -336,6 +348,10 @@ h1 {
     border-bottom: 1px solid var(--color-secondary-accent);
     padding-bottom: 8px;
     margin-bottom: 2px;
+}
+
+.panel-window-header-aux {
+    margin-bottom: 8px;
 }
 
 .panel-drag-handle {
@@ -367,6 +383,13 @@ h1 {
 #magic-panel, #inventory-panel, #skills-panel, #quests-panel, #lore-panel, #stats-panel, #selected-panel {
     width: min(340px, calc(100vw - 48px));
     overflow: visible;
+}
+
+#stats-panel {
+    min-height: 220px;
+    min-width: 260px;
+    resize: both;
+    overflow: auto;
 }
 
 #world-sidebar {
@@ -693,8 +716,16 @@ h1 {
         transform: none;
     }
 
+    .aux-draggable-panel {
+        position: static;
+        transform: none;
+        width: auto;
+        max-width: 100%;
+    }
+
     #game-log-container,
-    #quests-panel {
+    #quests-panel,
+    #stats-panel {
         margin-top: 0;
         height: 260px;
         max-height: 260px;


### PR DESCRIPTION
### Motivation

- Improve HUD ergonomics by allowing the `Stats` panel to be resized on desktop so long stat/formula blocks are inspectable without global zoom changes. 
- Reduce visual occlusion during play by making frequent action clusters (village actions, combat actions, village rumors) detachable and draggable so players can arrange them around the map.
- Reuse the existing transform-offset draggable model used by other HUD windows to keep persistence and spawn behavior consistent.

### Description

- Added a new `GameUiActionPanelController` that decorates `#village-actions`, `#battle-actions`, and `#village-rumors-section` with a lightweight header and pointer-based dragging behavior, seeds initial offsets, and updates CSS transform offsets. (`rgfn_game/js/systems/game/ui/GameUiActionPanelController.ts`)
- Wired the action-panel controller into the UI initialization flow by instantiating and binding it from `GameUiEventBinder` so action panels initialize alongside existing HUD systems. (`rgfn_game/js/systems/game/ui/GameUiEventBinder.ts`)
- Updated styling to support auxiliary floating action panels and stats resizing: added `.aux-draggable-panel` and `.panel-window-header-aux`, made `#stats-panel` desktop-resizable (`resize: both`) with sensible min sizes and mobile fallbacks that reset panels to in-flow/disable resizing under `max-width: 920px`. (`rgfn_game/style.css`)
- Documented the change and QA steps in the HUD panels doc with implementation notes and a checklist. (`rgfn_game/docs/systems/hud-panels.md`)
- Kept changes focused to the new controller, event binder wiring, CSS, and docs so existing HUD window persistence/transform model remains unchanged.

### Testing

- Ran ESLint targeting the modified/new UI files: `npx eslint rgfn_game/js/systems/game/ui/GameUiActionPanelController.ts rgfn_game/js/systems/game/ui/GameUiEventBinder.ts` and addressed style warnings for the touched files (no ESLint errors remained for those files). (passed)
- Built the RGFN TS bundle: `npm run build:rgfn` (TypeScript build succeeded). (passed)
- Ran unit tests: `node --test rgfn_game/test/**/*.test.js` which executed the full RGFN test suite (134 tests) and all tests passed. (134 passed, 0 failed)
- Note: `npm run lint:ts:rgfn` (full repo/style-guide lint) still reports many unrelated pre-existing lint/style-guide warnings and a small set of style-guide errors outside the scope of this change; those were not introduced by this PR and were left untouched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ae6f5a5c8323b8513585982ce12d)