### PR TITLE
Migrate state persistence to TypeScript and add migration guidance

### DIFF
--- a/docs/NEON_VOID_MIGRATION_NOTES.md
+++ b/docs/NEON_VOID_MIGRATION_NOTES.md
@@ -24,3 +24,35 @@ When converting a module from `*.js` to `*.ts`, always complete this checklist i
 
 A previous migration removed `js/config/*.js` while many JS modules and tests still imported `config/*.js`,
 causing runtime module resolution errors. This checklist prevents that regression.
+
+## 2026-04-08: statePersistence migration checkpoint
+
+### What was migrated
+- Added TypeScript source for state persistence at `js/core/game/statePersistence.ts`.
+- Kept runtime compatibility by preserving existing JS imports/entrypoints (no breaking import path changes in this step).
+
+### Type safety improvements added
+- Added explicit saved-state types (`SavedGameState`, `SavedTowerState`) to encode accepted persisted payload shape.
+- Added `GridCell` typing in persistence helpers to make cell resolution and tower restore flows clearer.
+- Added helper split for restore flow (`applyScoreState`, `applyWaveState`, `resetWaveObjects`) so future migrations can type each part independently.
+
+### Verification performed
+- `npm run build` (root TypeScript compile) passed after the migration.
+- `node --test test/game/stateManagement.test.js` passed (10/10).
+- `npx eslint js/core/game/statePersistence.ts` passed with zero warnings.
+
+### Useful follow-ups
+1. Migrate `js/core/game/formations.js` next; it is already isolated by unit tests (`test/game/formations.test.js`) and has low runtime coupling.
+2. Introduce a shared `GameLike` interface slice for persistence/tower/wave state to remove remaining `any` usage.
+3. Expand `SavedGameState.version` handling to explicit migration map when version 2 format is introduced.
+
+## OOP-first migration clarification (added 2026-04-08)
+
+For Neon Void TS migration steps, a "meaningful migration" now means more than adding `*.ts` extension:
+
+- Prefer class-based architecture when migrating modules with stateful behavior (services, coordinators, managers, mappers).
+- Introduce explicit domain types and use them in class method signatures; avoid leaving business logic in untyped free functions.
+- Keep backward-compatible module adapters only as thin shells over typed classes.
+- In PR descriptions, explicitly mention which classes were introduced and what responsibilities were split.
+
+This requirement should be treated as default guidance for all future Neon Void migration PRs unless a task explicitly asks for a different style.

--- a/docs/NEON_VOID_TYPESCRIPT_MIGRATION.md
+++ b/docs/NEON_VOID_TYPESCRIPT_MIGRATION.md
@@ -1123,3 +1123,17 @@ To begin migration:
 5. **Commit progress regularly**
 
 Good luck with the migration! 🚀
+
+---
+
+## Progress Log (incremental)
+
+### 2026-04-08
+- Migrated `js/core/game/statePersistence.js` logic into typed source file `js/core/game/statePersistence.ts`.
+- Confirmed compile and targeted persistence regression test pass.
+- Migration remains incremental: runtime JS entrypoints are still in use while TS coverage expands module-by-module.
+
+### OOP-first rule for future phases (added 2026-04-08)
+- Future migrations should prioritize class-based decomposition for stateful systems.
+- File conversion without architecture uplift is considered incomplete.
+- Preferred pattern: typed classes for core logic + thin compatibility adapter for legacy call sites.

--- a/js/core/game/statePersistence.ts
+++ b/js/core/game/statePersistence.ts
@@ -1,0 +1,34 @@
+import { StatePersistenceService } from './statePersistenceService.js';
+import type { GameLike, GridCell, SavedTowerState } from './statePersistenceService.js';
+
+const persistenceService = new StatePersistenceService();
+
+const statePersistence = {
+    restoreSavedState(this: GameLike) {
+        persistenceService.restoreSavedState(this);
+    },
+    restoreTowers(this: GameLike, towersState: SavedTowerState[]) {
+        persistenceService.restoreTowers(this, towersState);
+    },
+    resolveCellFromState(this: GameLike, identifier: string) {
+        const resolved = persistenceService.resolveCellFromState(this, identifier);
+        return resolved;
+    },
+    createCellIdentifier(this: GameLike, cell: GridCell) {
+        const identifier = persistenceService.createCellIdentifier(this, cell);
+        return identifier;
+    },
+    getPersistentState(this: GameLike) {
+        const state = persistenceService.getPersistentState(this);
+        return state;
+    },
+    persistState(this: GameLike) {
+        persistenceService.persistState(this);
+    },
+    clearSavedState() {
+        persistenceService.clearSavedState();
+    },
+};
+
+export { StatePersistenceService };
+export default statePersistence;

--- a/js/core/game/statePersistenceService.ts
+++ b/js/core/game/statePersistenceService.ts
@@ -1,0 +1,195 @@
+import Tower from '../../entities/Tower.js';
+import { clearGameState, loadGameState, saveBestScore, saveGameState } from '../../systems/dataStore.js';
+export type SavedTowerState = { cellId?: string; color?: string; level?: number };
+export type SavedGameState = {
+    version?: number; wave?: number; lives?: number; energy?: number; gold?: number;
+    score?: number; bestScore?: number; towers?: SavedTowerState[];
+};
+export type GridCell = { x: number; y: number; occupied: boolean; tower: Tower | null };
+export type GameLike = any;
+type RuntimeTower = Tower & { cell?: GridCell; color: string; level: number; lastShot?: number; flashTimer?: number; placementFlashTimer?: number };
+const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+const toInt = (value: unknown, fallback: number): number => {
+    const num = Number(value);
+    return Number.isFinite(num) ? Math.floor(num) : fallback;
+};
+export class PersistedStateValidator {
+    public load(): SavedGameState | null {
+        const savedState = loadGameState() as SavedGameState | null;
+        if (!savedState || typeof savedState !== 'object') {
+            return null;
+        }
+        if (savedState.version && savedState.version !== 1) {
+            return null;
+        }
+        return savedState;
+    }
+}
+export class TowerStateMapper {
+    public createCellIdentifier(game: GameLike, cell: GridCell): string | null {
+        const topIndex = game.topCells.indexOf(cell);
+        if (topIndex !== -1) {
+            return `top:${topIndex}`;
+        }
+        const bottomIndex = game.bottomCells.indexOf(cell);
+        return bottomIndex !== -1 ? `bottom:${bottomIndex}` : null;
+    }
+    public resolveCellFromState(game: GameLike, identifier: string): GridCell | null {
+        if (typeof identifier !== 'string') {
+            return null;
+        }
+        const [group, indexRaw] = identifier.split(':');
+        const index = Number(indexRaw);
+        if (!Number.isInteger(index) || index < 0) {
+            return null;
+        }
+        if (group === 'top') {
+            return game.topCells[index] ?? null;
+        }
+        if (group === 'bottom') {
+            return game.bottomCells[index] ?? null;
+        }
+        return null;
+    }
+    public snapshotTowers(game: GameLike): SavedTowerState[] {
+        const towers = game.towers
+            .filter((tower: RuntimeTower) => tower?.cell)
+            .map((tower: RuntimeTower) => ({ cellId: this.createCellIdentifier(game, tower.cell as GridCell), color: tower.color, level: tower.level }))
+            .filter((entry: SavedTowerState) => entry.cellId !== null);
+        return towers;
+    }
+    public rebuildTowers(game: GameLike, towersState: SavedTowerState[] | undefined): void {
+        game.towers = [];
+        game.grid.resetCells();
+        if (!Array.isArray(towersState)) {
+            return;
+        }
+        towersState.forEach((towerState: SavedTowerState) => {
+            const cell = this.resolveCellFromState(game, towerState?.cellId ?? '');
+            if (cell) {
+                this.createTowerInCell(game, cell, towerState);
+            }
+        });
+    }
+    private createTowerInCell(game: GameLike, cell: GridCell, towerState: SavedTowerState): void {
+        const color = typeof towerState?.color === 'string' ? towerState.color : 'red';
+        const level = Number(towerState?.level) || 1;
+        const tower = new Tower(cell.x, cell.y, color, level) as RuntimeTower;
+        tower.alignToCell(cell);
+        tower.cell = cell;
+        tower.lastShot = 0;
+        tower.flashTimer = 0;
+        tower.placementFlashTimer = 0;
+        cell.occupied = true;
+        cell.tower = tower;
+        game.towers.push(tower);
+    }
+}
+export class GameStateRestorer {
+    public applySavedResources(game: GameLike, savedState: SavedGameState): number {
+        const targetWave = clamp(toInt(savedState.wave, 1), 1, 9999);
+        game.lives = clamp(toInt(savedState.lives, game.initialLives), 0, 99);
+        game.energy = clamp(toInt(savedState.energy ?? savedState.gold, game.initialEnergy), 0, 999999);
+        this.applyScoreState(game, savedState);
+        this.applyWaveState(game, targetWave);
+        this.resetWaveObjects(game);
+        return targetWave;
+    }
+    public configureWaveAfterRestore(game: GameLike, waveNumber: number): void {
+        const index = waveNumber - 1;
+        const fallback = game.waveConfigs[game.waveConfigs.length - 1];
+        const cfg = typeof game.getOrCreateWaveConfig === 'function'
+            ? game.getOrCreateWaveConfig(waveNumber)
+            : game.waveConfigs[index] ?? fallback;
+        game.enemiesPerWave = 0;
+        game.prepareTankScheduleForWave(cfg, waveNumber, 0);
+        game.activeFormationPlan = null;
+        game.waveSpawnSchedule = null;
+        game.waveSpawnCursor = 0;
+        game.waveElapsed = 0;
+    }
+    private applyScoreState(game: GameLike, savedState: SavedGameState): void {
+        if (!game.scoreManager) {
+            return;
+        }
+        const score = clamp(toInt(savedState.score, 0), 0, 9999999);
+        game.scoreManager.setScore(score);
+        const fallbackBest = game.scoreManager.getBestScore();
+        const bestScore = clamp(toInt(savedState.bestScore, fallbackBest), 0, 9999999);
+        if (bestScore > fallbackBest) {
+            game.scoreManager.setBestScore(bestScore);
+            saveBestScore(bestScore);
+        }
+    }
+    private applyWaveState(game: GameLike, targetWave: number): void {
+        if (typeof game.ensureEndlessWaveTracking === 'function') {
+            game.ensureEndlessWaveTracking();
+        }
+        game.wave = targetWave;
+        if (typeof game.getOrCreateWaveConfig === 'function') {
+            game.getOrCreateWaveConfig(targetWave);
+        }
+        if (typeof game.getEnemyHpForWave === 'function') {
+            game.getEnemyHpForWave(targetWave);
+        }
+        const endlessMode = typeof game.isEndlessWave === 'function'
+            ? game.isEndlessWave(targetWave)
+            : Number.isFinite(game.maxWaves) && targetWave > game.maxWaves;
+        game.endlessModeActive = endlessMode;
+    }
+
+    private resetWaveObjects(game: GameLike): void {
+        game.waveInProgress = false;
+        game.spawned = 0;
+        game.spawnTimer = 0;
+        game.enemies = [];
+        game.projectiles = [];
+        game.explosions = [];
+        game.mergeAnimations = [];
+        game.maxProjectileRadius = game.projectileRadius;
+    }
+}
+export class StatePersistenceService {
+    private readonly validator = new PersistedStateValidator();
+    private readonly mapper = new TowerStateMapper();
+    private readonly restorer = new GameStateRestorer();
+    public restoreSavedState(game: GameLike): void {
+        const savedState = this.validator.load();
+        if (!savedState) {
+            return;
+        }
+        game.isRestoringState = true;
+        const waveNumber = this.restorer.applySavedResources(game, savedState);
+        this.restorer.configureWaveAfterRestore(game, waveNumber);
+        this.mapper.rebuildTowers(game, savedState.towers);
+        game.isRestoringState = false;
+    }
+    public persistState(game: GameLike): void {
+        if (!game.persistenceEnabled || game.isRestoringState || game.gameOver) {
+            return;
+        }
+        saveGameState(this.getPersistentState(game));
+    }
+    public getPersistentState(game: GameLike): SavedGameState {
+        const state: SavedGameState = {
+            version: 1,
+            lives: game.lives,
+            energy: game.energy,
+            wave: game.wave,
+            score: game.scoreManager ? game.scoreManager.getCurrentScore() : 0,
+            bestScore: game.scoreManager ? game.scoreManager.getBestScore() : 0,
+            towers: this.mapper.snapshotTowers(game),
+        };
+        return state;
+    }
+    public restoreTowers(game: GameLike, towersState: SavedTowerState[]): void { this.mapper.rebuildTowers(game, towersState); }
+    public resolveCellFromState(game: GameLike, identifier: string): GridCell | null {
+        const cell = this.mapper.resolveCellFromState(game, identifier);
+        return cell;
+    }
+    public createCellIdentifier(game: GameLike, cell: GridCell): string | null {
+        const cellId = this.mapper.createCellIdentifier(game, cell);
+        return cellId;
+    }
+    public clearSavedState(): void { clearGameState(); }
+}


### PR DESCRIPTION
### Motivation

- Convert the legacy state persistence logic into typed TypeScript to improve type safety and make future migrations incremental and less error-prone.
- Preserve runtime compatibility with existing JS entrypoints while introducing a typed service layer and clearer responsibilities for persistence and restore flows. 
- Record a migration checkpoint and enforce an "OOP-first" guideline for future stateful module migrations in the documentation.

### Description

- Added typed persistence implementation split across `js/core/game/statePersistenceService.ts` (new service and domain types) and `js/core/game/statePersistence.ts` (thin compatibility adapter exporting a default facade and `StatePersistenceService`).
- Introduced domain types `SavedGameState`, `SavedTowerState`, `GridCell`, and a `GameLike` alias, and implemented helper utilities `PersistedStateValidator`, `TowerStateMapper`, `GameStateRestorer`, and `StatePersistenceService` to separate validation, mapping, restoring, and persistence responsibilities. 
- Implemented cell identifier serialization/resolution, tower snapshot/rebuild, resource/wave/score application, and safe persistence with `saveGameState`/`loadGameState` integration. 
- Updated docs `docs/NEON_VOID_MIGRATION_NOTES.md` and `docs/NEON_VOID_TYPESCRIPT_MIGRATION.md` with a migration checkpoint, progress log, and an "OOP-first" migration guidance section.

### Testing

- Ran `npm run build` and the TypeScript compilation succeeded. 
- Executed targeted unit test with `node --test test/game/stateManagement.test.js` and it passed (10/10). 
- Linted the new TypeScript file with `npx eslint js/core/game/statePersistence.ts` and it produced zero warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69f6b3c388323be92b4e4bf8ea110)