### PR TITLE
RGFN: reduce mid-zoom world map terrain draw spikes

### DIFF
--- a/rgfn_game/docs/world/world-map-performance-notes.md
+++ b/rgfn_game/docs/world/world-map-performance-notes.md
@@ -253,3 +253,37 @@ Proceed to renderer migration when **all** are true after the time-boxed optimiz
   - optionally enable auto-refresh,
   - inspect the live JSON snapshot directly in the panel.
 - This removes the need to keep DevTools console open while testing map movement.
+
+## April 12, 2026 field profiling update (user-provided zoom sweep)
+
+Real in-game profiler sweep across seven zoom levels showed a **mid-zoom frame-time cliff**:
+
+- Closest zoom: `drawTotal.avgMs ~4.58`, `terrainLayer.avgMs ~4.36`
+- 28% out: `drawTotal.avgMs ~5.54`, `terrainLayer.avgMs ~5.21`
+- 42% out: `drawTotal.avgMs ~7.24`, `terrainLayer.avgMs ~6.84`
+- 56% out: `drawTotal.avgMs ~6.83`, `terrainLayer.avgMs ~6.43`
+- 70% out: `drawTotal.avgMs ~10.00`, `terrainLayer.avgMs ~9.55`
+- 84% out: `drawTotal.avgMs ~16.98`, `terrainLayer.avgMs ~16.30` (**worst point**)
+- Farthest zoom: `drawTotal.avgMs ~9.18`, `terrainLayer.avgMs ~7.80`
+
+### Interpretation
+
+- `terrainLayer` dominates total frame cost in every sample.
+- The non-monotonic shape (84% is worse than farthest zoom) indicates a **detail-level transition issue**, not only raw visible-cell growth.
+- In practice, this matches the renderer behavior where the map may switch into `full` detail around that band, re-enabling expensive per-cell neighbor work without cache benefits.
+
+### Follow-up change implemented
+
+- Adjusted detail-level thresholds to keep more mid-zoom states in `medium` detail:
+  - previous medium condition: `cellSize <= 14 || visibleCellCount >= 1400`
+  - new medium condition: `cellSize <= 18 || visibleCellCount >= 900`
+- Goal: avoid entering `full` detail while visible window is still large enough to make per-cell neighbor sampling expensive.
+
+### What to verify next
+
+1. Re-run the same seven zoom checkpoints and compare:
+   - `drawTotal.avgMs`
+   - `terrainLayer.avgMs`
+   - `terrainLayer.maxMs`
+2. Ensure close zoom visuals still look sufficiently rich (full detail should still be used when zoomed in enough).
+3. If needed, tune thresholds one more time using the same profiler protocol rather than subjective feel.

--- a/rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts
+++ b/rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts
@@ -162,7 +162,9 @@ export default class WorldMapVillageNavigationAndRender extends WorldMapMovement
         const visibleRows = Math.max(0, bounds.endRow - bounds.startRow + 1);
         const visibleCellCount = visibleColumns * visibleRows;
         if (this.grid.cellSize <= 10 || (!this.mapDisplayConfig.fogOfWar && visibleCellCount >= 2500)) {return 'low';}
-        if (this.grid.cellSize <= 14 || visibleCellCount >= 1400) {return 'medium';}
+        // Keep medium detail over a wider "mid-zoom" band to avoid expensive full-detail
+        // neighbor sampling on large visible windows (observed profiler spike around ~70-84% zoom).
+        if (this.grid.cellSize <= 18 || visibleCellCount >= 900) {return 'medium';}
         return 'full';
     }
 


### PR DESCRIPTION
### Motivation

- Field profiling showed a non-monotonic frame-time cliff at mid-zoom (worst at ~84%), indicating a detail-level transition hotspot rather than pure map-size scaling.
- The renderer was switching into expensive `full` detail for a band of mid-zoom viewports, re-enabling per-cell neighbor sampling and causing the spike.

### Description

- Widened the medium-detail band in `getRenderDetailLevel` to `cellSize <= 18 || visibleCellCount >= 900` so the renderer stays in cached medium mode longer and avoids entering `full` detail prematurely (`rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts`).
- Added an inline comment next to the threshold explaining the mid-zoom rationale and profiler observation to help future tuning (`getRenderDetailLevel`).
- Documented the April 12, 2026 seven-point zoom profiling sweep, interpretation, implemented follow-up change, and a verification checklist in `rgfn_game/docs/world/world-map-performance-notes.md`.

### Testing

- Ran `npm run build:rgfn` and the build completed successfully.
- Ran the RGFN test suite via `npm run test:rgfn` and the relevant world-map tests passed (all RGFN tests passed in this run).
- Executed targeted test runs with `node --test rgfn_game/test/systems/worldMap.test.js rgfn_game/test/systems/scenarios/worldMapRenderer.test.js` and they passed.
- Ran `npx eslint` against the modified file with `npx eslint rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts --ext .ts` and it reported no errors for the touched file, while `npm run lint:ts:rgfn` still fails due to a pre-existing unrelated style-guide error in `rgfn_game/js/systems/village/VillageDialogueEngine.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd14d29b48323a71335d0ff9d274b)