### PR TITLE
RGFN: show NPC quest dialogue actions only when available

### DIFF
--- a/rgfn_game/docs/village/village-dialogue-directions.md
+++ b/rgfn_game/docs/village/village-dialogue-directions.md
@@ -73,13 +73,15 @@ Village rumors now support asking about **people**, not only settlements.
 - Lists are deduplicated and sorted alphabetically.
 
 ### Button availability rule (RGFN UX)
-- The following four dialogue/barter buttons are now always enabled in the village UI:
+- Core dialogue actions remain available once an NPC is selected:
   - **Ask about location**
   - **Ask about person**
   - **Ask about barter**
-  - **I have what you need, let's do our barter**
-- Validation remains in action handlers, so if no NPC is selected or required input is missing, the game log explains what to do next.
-- This preserves guidance via feedback while removing click-lock friction.
+- Quest-only follow-up actions are now **context-sensitive and hidden by default**:
+  - **I have what you need, let's do our barter** appears only for selected NPCs with an unfinished barter contract in the current village.
+  - **Confront for quest item** appears only when the selected NPC is the currently valid recover quest confrontation target and the target has already been revealed.
+  - **Join my group** appears only when the selected NPC is currently recruitable for an active escort objective in this village.
+- Goal: prevent dead-end button clicks and show only actionable quest interactions per-NPC.
 
 ### Reliability model (intentionally lower than village directions)
 - Person rumors have an explicit low knowledge chance (`26%`) before truthful/imprecise branches can trigger.

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -304,9 +304,9 @@
                     <select id="village-ask-person-input" class="village-ask-input"></select>
                     <button id="village-ask-person-btn" class="action-btn">Ask about person</button>
                     <button id="village-ask-barter-btn" class="action-btn">Ask about barter</button>
-                    <button id="village-confirm-barter-btn" class="action-btn">I have what you need, let's do our barter</button>
-                    <button id="village-confront-recover-btn" class="action-btn">Confront for quest item</button>
-                    <button id="village-recruit-escort-btn" class="action-btn">Join my group</button>
+                    <button id="village-confirm-barter-btn" class="action-btn hidden">I have what you need, let's do our barter</button>
+                    <button id="village-confront-recover-btn" class="action-btn hidden">Confront for quest item</button>
+                    <button id="village-recruit-escort-btn" class="action-btn hidden">Join my group</button>
                 </div>
             </div>
         </div>

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -22,6 +22,7 @@ export default class VillageActionsController {
     private selectedNpcId: string | null = null;
     private escortContracts: QuestEscortContract[] = [];
     private knownNpcNames: Set<string> = new Set();
+    private joinedEscortNpcKeys: Set<string> = new Set();
 
     constructor(player: Player, villageUI: VillageUI, gameLog: HTMLElement, callbacks: VillageActionsCallbacks) {
         this.villageUI = villageUI;
@@ -114,7 +115,9 @@ export default class VillageActionsController {
         }
         const status = this.callbacks.onTryRecruitEscort(npc.name, this.currentVillageName);
         if (status === 'joined') {
+            this.joinedEscortNpcKeys.add(this.getEscortNpcKey(npc.name, this.currentVillageName));
             this.addLog(`${npc.name} agrees to travel with you. Escort objective updated.`, 'system');
+            this.updateButtons();
             this.callbacks.onAdvanceTime(20, 0.15);
             return;
         }
@@ -151,6 +154,10 @@ export default class VillageActionsController {
         getSelectedNpc: () => this.getSelectedNpc(),
         getSellPrice: (item) => this.stockService.getSellPrice(item),
         isInnkeeper: (role) => this.isInnkeeper(role),
+        shouldShowBarterNowAction: (npcName) => this.hasActiveBarterDealForNpc(npcName),
+        shouldShowConfrontRecoverAction: (npcName, villageName) => this.canConfrontRecoverTarget(npcName, villageName),
+        shouldShowRecruitEscortAction: (npcName, villageName) => this.canRecruitEscort(npcName, villageName),
+        getCurrentVillageName: () => this.currentVillageName,
     });
 
     private createTradeInteraction = (player: Player, callbacks: VillageActionsCallbacks): VillageTradeInteractionService => new VillageTradeInteractionService({
@@ -279,6 +286,39 @@ export default class VillageActionsController {
     private refreshDialogueTargetOptions(): void {
         this.populateSelectWithOptions(this.villageUI.askVillageInput, this.getKnownSettlementNames(), 'Choose known settlement');
         this.populateSelectWithOptions(this.villageUI.askPersonInput, this.getKnownPersonNames(), 'Choose known person');
+    }
+
+    private hasActiveBarterDealForNpc(npcName: string): boolean {
+        if (!npcName.trim() || !this.currentVillageName.trim()) {
+            return false;
+        }
+        const deal = this.barterService.getBarterDealForNpc(this.currentVillageName, npcName);
+        return Boolean(deal && !deal.isCompleted);
+    }
+
+    private canConfrontRecoverTarget(npcName: string, villageName: string): boolean {
+        const selectedNpc = this.getSelectedNpc();
+        if (!npcName.trim() || !villageName.trim() || !selectedNpc) {
+            return false;
+        }
+        return selectedNpc.role.trim().toLocaleLowerCase().startsWith('wanted for ');
+    }
+
+    private canRecruitEscort(npcName: string, villageName: string): boolean {
+        if (!npcName.trim() || !villageName.trim()) {
+            return false;
+        }
+        const normalizedNpc = npcName.trim().toLocaleLowerCase();
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        const isEscortContractNpc = this.escortContracts.some((contract) =>
+            contract.personName.trim().toLocaleLowerCase() === normalizedNpc
+            && contract.sourceVillage.trim().toLocaleLowerCase() === normalizedVillage,
+        );
+        return isEscortContractNpc && !this.joinedEscortNpcKeys.has(this.getEscortNpcKey(npcName, villageName));
+    }
+
+    private getEscortNpcKey(npcName: string, villageName: string): string {
+        return `${villageName.trim().toLocaleLowerCase()}::${npcName.trim().toLocaleLowerCase()}`;
     }
 
     private getKnownSettlementNames(): string[] {

--- a/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
+++ b/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
@@ -12,6 +12,10 @@ type PresenterDeps = {
     getSelectedNpc: () => VillageNpcProfile | null;
     getSellPrice: (item: Item) => number;
     isInnkeeper: (role: string) => boolean;
+    shouldShowBarterNowAction: (npcName: string) => boolean;
+    shouldShowConfrontRecoverAction: (npcName: string, villageName: string) => boolean;
+    shouldShowRecruitEscortAction: (npcName: string, villageName: string) => boolean;
+    getCurrentVillageName: () => string;
 };
 
 export default class VillageUiPresenter {
@@ -46,9 +50,19 @@ export default class VillageUiPresenter {
         this.deps.villageUI.askVillageBtn.disabled = !hasSelectedNpc;
         this.deps.villageUI.askPersonBtn.disabled = !hasSelectedNpc;
         this.deps.villageUI.askBarterBtn.disabled = !hasSelectedNpc;
-        this.deps.villageUI.barterNowBtn.disabled = !hasSelectedNpc;
-        this.deps.villageUI.confrontRecoverBtn.disabled = !hasSelectedNpc;
-        this.deps.villageUI.recruitEscortBtn.disabled = !hasSelectedNpc;
+        const selectedNpcName = selectedNpc?.name ?? '';
+        const currentVillageName = this.deps.getCurrentVillageName();
+        const showBarterNow = hasSelectedNpc && this.deps.shouldShowBarterNowAction(selectedNpcName);
+        const showConfrontRecover = hasSelectedNpc && this.deps.shouldShowConfrontRecoverAction(selectedNpcName, currentVillageName);
+        const showRecruitEscort = hasSelectedNpc && this.deps.shouldShowRecruitEscortAction(selectedNpcName, currentVillageName);
+
+        this.deps.villageUI.barterNowBtn.classList.toggle('hidden', !showBarterNow);
+        this.deps.villageUI.confrontRecoverBtn.classList.toggle('hidden', !showConfrontRecover);
+        this.deps.villageUI.recruitEscortBtn.classList.toggle('hidden', !showRecruitEscort);
+
+        this.deps.villageUI.barterNowBtn.disabled = !showBarterNow;
+        this.deps.villageUI.confrontRecoverBtn.disabled = !showConfrontRecover;
+        this.deps.villageUI.recruitEscortBtn.disabled = !showRecruitEscort;
         this.deps.villageUI.sleepRoomBtn.disabled = !hasSelectedNpc || !this.deps.isInnkeeper(selectedNpc?.role ?? '');
     }
 

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -4,11 +4,37 @@ import assert from 'node:assert/strict';
 import VillageActionsController from '../../../dist/systems/village/VillageActionsController.js';
 
 function createClassList() {
+  const classes = new Set();
   return {
     added: [],
     removed: [],
-    add(name) { this.added.push(name); },
-    remove(name) { this.removed.push(name); },
+    add(name) {
+      this.added.push(name);
+      classes.add(name);
+    },
+    remove(name) {
+      this.removed.push(name);
+      classes.delete(name);
+    },
+    toggle(name, force) {
+      if (typeof force === 'boolean') {
+        if (force) {
+          this.add(name);
+          return true;
+        }
+        this.remove(name);
+        return false;
+      }
+      if (classes.has(name)) {
+        this.remove(name);
+        return false;
+      }
+      this.add(name);
+      return true;
+    },
+    contains(name) {
+      return classes.has(name);
+    },
   };
 }
 
@@ -68,6 +94,7 @@ function createVillageUi() {
     askBarterBtn: createElement('button'),
     barterNowBtn: createElement('button'),
     confrontRecoverBtn: createElement('button'),
+    recruitEscortBtn: createElement('button'),
     leaveBtn: createElement('button'),
   };
 }
@@ -387,4 +414,41 @@ test('VillageActionsController asks NPC about nearby settlements via dialogue en
   controller.handleAskAboutNearbySettlements();
 
   assert.equal(gameLog.children.some((child) => child.textContent.includes('Nearby list.')), true);
+}));
+
+test('VillageActionsController shows contextual dialogue action buttons only when available for selected NPC', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onLeaveVillage: () => {},
+    onTryRecruitEscort: () => 'not-available',
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+  });
+
+  controller.configureQuestBarterContracts([{ traderName: 'Olive', itemName: 'Kator Kaesh', sourceVillage: 'Mossbrook' }]);
+  controller.configureQuestEscortContracts([{ personName: 'Olive', sourceVillage: 'Mossbrook', destinationVillage: 'Farwatch' }]);
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'moss-0', name: 'Mara', role: 'Trader', look: 'cloak', speechStyle: 'calm', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Mossbrook');
+  assert.equal(villageUI.barterNowBtn.classList.contains('hidden'), true);
+  assert.equal(villageUI.confrontRecoverBtn.classList.contains('hidden'), true);
+  assert.equal(villageUI.recruitEscortBtn.classList.contains('hidden'), true);
+
+  const oliveIndex = controller['npcRoster'].findIndex((npc) => npc.name === 'Olive');
+  controller.handleSelectNpc(oliveIndex);
+  assert.equal(villageUI.barterNowBtn.classList.contains('hidden'), false);
+  assert.equal(villageUI.recruitEscortBtn.classList.contains('hidden'), false);
+  assert.equal(villageUI.confrontRecoverBtn.classList.contains('hidden'), true);
+
+  controller['callbacks'].onRevealRecoverHolder = () => ({ revealed: true, personName: 'Pablo Menéndez', itemName: 'Torva' });
+  controller.handleSelectNpc(oliveIndex);
+  const recoverIndex = controller['npcRoster'].findIndex((npc) => npc.name === 'Pablo Menéndez');
+  controller.handleSelectNpc(recoverIndex);
+  assert.equal(villageUI.confrontRecoverBtn.classList.contains('hidden'), false);
 }));


### PR DESCRIPTION
### Motivation

- Prevent the three quest-only dialogue buttons from being visible for every NPC and reduce dead-end clicks by showing them only when actually actionable.  
- Make UI behavior reflect quest state (barter, recover confrontation, escort join) per selected NPC and current village.  
- Improve UX clarity and reduce accidental/invalid actions while keeping existing action handlers and logging semantics.

### Description

- Hide the three quest-only buttons by default in the dialogue modal (`index.html`) by adding the `hidden` class to the markup for the barter, confront and recruit buttons.  
- Add contextual visibility logic to `VillageUiPresenter` by introducing presenter callbacks (`shouldShowBarterNowAction`, `shouldShowConfrontRecoverAction`, `shouldShowRecruitEscortAction`, `getCurrentVillageName`) and toggling button `hidden` state and `disabled` based on those callbacks.  
- Implement the context checks in `VillageActionsController`: `hasActiveBarterDealForNpc`, `canConfrontRecoverTarget`, `canRecruitEscort`, plus a `joinedEscortNpcKeys` set to hide escort join after successful recruitment and call `updateButtons()` when relevant.  
- Update tests and test harness: extend the stubbed `classList` in `villageActionsController` tests to support `toggle/contains`, include the recruit button in the fake UI, and add a new scenario test that verifies the contextual show/hide behavior for barter, confront, and recruit actions.  
- Update documentation (`docs/village/village-dialogue-directions.md`) to describe the new context-sensitive visibility rules for quest actions.

### Testing

- Ran the RGFN test suite with `npm run test:rgfn` (build + tests); all tests passed (`134` tests passed).  
- Ran ESLint on the modified presenter/controller files with `npx eslint rgfn_game/js/systems/village/actions/VillageUiPresenter.ts rgfn_game/js/systems/village/VillageActionsController.ts`; there were no errors (only project/style warnings remain in long-lived files).  
- Verified the new unit scenario that asserts buttons are hidden by default and appear only when the selected NPC has the corresponding contextual opportunity succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6afb3f344832397d77f91b18e7d6c)