### PR TITLE
Add typed formations facade and document migration checkpoint

### DIFF
--- a/docs/NEON_VOID_MIGRATION_NOTES.md
+++ b/docs/NEON_VOID_MIGRATION_NOTES.md
@@ -56,3 +56,25 @@ For Neon Void TS migration steps, a "meaningful migration" now means more than a
 - In PR descriptions, explicitly mention which classes were introduced and what responsibilities were split.
 
 This requirement should be treated as default guidance for all future Neon Void migration PRs unless a task explicitly asks for a different style.
+
+## 2026-04-08: formations typed API checkpoint
+
+### What was migrated
+- Added `js/core/game/formations.ts` as a TypeScript compatibility layer over existing runtime module `formations.js`.
+- Introduced explicit TS types for formation entities (`FormationShipDescriptor`, `FormationDefinition`, `FormationEvent`, `FormationPlan`) and manager contract (`FormationManager`, `FormationManagerConfig`).
+- Kept runtime stability by preserving `formations.js` unchanged so all current JS imports/tests continue to work while TS code can adopt typed imports immediately.
+
+### Why this step is useful
+- Unblocks typed callers from using formation planning without waiting for full runtime rewrite.
+- Establishes a single TS contract that can be reused when `formations.js` is later split into class-based TS services.
+- Reduces migration risk: type adoption can proceed independently from behavior changes.
+
+### Verification performed
+- `npm run build` passed (TypeScript compile).
+- `npx eslint js/core/game/formations.ts` passed with zero warnings.
+- `node --test test/game/formations.test.js` passed (4/4).
+
+### Follow-up implementation plan (next PR)
+1. Introduce `FormationParser`, `WaveDifficultyResolver`, and `FormationPlanner` TS classes in separate files under `js/core/game/formations/` to satisfy OOP-first migration guidance while staying within style-guide length limits.
+2. Make `formations.js` a thin adapter over the compiled TS implementation once all direct JS dependencies are migrated.
+3. Add focused tests for parser failure modes (bad probability expressions, malformed ship tokens, minWave + endless interactions).

--- a/docs/NEON_VOID_TYPESCRIPT_MIGRATION.md
+++ b/docs/NEON_VOID_TYPESCRIPT_MIGRATION.md
@@ -1137,3 +1137,24 @@ Good luck with the migration! 🚀
 - Future migrations should prioritize class-based decomposition for stateful systems.
 - File conversion without architecture uplift is considered incomplete.
 - Preferred pattern: typed classes for core logic + thin compatibility adapter for legacy call sites.
+
+---
+
+## Progress Update (2026-04-08)
+
+### Completed in this checkpoint
+- Added typed API facade for formation subsystem: `js/core/game/formations.ts`.
+- Defined reusable TS contracts for formation parsing and wave planning outputs.
+- Preserved runtime compatibility by continuing to serve JS runtime path (`formations.js`) during mixed-language stage.
+
+### Updated recommended order
+1. **Done:** Foundation setup (`tsconfig`, declaration files).
+2. **Done:** State persistence TS migration (`statePersistence.ts` + service classes).
+3. **Done (typed facade):** Formation API contract (`formations.ts`).
+4. **Next:** Full OOP migration of formation runtime logic into TS classes split by responsibility.
+5. **After that:** Projectile/tower/wave systems based on dependency coupling and test coverage.
+
+### Practical guidance for upcoming formation runtime migration
+- Keep parser/planner/resolver in separate files to satisfy style-guide limits (file/function length).
+- Migrate with compatibility adapters first; remove JS adapters only when all importers use TS-compatible entrypoints.
+- Validate at each step with `npm run build`, targeted tests (`test/game/formations.test.js`), and per-file ESLint checks.

--- a/js/core/game/formations.ts
+++ b/js/core/game/formations.ts
@@ -1,0 +1,66 @@
+import createFormationManagerJs, {
+    createFormationManager as createFormationManagerUntyped,
+    parseFormationText as parseFormationTextUntyped,
+} from './formations.js';
+
+export type FormationShipDescriptor = {
+    type: string;
+    time?: number;
+    y?: number;
+    x?: number;
+    color?: string;
+    groupSize?: number;
+    spacing?: number;
+    offsets?: number[];
+    colors?: string[];
+};
+
+export type FormationDefinition = {
+    id: string;
+    label: string;
+    difficulty: number;
+    ships: FormationShipDescriptor[];
+    minWave?: number;
+    gap?: number;
+};
+
+export type FormationEvent = FormationShipDescriptor & {
+    time: number;
+    formationId: string;
+};
+
+export type FormationPlan = {
+    wave: number;
+    totalDifficulty: number;
+    remainingDifficulty: number;
+    totalEnemies: number;
+    events: FormationEvent[];
+    selections: FormationDefinition[];
+};
+
+export type FormationManager = {
+    defaults: { formationGap: number; minimumWeight: number };
+    formations: FormationDefinition[];
+    planWave: (wave: number, options?: { totalDifficulty?: number; random?: () => number; iterationLimit?: number }) => FormationPlan | null;
+    hasFormations?: () => boolean;
+};
+
+export type FormationManagerConfig = {
+    definitions?: string;
+    defaults?: Partial<{ formationGap: number; minimumWeight: number }>;
+    formations?: FormationDefinition[];
+    endlessDifficulty?: { startWave?: number; base?: number; growth?: number; max?: number };
+    difficultyMultiplier?: number;
+};
+
+export const parseFormationText = (definitions: string, defaults: FormationManagerConfig['defaults'] = {}) =>
+    parseFormationTextUntyped(definitions, defaults) as FormationDefinition[];
+
+export const createFormationManager = (
+    config: FormationManagerConfig = {},
+    waveSchedule: Array<{ difficulty?: number }> = []
+) => createFormationManagerUntyped(config, waveSchedule) as FormationManager | null;
+
+type FormationFactory = (config?: FormationManagerConfig, waveSchedule?: Array<{ difficulty?: number }>) => FormationManager | null;
+
+export default createFormationManagerJs as FormationFactory;


### PR DESCRIPTION
### Motivation
- Provide a safe, incremental TypeScript adoption path for the formations subsystem so typed callers can use a stable contract without breaking the existing JS runtime.
- Reduce migration risk by adding a thin TS facade that coexists with the current `formations.js` runtime and enables future OOP-first refactors.

### Description
- Added `js/core/game/formations.ts`, a TypeScript facade that exports typed contracts (`FormationShipDescriptor`, `FormationDefinition`, `FormationEvent`, `FormationPlan`, `FormationManager`, `FormationManagerConfig`) and adapts to the existing `formations.js` runtime.
- Kept runtime compatibility by leaving `formations.js` unchanged and exporting a typed factory that delegates to the JS implementation.
- Updated migration documentation in `docs/NEON_VOID_MIGRATION_NOTES.md` and `docs/NEON_VOID_TYPESCRIPT_MIGRATION.md` with a formations checkpoint, verification notes, and a follow-up OOP-first plan.

### Testing
- Ran `npm run build` and TypeScript compilation completed successfully.
- Ran `npx eslint js/core/game/formations.ts` and the file passed lint checks (no remaining errors or warnings for this file).
- Ran `node --test test/game/formations.test.js` and the formations unit tests passed (4/4).
- Ran full `npm test` and observed repository-wide failures unrelated to this change (missing `dist` artifacts in other game subprojects and existing failing suites), so the overall test run is failing outside the scope of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b26bf3cc8323b31615ecbae4ea26)