### PR TITLE
Fix RGFN HUD panel clipping and restore stats resize

### DIFF
--- a/docs/Tasks/rgfn_stats_panel_resizing_and_clipping_fix.md
+++ b/docs/Tasks/rgfn_stats_panel_resizing_and_clipping_fix.md
@@ -1,0 +1,24 @@
+# RGFN HUD Panel Resizing + Overflow Clipping Fix (2026-04-11)
+
+## Problem report
+- Stats panel content could render past the panel border when formulas or long stat rows pushed beyond available height.
+- Stats panel had lost desktop resize behavior.
+
+## What changed
+- Updated `rgfn_game/style.css` so all draggable HUD panels use:
+  - desktop resizing (`resize: both`),
+  - viewport-bound dimensions (`max-height/max-width` guards),
+  - clipped/scrollable content (`overflow: auto`) so text does not bleed outside borders.
+- Included stats, skills, inventory, magic, quests, group, lore, selected, world map, battle, village, and log-related draggable panels in the shared rule set.
+- Kept responsive behavior: on narrow/mobile viewports, panel resizing is disabled (`resize: none`) and fixed mobile heights remain enforced.
+
+## Regression tests
+- Added `rgfn_game/test/systems/scenarios/panelStyles.test.js` to assert CSS keeps:
+  - desktop panel clipping + resizing,
+  - mobile resize disablement.
+
+## Notes for future UI work
+- Prefer a single shared panel sizing/overflow rule for draggable HUD windows to avoid panel-specific drift.
+- If adding a new draggable panel id, include it in both:
+  1) desktop shared panel selector,
+  2) mobile `@media (max-width: 920px)` selector.

--- a/rgfn_game/style.css
+++ b/rgfn_game/style.css
@@ -364,29 +364,23 @@ h1 {
     font-weight: 700;
 }
 
-#magic-panel, #inventory-panel, #skills-panel, #quests-panel, #lore-panel, #stats-panel, #selected-panel {
+#magic-panel, #inventory-panel, #skills-panel, #quests-panel, #lore-panel, #stats-panel, #selected-panel, #group-panel,
+#world-sidebar, #battle-sidebar, #village-sidebar, #game-log-container, #village-actions, #village-rumors-section {
     width: min(340px, calc(100vw - 48px));
-    overflow: visible;
-}
-
-#world-sidebar {
-    width: min(340px, calc(100vw - 48px));
-    max-height: min(100%, calc(100dvh - 180px));
+    max-width: calc(100vw - 32px);
+    max-inline-size: calc(100vw - 32px);
+    min-height: 220px;
+    min-inline-size: 260px;
+    max-height: calc(100dvh - 32px);
+    max-block-size: calc(100dvh - 32px);
     overflow: auto;
+    resize: both;
 }
 
 #world-sidebar {
     flex-shrink: 0;
-    max-height: none;
-    overflow: visible;
 }
 #game-log-container {
-    width: min(340px, calc(100vw - 48px));
-    max-width: calc(100vw - 32px);
-    max-inline-size: calc(100vw - 32px);
-    max-height: calc(100dvh - 32px);
-    max-block-size: calc(100dvh - 32px);
-    overflow: hidden;
     align-self: flex-start;
 }
 
@@ -396,25 +390,9 @@ h1 {
     display: none;
 }
 
-#game-log-container {
-    min-height: 220px;
-    height: min(42vh, 360px);
-    min-width: 260px;
-    min-inline-size: 260px;
-    resize: both;
-}
-
 #battle-sidebar {
-    width: min(340px, calc(100vw - 48px));
-    max-width: calc(100vw - 32px);
-    max-inline-size: calc(100vw - 32px);
-    min-height: 220px;
     height: min(42vh, 360px);
-    min-width: 260px;
-    min-inline-size: 260px;
-    overflow: hidden;
     align-self: flex-start;
-    resize: both;
 }
 
 #quests-panel {
@@ -422,17 +400,14 @@ h1 {
     top: 0;
     left: 0;
     transform: translate(var(--panel-offset-x, 0px), var(--panel-offset-y, 0px));
-    max-width: calc(100vw - 32px);
-    max-inline-size: calc(100vw - 32px);
     max-height: none;
     max-block-size: none;
-    min-height: 220px;
     height: min(42vh, 360px);
-    min-width: 260px;
-    min-inline-size: 260px;
-    overflow: hidden;
     align-self: flex-start;
-    resize: both;
+}
+
+#game-log-container {
+    height: min(42vh, 360px);
 }
 
 #game-log-container h3 {
@@ -706,9 +681,8 @@ h1 {
         transform: none;
     }
 
-    #game-log-container,
-    #quests-panel,
-    #battle-sidebar {
+    #magic-panel, #inventory-panel, #skills-panel, #quests-panel, #lore-panel, #stats-panel, #selected-panel, #group-panel,
+    #world-sidebar, #battle-sidebar, #village-sidebar, #game-log-container, #village-actions, #village-rumors-section {
         margin-top: 0;
         height: 260px;
         max-height: 260px;

--- a/rgfn_game/test/systems/scenarios/panelStyles.test.js
+++ b/rgfn_game/test/systems/scenarios/panelStyles.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('HUD panel style rules keep content clipped and panels resizable on desktop', () => {
+  const css = readFileSync(resolve(process.cwd(), 'rgfn_game/style.css'), 'utf8');
+
+  assert.match(css, /#magic-panel, #inventory-panel, #skills-panel, #quests-panel, #lore-panel, #stats-panel, #selected-panel, #group-panel,/);
+  assert.match(css, /overflow:\s*auto;/);
+  assert.match(css, /resize:\s*both;/);
+  assert.match(css, /max-height:\s*calc\(100dvh - 32px\);/);
+});
+
+test('HUD panel style rules disable resizing on narrow viewports', () => {
+  const css = readFileSync(resolve(process.cwd(), 'rgfn_game/style.css'), 'utf8');
+
+  assert.match(css, /@media \(max-width: 920px\)/);
+  assert.match(css, /#magic-panel, #inventory-panel, #skills-panel, #quests-panel, #lore-panel, #stats-panel, #selected-panel, #group-panel,/);
+  assert.match(css, /resize:\s*none;/);
+});


### PR DESCRIPTION
### Motivation
- The Stats panel could render text outside the panel when long formulas or stat rows exceeded the available height, and the desktop resizable behavior for HUD panels had been lost.
- Panels need consistent, fail-safe clipping and sizing so content never bleeds outside borders across all HUD windows and viewport sizes.

### Description
- Updated `rgfn_game/style.css` to unify draggable HUD panel rules: added `overflow: auto`, `resize: both`, viewport bounds (`max-width`/`max-height` / `max-inline-size` / `max-block-size`) and sensible `min-` sizes for stats, skills, inventory, magic, quests, group, lore, selected, world/battle/village sidebars, and log containers.
- Preserved responsive behavior by disabling resizing in the mobile/narrow rule (`@media (max-width: 920px)`) so mobile layout remains fixed.
- Added a regression test `rgfn_game/test/systems/scenarios/panelStyles.test.js` that asserts the desktop clipping+resizable rules and mobile resize disablement are present in the CSS.
- Documented the change and future guidance in `docs/Tasks/rgfn_stats_panel_resizing_and_clipping_fix.md` to make future panel additions follow the shared rule-set.

### Testing
- Ran `npm run test:rgfn` (build + full rgfn test suite): all tests passed (136/136).
- Ran the new targeted tests with `node --test rgfn_game/test/systems/scenarios/panelStyles.test.js`: tests passed (2/2).
- Ran `npm run lint:ts:rgfn`: lint/style-guide audit reported pre-existing repository-wide errors and warnings unrelated to the files changed; no new lint errors were introduced by the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da843277f0832386ee14eb0aadd9e5)