### PR TITLE
RGFN: make combat/village action surfaces draggable via panel headers

### DIFF
--- a/rgfn_game/docs/systems/hud-panels.md
+++ b/rgfn_game/docs/systems/hud-panels.md
@@ -522,3 +522,31 @@ The `Quests` panel (`#quests-panel`) now mirrors the desktop resize behavior of 
    - drag behavior should remain unchanged.
 5. Reduce viewport below `920px`:
    - resize affordance should disappear for quests (and still for log).
+
+## Draggable parity for combat/village action surfaces (April 11, 2026)
+
+To align interaction behavior with existing HUD windows (`Stats`, `Skills`, etc.), three gameplay panels now use the same draggable header system:
+
+- `#battle-sidebar` → header title `Combat Actions`
+- `#village-actions` → header title `Village Actions`
+- `#village-rumors-section` → header title `Village Rumors`
+
+### Behavior details
+
+- Drag is initiated **only** from the injected panel header drag handle (same pointer handling path used by HUD windows).
+- These three panels are configured as **non-closable** in the shared panel decorator (`✕` is disabled/hidden), because they are mode-driven runtime surfaces and do not have standalone HUD menu reopen toggles.
+- Layout persistence (offset, z-index, hidden state snapshots) still uses the same storage/context pipeline as other draggable windows, so world/battle context switching remains consistent.
+
+### Dev notes
+
+- `GameUiHudPanelController` now discovers these three mode panels directly by DOM id (`battle-sidebar`, `village-actions`, `village-rumors-section`) and decorates them through the same draggable-window pipeline.
+- Existing panel-controller tests still pass after extending panel config inventory and test DOM mocks.
+
+### Quick QA checklist
+
+1. Enter battle mode and drag `Combat Actions` by its header.
+2. Enter village mode, open village actions, and drag:
+   - `Village Actions` by its header;
+   - `Village Rumors` by its header.
+3. Confirm body content interactions (buttons/selects) still work and do **not** trigger drag.
+4. Switch between world and battle modes and verify panel placements remain stable.

--- a/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
@@ -1,7 +1,12 @@
 import { HudElements } from './GameUiTypes.js';
 import { GameUiEventCallbacks, HudPanelToggle } from './GameUiEventBinderTypes.js';
-
-type PanelConfig = { key: HudPanelToggle; title: string; element: HTMLElement };
+type PanelConfig = {
+    key: HudPanelToggle | null;
+    title: string;
+    element: HTMLElement;
+    closable?: boolean;
+    persistenceKey?: string;
+};
 type LayoutContext = 'world' | 'battle';
 type PanelLayoutSnapshot = {
     offsetX: number;
@@ -11,8 +16,7 @@ type PanelLayoutSnapshot = {
     hidden: boolean;
     zIndex: number | null;
 };
-type StoredPanelLayout = Partial<Record<HudPanelToggle, PanelLayoutSnapshot>>;
-
+type StoredPanelLayout = Record<string, PanelLayoutSnapshot>;
 export default class GameUiHudPanelController {
     private static readonly WORLD_LAYOUT_STORAGE_KEY = 'rgfn_hud_panel_layout_world_v1';
     private static readonly BATTLE_LAYOUT_STORAGE_KEY = 'rgfn_hud_panel_layout_battle_v1';
@@ -22,12 +26,10 @@ export default class GameUiHudPanelController {
     private readonly panelSpawnOrigin = { x: 24, y: 96 };
     private readonly panelSpawnStepY = 34;
     private activeLayoutContext: LayoutContext = 'world';
-
     constructor(hudElements: HudElements, callbacks: GameUiEventCallbacks) {
         this.hudElements = hudElements;
         this.callbacks = callbacks;
     }
-
     public bind(): void {
         this.bindHudMenuEvents();
         this.bindPanelToggleButtons();
@@ -36,14 +38,12 @@ export default class GameUiHudPanelController {
         this.restoreLayoutForCurrentContext();
         this.bindLayoutContextListener();
     }
-
     private bindHudMenuEvents(): void {
         this.hudElements.hudMenuToggleBtn.addEventListener('click', () => {
             const menuIsClosed = this.hudElements.hudMenuPanel.classList.contains('hidden');
             this.setHudMenuOpen(menuIsClosed);
         });
     }
-
     private bindPanelToggleButtons(): void {
         this.hudElements.toggleStatsPanelBtn.addEventListener('click', () => this.handlePanelToggle('stats'));
         this.hudElements.toggleSkillsPanelBtn.addEventListener('click', () => this.handlePanelToggle('skills'));
@@ -56,78 +56,73 @@ export default class GameUiHudPanelController {
         this.hudElements.toggleWorldMapPanelBtn.addEventListener('click', () => this.handlePanelToggle('worldMap'));
         this.hudElements.toggleLogPanelBtn.addEventListener('click', () => this.handlePanelToggle('log'));
     }
-
     private initializeHudPanelWindows(): void {
-        this.getPanelConfigs().forEach(({ key, title, element }, panelIndex) => {
-            this.decorateHudPanelWindow(key, title, element, panelIndex);
-        });
+        this.getPanelConfigs().forEach(({ key, title, element, closable }, panelIndex) => this.decorateHudPanelWindow(key, title, element, panelIndex, closable ?? true));
     }
-
-    private getPanelConfigs = (): PanelConfig[] => [
-        { key: 'stats', title: 'Stats', element: this.hudElements.statsPanel },
-        { key: 'skills', title: 'Skills', element: this.hudElements.skillsPanel },
-        { key: 'inventory', title: 'Inventory', element: this.hudElements.inventoryPanel },
-        { key: 'magic', title: 'Magic', element: this.hudElements.magicPanel },
-        { key: 'quests', title: 'Quests', element: this.hudElements.questsPanel },
-        { key: 'group', title: 'Group', element: this.hudElements.groupPanel },
-        { key: 'lore', title: 'Lore', element: this.hudElements.lorePanel },
-        { key: 'selected', title: 'Selected', element: this.hudElements.selectedPanel },
-        { key: 'worldMap', title: 'World Map', element: this.hudElements.worldMapPanel },
-        { key: 'log', title: 'Log', element: this.hudElements.logPanel },
-    ];
-
-    private decorateHudPanelWindow(panelKey: HudPanelToggle, title: string, panel: HTMLElement, panelIndex: number): void {
+    private getPanelConfigs = (): PanelConfig[] => {
+        const battleActionsPanel = document.getElementById('battle-sidebar');
+        const villageActionsPanel = document.getElementById('village-actions');
+        const villageRumorsPanel = document.getElementById('village-rumors-section');
+        return [
+            { key: 'stats', title: 'Stats', element: this.hudElements.statsPanel },
+            { key: 'skills', title: 'Skills', element: this.hudElements.skillsPanel },
+            { key: 'inventory', title: 'Inventory', element: this.hudElements.inventoryPanel },
+            { key: 'magic', title: 'Magic', element: this.hudElements.magicPanel },
+            { key: 'quests', title: 'Quests', element: this.hudElements.questsPanel },
+            { key: 'group', title: 'Group', element: this.hudElements.groupPanel },
+            { key: 'lore', title: 'Lore', element: this.hudElements.lorePanel },
+            { key: 'selected', title: 'Selected', element: this.hudElements.selectedPanel },
+            { key: 'worldMap', title: 'World Map', element: this.hudElements.worldMapPanel },
+            { key: 'log', title: 'Log', element: this.hudElements.logPanel },
+            ...(battleActionsPanel ? [{ key: null, title: 'Combat Actions', element: battleActionsPanel, closable: false, persistenceKey: 'battleActions' }] : []),
+            ...(villageActionsPanel ? [{ key: null, title: 'Village Actions', element: villageActionsPanel, closable: false, persistenceKey: 'villageActions' }] : []),
+            ...(villageRumorsPanel ? [{ key: null, title: 'Village Rumors', element: villageRumorsPanel, closable: false, persistenceKey: 'villageRumors' }] : []),
+        ];
+    };
+    private decorateHudPanelWindow(panelKey: HudPanelToggle | null, title: string, panel: HTMLElement, panelIndex: number, closable: boolean): void {
         if (panel.querySelector('.panel-window-header')) {
             return;
         }
-
         panel.classList.add('draggable-panel');
         const header = document.createElement('div');
         header.className = 'panel-window-header';
-
         const dragHandle = document.createElement('div');
         dragHandle.className = 'panel-drag-handle';
         dragHandle.textContent = title;
         dragHandle.title = 'Drag to move panel';
-
         const closeBtn = document.createElement('button');
         closeBtn.className = 'action-btn panel-close-btn';
         closeBtn.type = 'button';
         closeBtn.textContent = '✕';
         closeBtn.setAttribute('aria-label', `Close ${title} panel`);
         closeBtn.addEventListener('click', () => this.handlePanelClose(panelKey, panel));
-
+        closeBtn.classList.toggle('hidden', !closable);
+        closeBtn.disabled = !closable;
         header.append(dragHandle, closeBtn);
         panel.prepend(header);
         this.bindPanelDragEvents(panel, dragHandle);
         this.bindPanelSpawnPositioning(panel, panelIndex);
         this.bindPanelPersistenceObserver(panel);
     }
-
-    private handlePanelClose(panelKey: HudPanelToggle, panel: HTMLElement): void {
-        if (!panel.classList.contains('hidden')) {
+    private handlePanelClose(panelKey: HudPanelToggle | null, panel: HTMLElement): void {
+        if (panelKey !== null && !panel.classList.contains('hidden')) {
             this.callbacks.onTogglePanel(panelKey);
         }
-
         this.setHudMenuOpen(false);
     }
-
     private bindPanelDragEvents(panel: HTMLElement, dragHandle: HTMLElement): void {
         dragHandle.addEventListener('pointerdown', (event: PointerEvent) => {
             if (event.button !== 0) {
                 return;
             }
-
             event.preventDefault();
             dragHandle.setPointerCapture(event.pointerId);
             panel.style.zIndex = String(this.nextPanelZIndex++);
             panel.classList.add('panel-dragging');
-
             const startX = event.clientX;
             const startY = event.clientY;
             const initialOffsetX = Number.parseFloat(panel.dataset.offsetX ?? '0') || 0;
             const initialOffsetY = Number.parseFloat(panel.dataset.offsetY ?? '0') || 0;
-
             const onPointerMove = (moveEvent: PointerEvent): void => {
                 const nextOffsetX = initialOffsetX + (moveEvent.clientX - startX);
                 const nextOffsetY = initialOffsetY + (moveEvent.clientY - startY);
@@ -137,31 +132,26 @@ export default class GameUiHudPanelController {
                 panel.style.setProperty('--panel-offset-y', `${nextOffsetY}px`);
                 this.persistCurrentContextLayout();
             };
-
             const stopDrag = (): void => {
                 panel.classList.remove('panel-dragging');
                 dragHandle.removeEventListener('pointermove', onPointerMove);
                 dragHandle.removeEventListener('pointerup', stopDrag);
                 dragHandle.removeEventListener('pointercancel', stopDrag);
             };
-
             dragHandle.addEventListener('pointermove', onPointerMove);
             dragHandle.addEventListener('pointerup', stopDrag);
             dragHandle.addEventListener('pointercancel', stopDrag);
         });
     }
-
     private bindPanelSpawnPositioning(panel: HTMLElement, panelIndex: number): void {
         const placePanelAtSpawn = (): void => {
             if (panel.classList.contains('hidden') || panel.dataset.spawnPositioned === 'true') {
                 return;
             }
-
             const panelRect = panel.getBoundingClientRect();
             if (panelRect.width <= 0 || panelRect.height <= 0) {
                 return;
             }
-
             const targetX = this.panelSpawnOrigin.x;
             const targetY = this.panelSpawnOrigin.y + (panelIndex * this.panelSpawnStepY);
             const nextOffsetX = targetX - panelRect.left;
@@ -173,7 +163,6 @@ export default class GameUiHudPanelController {
             panel.style.setProperty('--panel-offset-y', `${nextOffsetY}px`);
             this.ensurePanelDragHandleIsReachable(panel);
         };
-
         const scheduleSpawnPlacement = (): void => {
             requestAnimationFrame(() => placePanelAtSpawn());
         };
@@ -181,7 +170,6 @@ export default class GameUiHudPanelController {
         const visibilityObserver = new MutationObserver(() => scheduleSpawnPlacement());
         visibilityObserver.observe(panel, { attributes: true, attributeFilter: ['class'] });
     }
-
     private handlePanelToggle(panel: HudPanelToggle): void {
         this.callbacks.onTogglePanel(panel);
         const panelElement = this.getPanelElement(panel);
@@ -191,54 +179,49 @@ export default class GameUiHudPanelController {
         this.setHudMenuOpen(false);
         this.persistCurrentContextLayout();
     }
-
     private setHudMenuOpen(isOpen: boolean): void {
         this.hudElements.hudMenuPanel.classList.toggle('hidden', !isOpen);
         this.hudElements.hudMenuToggleBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
     }
-
     private bindPanelPersistenceObserver(panel: HTMLElement): void {
         const observer = new MutationObserver(() => this.persistCurrentContextLayout());
         observer.observe(panel, { attributes: true, attributeFilter: ['class', 'style'] });
     }
-
     private bindLayoutContextListener(): void {
         const modeIndicator = this.hudElements.modeIndicator;
         const observer = new MutationObserver(() => this.handleLayoutContextChange());
         observer.observe(modeIndicator, { childList: true, characterData: true, subtree: true });
     }
-
     private handleLayoutContextChange(): void {
         const nextContext = this.getLayoutContextFromModeIndicator();
         if (nextContext === this.activeLayoutContext) {
             return;
         }
-
         this.persistCurrentContextLayout();
         this.activeLayoutContext = nextContext;
         this.restoreLayoutForCurrentContext();
     }
-
     private getLayoutContextFromModeIndicator(): LayoutContext {
         return this.hudElements.modeIndicator.textContent?.trim() === 'Battle!' ? 'battle' : 'world';
     }
-
     private restoreLayoutForCurrentContext(): void {
         const storedLayout = this.getStoredLayout(this.activeLayoutContext);
         const panelConfigs = this.getPanelConfigs();
-
         if (!storedLayout) {
             panelConfigs.forEach(({ element }, panelIndex) => this.resetPanelToSpawn(element, panelIndex));
             return;
         }
-
-        panelConfigs.forEach(({ key, element }, panelIndex) => {
-            const snapshot = storedLayout[key];
+        panelConfigs.forEach(({ key, element, persistenceKey }, panelIndex) => {
+            const layoutKey = key ?? persistenceKey;
+            if (!layoutKey) {
+                this.resetPanelToSpawn(element, panelIndex);
+                return;
+            }
+            const snapshot = storedLayout[layoutKey];
             if (!snapshot) {
                 this.resetPanelToSpawn(element, panelIndex);
                 return;
             }
-
             element.dataset.offsetX = String(snapshot.offsetX);
             element.dataset.offsetY = String(snapshot.offsetY);
             element.dataset.spawnPositioned = 'true';
@@ -246,21 +229,17 @@ export default class GameUiHudPanelController {
             element.style.setProperty('--panel-offset-y', `${snapshot.offsetY}px`);
             element.style.width = snapshot.width ?? '';
             element.style.height = snapshot.height ?? '';
-
             if (snapshot.zIndex !== null) {
                 element.style.zIndex = String(snapshot.zIndex);
             } else {
                 element.style.removeProperty('z-index');
             }
-
             element.classList.toggle('hidden', snapshot.hidden);
-
             if (!snapshot.hidden) {
                 requestAnimationFrame(() => this.ensurePanelDragHandleIsReachable(element));
             }
         });
     }
-
     private resetPanelToSpawn(panel: HTMLElement, panelIndex: number): void {
         panel.dataset.offsetX = '0';
         panel.dataset.offsetY = '0';
@@ -274,12 +253,10 @@ export default class GameUiHudPanelController {
             if (panel.classList.contains('hidden')) {
                 return;
             }
-
             const panelRect = panel.getBoundingClientRect();
             if (panelRect.width <= 0 || panelRect.height <= 0) {
                 return;
             }
-
             const targetX = this.panelSpawnOrigin.x;
             const targetY = this.panelSpawnOrigin.y + (panelIndex * this.panelSpawnStepY);
             const nextOffsetX = targetX - panelRect.left;
@@ -292,42 +269,34 @@ export default class GameUiHudPanelController {
             this.ensurePanelDragHandleIsReachable(panel);
         });
     }
-
     private getPanelElement = (panel: HudPanelToggle): HTMLElement | null => this.getPanelConfigs().find((config) => config.key === panel)?.element ?? null;
-
     private ensurePanelDragHandleIsReachable(panel: HTMLElement): void {
         if (panel.classList.contains('hidden')) {
             return;
         }
-
         const dragHandle = panel.querySelector<HTMLElement>('.panel-drag-handle');
         if (!dragHandle) {
             return;
         }
-
         const menuToggleRect = this.hudElements.hudMenuToggleBtn.getBoundingClientRect();
         const dragHandleRect = dragHandle.getBoundingClientRect();
         if (menuToggleRect.width <= 0 || menuToggleRect.height <= 0 || dragHandleRect.width <= 0 || dragHandleRect.height <= 0) {
             return;
         }
-
         if (!this.rectanglesOverlap(dragHandleRect, menuToggleRect)) {
             return;
         }
-
         const clearancePx = 12;
         const horizontalShift = (menuToggleRect.right + clearancePx) - dragHandleRect.left;
         const verticalShift = (menuToggleRect.bottom + clearancePx) - dragHandleRect.top;
         this.applyPanelNudge(panel, horizontalShift, verticalShift);
     }
-
     private rectanglesOverlap = (firstRect: DOMRect, secondRect: DOMRect): boolean => !(
         firstRect.right < secondRect.left
         || firstRect.left > secondRect.right
         || firstRect.bottom < secondRect.top
         || firstRect.top > secondRect.bottom
     );
-
     private applyPanelNudge(panel: HTMLElement, horizontalShift: number, verticalShift: number): void {
         const shouldShiftHorizontally = horizontalShift <= verticalShift;
         const currentOffsetX = Number.parseFloat(panel.dataset.offsetX ?? '0') || 0;
@@ -336,7 +305,6 @@ export default class GameUiHudPanelController {
         const nextOffsetY = shouldShiftHorizontally ? currentOffsetY : (currentOffsetY + verticalShift);
         this.applyPanelOffset(panel, nextOffsetX, nextOffsetY);
     }
-
     private applyPanelOffset(panel: HTMLElement, nextOffsetX: number, nextOffsetY: number): void {
         panel.dataset.offsetX = String(nextOffsetX);
         panel.dataset.offsetY = String(nextOffsetY);
@@ -344,18 +312,20 @@ export default class GameUiHudPanelController {
         panel.style.setProperty('--panel-offset-x', `${nextOffsetX}px`);
         panel.style.setProperty('--panel-offset-y', `${nextOffsetY}px`);
     }
-
     private persistCurrentContextLayout(): void {
         if (!window.localStorage) {
             return;
         }
-
         const layout: StoredPanelLayout = {};
-        this.getPanelConfigs().forEach(({ key, element }) => {
+        this.getPanelConfigs().forEach(({ key, element, persistenceKey }) => {
+            const layoutKey = key ?? persistenceKey;
+            if (!layoutKey) {
+                return;
+            }
             const offsetX = Number.parseFloat(element.dataset.offsetX ?? '0') || 0;
             const offsetY = Number.parseFloat(element.dataset.offsetY ?? '0') || 0;
             const zIndex = Number.parseInt(element.style.zIndex || '', 10);
-            layout[key] = {
+            layout[layoutKey] = {
                 offsetX,
                 offsetY,
                 width: element.style.width || null,
@@ -364,27 +334,22 @@ export default class GameUiHudPanelController {
                 zIndex: Number.isFinite(zIndex) ? zIndex : null,
             };
         });
-
         window.localStorage.setItem(this.getStorageKey(this.activeLayoutContext), JSON.stringify(layout));
     }
-
     private getStoredLayout(context: LayoutContext): StoredPanelLayout | null {
         if (!window.localStorage) {
             return null;
         }
-
         const raw = window.localStorage.getItem(this.getStorageKey(context));
         if (!raw) {
             return null;
         }
-
         try {
             return JSON.parse(raw) as StoredPanelLayout;
         } catch {
             return null;
         }
     }
-
     private getStorageKey(context: LayoutContext): string {
         return context === 'battle'
             ? GameUiHudPanelController.BATTLE_LAYOUT_STORAGE_KEY

--- a/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
+++ b/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
@@ -83,6 +83,9 @@ function createHudElements() {
   const selectedPanel = createElement('selected');
   const worldMapPanel = createElement('worldMap');
   const logPanel = createElement('log');
+  const battleActionsPanel = createElement('battleActions');
+  const villageActionsPanel = createElement('villageActions');
+  const villageRumorsPanel = createElement('villageRumors');
 
   const modeIndicator = createElement('mode');
   modeIndicator.textContent = 'World Map';
@@ -111,6 +114,22 @@ function createHudElements() {
     selectedPanel,
     worldMapPanel,
     logPanel,
+    battleActionsPanel,
+    villageActionsPanel,
+    villageRumorsPanel,
+  };
+}
+
+function createMockDocument(hudElements) {
+  const idMap = {
+    'battle-sidebar': hudElements.battleActionsPanel,
+    'village-actions': hudElements.villageActionsPanel,
+    'village-rumors-section': hudElements.villageRumorsPanel,
+  };
+
+  return {
+    createElement: () => createElement('dynamic'),
+    getElementById(id) { return idMap[id] ?? null; },
   };
 }
 
@@ -130,7 +149,8 @@ test('GameUiHudPanelController stores separate panel layouts for world map and b
   const observers = [];
 
   global.window = { localStorage: createLocalStorage() };
-  global.document = { createElement: () => createElement('dynamic') };
+  const hudElements = createHudElements();
+  global.document = createMockDocument(hudElements);
   global.requestAnimationFrame = (callback) => callback();
   global.MutationObserver = class {
     constructor(callback) { this.callback = callback; observers.push(this); }
@@ -139,7 +159,6 @@ test('GameUiHudPanelController stores separate panel layouts for world map and b
   };
 
   try {
-    const hudElements = createHudElements();
     const controller = new GameUiHudPanelController(hudElements, {
       onTogglePanel(panel) {
         const key = `${panel}Panel`;
@@ -190,7 +209,8 @@ test('GameUiHudPanelController persists panel hidden state on toggle', () => {
   const originalRequestAnimationFrame = global.requestAnimationFrame;
 
   global.window = { localStorage: createLocalStorage() };
-  global.document = { createElement: () => createElement('dynamic') };
+  const hudElements = createHudElements();
+  global.document = createMockDocument(hudElements);
   global.requestAnimationFrame = (callback) => callback();
   global.MutationObserver = class {
     constructor() {}
@@ -198,7 +218,6 @@ test('GameUiHudPanelController persists panel hidden state on toggle', () => {
   };
 
   try {
-    const hudElements = createHudElements();
     const controller = new GameUiHudPanelController(hudElements, {
       onTogglePanel(panel) {
         const key = `${panel}Panel`;


### PR DESCRIPTION
### Motivation

- Make the in-flow mode panels used during battles and village visits match the existing HUD draggable-window UX so players can move `Combat Actions`, `Village Actions` and `Village Rumors` by a header drag handle like `Stats`/`Skills`.

### Description

- Extend the HUD panel decorator so `#battle-sidebar`, `#village-actions` and `#village-rumors-section` are discovered at runtime and decorated with the same draggable header, drag handling, spawn placement and persistence pipeline as other HUD windows. 
- Treat these three mode-driven panels as non-closable (the `✕` button is hidden/disabled) to avoid creating a panel that cannot be reopened via HUD toggles. 
- Adjust layout persistence to store/load panels by a string key so the new mode panels (which are not part of the regular `HudElements` toggles) persist offset/size/z-index across `world`/`battle` contexts. 
- Update unit tests to provide DOM mocks for the new panel ids and add a `createMockDocument` helper so the `GameUiHudPanelController` tests exercise the new discovery flow. 
- Add documentation describing the draggable parity, behavior details and QA checklist in `rgfn_game/docs/systems/hud-panels.md`.

### Testing

- Ran the RGFN build with `npm run build:rgfn` which completed successfully. 
- Ran the RGFN test suite with `npm run test:rgfn` and all tests passed (`134` tests, `0` failures). 
- Ran targeted linting (`npx eslint` on the modified files) and observed only style warnings for `GameUiHudPanelController.ts` (no lint errors), so automated test/lint pipelines remain green for the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da79efc45c8323826cbfa8f3e239d7)