### PR TITLE
Lock combat panel to battle mode, add resize parity, and test visibility

### DIFF
--- a/rgfn_game/docs/systems/hud-panels.md
+++ b/rgfn_game/docs/systems/hud-panels.md
@@ -550,3 +550,55 @@ To align interaction behavior with existing HUD windows (`Stats`, `Skills`, etc.
    - `Village Rumors` by its header.
 3. Confirm body content interactions (buttons/selects) still work and do **not** trigger drag.
 4. Switch between world and battle modes and verify panel placements remain stable.
+
+## Combat panel mode-lock + resize parity fix (April 11, 2026, follow-up)
+
+### Problem summary
+
+- `#battle-sidebar` (combat actions) could appear while the game was in non-battle contexts (world map / village), which is invalid UX because the panel contains battle-only actions.
+- The panel width was not constrained like standard HUD windows (`Stats`, `Village Actions`) and could render overly wide.
+- Unlike `Log` and `Quests`, the combat panel was not resizable.
+
+### Implementation details
+
+- Added explicit mode-text mapping inside `GameUiHudPanelController` and now treat only exact `Battle!` as battle layout context.
+- Added a dedicated combat panel guard (`enforceCombatPanelVisibility`) that runs during:
+  - initial bind,
+  - every layout-context observer update,
+  - layout restore,
+  - layout persistence.
+- The guard forces strict visibility:
+  - **battle context** → combat panel visible,
+  - **non-battle context** (world/village/unknown text) → combat panel hidden.
+- Persistence now hard-locks combat panel hidden-state snapshots by context (never trusting stale DOM class state in non-battle contexts).
+
+### Sizing/resize parity updates
+
+- `#battle-sidebar` now uses the same desktop sizing contract as other floating panels:
+  - width: `min(340px, calc(100vw - 48px))`,
+  - min-size: `260x220`,
+  - viewport caps: `calc(100vw - 32px)`,
+  - `resize: both`,
+  - `overflow: hidden`,
+  - `align-self: flex-start`.
+- Mobile fallback (`max-width: 920px`) now disables battle panel resize exactly like log/quests (`resize: none` and fixed stacked height).
+
+### Regression coverage
+
+- Added `GameUiHudPanelController` scenario test verifying combat panel visibility lock:
+  1. Hidden in `World Map`,
+  2. Visible in `Battle!`,
+  3. Hidden again in `Village`.
+
+### Quick QA checklist
+
+1. Start in world map mode:
+   - combat panel should stay hidden.
+2. Enter battle:
+   - combat panel appears automatically.
+3. Leave battle to village/world:
+   - combat panel hides immediately.
+4. In battle on desktop:
+   - drag lower-right corner to resize panel width/height.
+5. On mobile breakpoint (`<=920px`):
+   - resize affordance should be disabled.

--- a/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
@@ -20,6 +20,12 @@ type StoredPanelLayout = Record<string, PanelLayoutSnapshot>;
 export default class GameUiHudPanelController {
     private static readonly WORLD_LAYOUT_STORAGE_KEY = 'rgfn_hud_panel_layout_world_v1';
     private static readonly BATTLE_LAYOUT_STORAGE_KEY = 'rgfn_hud_panel_layout_battle_v1';
+    private static readonly COMBAT_PANEL_PERSISTENCE_KEY = 'battleActions';
+    private static readonly MODE_TEXT = {
+        battle: 'Battle!',
+        village: 'Village',
+        world: 'World Map',
+    } as const;
     private hudElements: HudElements;
     private callbacks: GameUiEventCallbacks;
     private nextPanelZIndex = 10;
@@ -36,6 +42,7 @@ export default class GameUiHudPanelController {
         this.initializeHudPanelWindows();
         this.activeLayoutContext = this.getLayoutContextFromModeIndicator();
         this.restoreLayoutForCurrentContext();
+        this.enforceCombatPanelVisibility(this.activeLayoutContext);
         this.bindLayoutContextListener();
     }
     private bindHudMenuEvents(): void {
@@ -195,14 +202,23 @@ export default class GameUiHudPanelController {
     private handleLayoutContextChange(): void {
         const nextContext = this.getLayoutContextFromModeIndicator();
         if (nextContext === this.activeLayoutContext) {
+            this.enforceCombatPanelVisibility(nextContext);
             return;
         }
         this.persistCurrentContextLayout();
         this.activeLayoutContext = nextContext;
         this.restoreLayoutForCurrentContext();
+        this.enforceCombatPanelVisibility(nextContext);
     }
     private getLayoutContextFromModeIndicator(): LayoutContext {
-        return this.hudElements.modeIndicator.textContent?.trim() === 'Battle!' ? 'battle' : 'world';
+        const modeText = this.hudElements.modeIndicator.textContent?.trim() ?? '';
+        if (modeText === GameUiHudPanelController.MODE_TEXT.battle) {
+            return 'battle';
+        }
+        if (modeText === GameUiHudPanelController.MODE_TEXT.world || modeText === GameUiHudPanelController.MODE_TEXT.village) {
+            return 'world';
+        }
+        return 'world';
     }
     private restoreLayoutForCurrentContext(): void {
         const storedLayout = this.getStoredLayout(this.activeLayoutContext);
@@ -239,6 +255,7 @@ export default class GameUiHudPanelController {
                 requestAnimationFrame(() => this.ensurePanelDragHandleIsReachable(element));
             }
         });
+        this.enforceCombatPanelVisibility(this.activeLayoutContext);
     }
     private resetPanelToSpawn(panel: HTMLElement, panelIndex: number): void {
         panel.dataset.offsetX = '0';
@@ -316,6 +333,7 @@ export default class GameUiHudPanelController {
         if (!window.localStorage) {
             return;
         }
+        this.enforceCombatPanelVisibility(this.activeLayoutContext);
         const layout: StoredPanelLayout = {};
         this.getPanelConfigs().forEach(({ key, element, persistenceKey }) => {
             const layoutKey = key ?? persistenceKey;
@@ -325,16 +343,30 @@ export default class GameUiHudPanelController {
             const offsetX = Number.parseFloat(element.dataset.offsetX ?? '0') || 0;
             const offsetY = Number.parseFloat(element.dataset.offsetY ?? '0') || 0;
             const zIndex = Number.parseInt(element.style.zIndex || '', 10);
+            const isCombatPanel = layoutKey === GameUiHudPanelController.COMBAT_PANEL_PERSISTENCE_KEY;
+            const hidden = isCombatPanel
+                ? this.activeLayoutContext !== 'battle'
+                : element.classList.contains('hidden');
             layout[layoutKey] = {
                 offsetX,
                 offsetY,
                 width: element.style.width || null,
                 height: element.style.height || null,
-                hidden: element.classList.contains('hidden'),
+                hidden,
                 zIndex: Number.isFinite(zIndex) ? zIndex : null,
             };
         });
         window.localStorage.setItem(this.getStorageKey(this.activeLayoutContext), JSON.stringify(layout));
+    }
+    private enforceCombatPanelVisibility(context: LayoutContext): void {
+        const combatPanel = this.getPanelConfigs()
+            .find(({ persistenceKey }) => persistenceKey === GameUiHudPanelController.COMBAT_PANEL_PERSISTENCE_KEY)
+            ?.element;
+        if (!combatPanel) {
+            return;
+        }
+        const shouldBeVisible = context === 'battle';
+        combatPanel.classList.toggle('hidden', !shouldBeVisible);
     }
     private getStoredLayout(context: LayoutContext): StoredPanelLayout | null {
         if (!window.localStorage) {

--- a/rgfn_game/style.css
+++ b/rgfn_game/style.css
@@ -404,6 +404,19 @@ h1 {
     resize: both;
 }
 
+#battle-sidebar {
+    width: min(340px, calc(100vw - 48px));
+    max-width: calc(100vw - 32px);
+    max-inline-size: calc(100vw - 32px);
+    min-height: 220px;
+    height: min(42vh, 360px);
+    min-width: 260px;
+    min-inline-size: 260px;
+    overflow: hidden;
+    align-self: flex-start;
+    resize: both;
+}
+
 #quests-panel {
     position: fixed;
     top: 0;
@@ -694,7 +707,8 @@ h1 {
     }
 
     #game-log-container,
-    #quests-panel {
+    #quests-panel,
+    #battle-sidebar {
         margin-top: 0;
         height: 260px;
         max-height: 260px;

--- a/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
+++ b/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
@@ -236,3 +236,41 @@ test('GameUiHudPanelController persists panel hidden state on toggle', () => {
     global.requestAnimationFrame = originalRequestAnimationFrame;
   }
 });
+
+test('GameUiHudPanelController keeps combat actions panel hidden outside battle mode', () => {
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalMutationObserver = global.MutationObserver;
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+  const observers = [];
+
+  global.window = { localStorage: createLocalStorage() };
+  const hudElements = createHudElements();
+  global.document = createMockDocument(hudElements);
+  global.requestAnimationFrame = (callback) => callback();
+  global.MutationObserver = class {
+    constructor(callback) { this.callback = callback; observers.push(this); }
+    observe(target) { this.target = target; }
+    trigger() { this.callback(); }
+  };
+
+  try {
+    const controller = new GameUiHudPanelController(hudElements, { onTogglePanel() {} });
+    controller.bind();
+
+    assert.equal(hudElements.battleActionsPanel.classList.contains('hidden'), true);
+
+    hudElements.modeIndicator.textContent = 'Battle!';
+    observers.forEach((observer) => observer.target === hudElements.modeIndicator && observer.trigger());
+    assert.equal(hudElements.battleActionsPanel.classList.contains('hidden'), false);
+
+    hudElements.modeIndicator.textContent = 'Village';
+    observers.forEach((observer) => observer.target === hudElements.modeIndicator && observer.trigger());
+    assert.equal(hudElements.battleActionsPanel.classList.contains('hidden'), true);
+  } finally {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.MutationObserver = originalMutationObserver;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});


### PR DESCRIPTION
### Motivation

- Combat actions panel (`#battle-sidebar`) could appear outside of battles and had a non-standard width/resize behavior, causing invalid UX and layout issues.
- The UI should enforce strict mode checks so high-frequency code paths never show battle-only controls in world/village contexts.
- The combat panel should match other HUD windows in sizing and be resizable on desktop with the same mobile fallback as `Log`/`Quests`.

### Description

- Added explicit mode-text mapping and a dedicated guard `enforceCombatPanelVisibility` in `GameUiHudPanelController` so only exact `Battle!` maps to battle context and the combat panel is forced visible only in battle; it runs during bind, context-change, restore, and persistence paths and uses a `COMBAT_PANEL_PERSISTENCE_KEY` for consistent handling.
- Hardened persistence logic so the combat panel hidden-state is derived from the active context (not stale DOM state) when saving/restoring layouts.
- CSS updates for `#battle-sidebar` to align its width/min-size/viewport caps with other floating panels and enable `resize: both` on desktop while disabling resize at the mobile breakpoint to match `Log`/`Quests` behavior.
- Added a scenario test `GameUiHudPanelController keeps combat actions panel hidden outside battle mode` covering World Map → Battle! → Village transitions, and updated docs (`docs/systems/hud-panels.md`) with implementation notes and QA checklist for the change.

### Testing

- Ran `npm run build:rgfn` and the TypeScript build succeeded.
- Ran `npm run test:rgfn` which executes the built scenario tests; the test suite completed successfully (all tests passed including the new combat-panel visibility test).
- Ran lint checks; `npm run lint:ts:rgfn` reported pre-existing repo-wide lint issues unrelated to these changes, so the full lint task exited non-zero, while `npx eslint` on the modified `GameUiHudPanelController.ts` produced warnings only (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7e602014832398ca5560591cfd38)