### PR TITLE
RGFN: add world profiling render-layer checkboxes and draw gating

### DIFF
--- a/rgfn_game/docs/world/world-map-performance-notes.md
+++ b/rgfn_game/docs/world/world-map-performance-notes.md
@@ -287,3 +287,38 @@ Real in-game profiler sweep across seven zoom levels showed a **mid-zoom frame-t
    - `terrainLayer.maxMs`
 2. Ensure close zoom visuals still look sufficiently rich (full detail should still be used when zoomed in enough).
 3. If needed, tune thresholds one more time using the same profiler protocol rather than subjective feel.
+
+## April 12, 2026 update: world-profiling render-layer checkboxes for isolation tests
+
+Added five independent render-layer toggles to the **World Map Profiling** panel so QA can profile stage costs and machine thermals in controlled combinations:
+
+- `Render terrain`
+- `Render character marker`
+- `Render locations`
+- `Render roads`
+- `Render selection cursor`
+
+### Behavior details
+
+- Each toggle immediately updates world-map rendering behavior at runtime.
+- Toggling does **not** require reopening the profiling panel.
+- If all five toggles are off, world-map draw path now short-circuits to a blank canvas (`clearRect`) and skips layer rendering entirely.
+- Profiling JSON now includes a `renderLayers` object so recorded snapshots explicitly show which layers were enabled during capture.
+
+### Practical profiling recipes
+
+1. **Terrain-only baseline**
+   - Enable only `Render terrain`.
+   - Use this as primary baseline for draw-time + CPU load comparisons.
+2. **Overlays-only impact**
+   - Disable terrain, enable locations/roads/markers selectively.
+   - Useful for measuring non-terrain overhead independently.
+3. **Blank-canvas thermal/control state**
+   - Disable all five toggles.
+   - Confirms idle/global-map-overhead floor while world mode stays active.
+
+### Related automated coverage
+
+- Added tests to verify:
+  - all-layer-off mode produces a blank map draw path (no background draw, explicit clear),
+  - character marker and selection cursor toggles are independently respected.

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -429,6 +429,14 @@
                 <label class="dev-events-toggle" for="dev-world-map-profiling-enabled"><input id="dev-world-map-profiling-enabled" type="checkbox"> Enable world-map draw profiling (resets counters on enable)</label>
                 <label class="dev-events-toggle" for="dev-world-map-profiling-auto-refresh"><input id="dev-world-map-profiling-auto-refresh" type="checkbox"> Auto-refresh values (every ~0.75s)</label>
             </div>
+            <p class="dev-events-hint dev-events-hint-tight">Layer toggles for CPU/render isolation profiling (turn all off for a fully blank global map).</p>
+            <div class="dev-events-toggle-grid dev-events-toggle-grid-single">
+                <label class="dev-events-toggle" for="dev-world-map-render-terrain"><input id="dev-world-map-render-terrain" type="checkbox" checked> Render terrain</label>
+                <label class="dev-events-toggle" for="dev-world-map-render-character"><input id="dev-world-map-render-character" type="checkbox" checked> Render character marker</label>
+                <label class="dev-events-toggle" for="dev-world-map-render-locations"><input id="dev-world-map-render-locations" type="checkbox" checked> Render locations</label>
+                <label class="dev-events-toggle" for="dev-world-map-render-roads"><input id="dev-world-map-render-roads" type="checkbox" checked> Render roads</label>
+                <label class="dev-events-toggle" for="dev-world-map-render-selection-cursor"><input id="dev-world-map-render-selection-cursor" type="checkbox" checked> Render selection cursor</label>
+            </div>
             <div class="dev-roll-actions">
                 <button id="dev-world-map-profiling-refresh-btn" class="action-btn" type="button">Refresh Profiling Snapshot</button>
             </div>

--- a/rgfn_game/js/game/GameRuntimeAssembly.ts
+++ b/rgfn_game/js/game/GameRuntimeAssembly.ts
@@ -60,6 +60,8 @@ const createDevController = (
     isWorldMapDrawProfilingEnabled: () => worldMap.isDrawProfilingEnabled(),
     resetWorldMapDrawProfiling: () => worldMap.resetDrawProfiling(),
     getWorldMapDrawProfilingSnapshot: () => worldMap.getDrawProfilingSnapshot(),
+    setWorldMapRenderLayerToggles: (toggles) => worldMap.setRenderLayerToggles(toggles),
+    getWorldMapRenderLayerToggles: () => worldMap.getRenderLayerToggles(),
 });
 
 // eslint-disable-next-line style-guide/function-length-warning

--- a/rgfn_game/js/systems/encounter/DeveloperEventController.ts
+++ b/rgfn_game/js/systems/encounter/DeveloperEventController.ts
@@ -46,6 +46,7 @@ export default class DeveloperEventController {
         this.randomAndMapControls.renderMapDisplayControls();
         this.developerUI.developerModeToggle.checked = getDeveloperModeConfig().enabled;
         this.developerUI.worldMapProfilingToggle.checked = this.callbacks.isWorldMapDrawProfilingEnabled();
+        this.syncWorldMapRenderLayerTogglesFromMap();
         this.renderWorldMapProfilingPanel();
     }
 
@@ -155,6 +156,7 @@ export default class DeveloperEventController {
         }
         this.ensureWorldMapProfilingPanelSpawnPosition();
         this.developerUI.worldMapProfilingToggle.checked = this.callbacks.isWorldMapDrawProfilingEnabled();
+        this.syncWorldMapRenderLayerTogglesFromMap();
         this.renderWorldMapProfilingPanel();
     }
 
@@ -169,6 +171,12 @@ export default class DeveloperEventController {
             return;
         }
         this.startWorldMapProfilingAutoRefresh();
+    }
+
+    public handleWorldMapRenderLayerToggle(layer: 'terrain' | 'character' | 'locations' | 'roads' | 'selectionCursor', enabled: boolean): void {
+        this.callbacks.setWorldMapRenderLayerToggles({ [layer]: enabled });
+        this.callbacks.addVillageLog(`[DEV] World-map render layer "${layer}" ${enabled ? 'enabled' : 'disabled'}.`, 'system');
+        this.renderWorldMapProfilingPanel();
     }
 
     private startWorldMapProfilingAutoRefresh(): void {
@@ -188,8 +196,22 @@ export default class DeveloperEventController {
 
     public renderWorldMapProfilingPanel(): void {
         const snapshot = this.callbacks.getWorldMapDrawProfilingSnapshot();
-        const payload = { capturedAt: new Date().toISOString(), profilingEnabled: this.callbacks.isWorldMapDrawProfilingEnabled(), sections: snapshot };
+        const payload = {
+            capturedAt: new Date().toISOString(),
+            profilingEnabled: this.callbacks.isWorldMapDrawProfilingEnabled(),
+            renderLayers: this.callbacks.getWorldMapRenderLayerToggles(),
+            sections: snapshot,
+        };
         this.developerUI.worldMapProfilingOutput.textContent = JSON.stringify(payload, null, 2);
+    }
+
+    private syncWorldMapRenderLayerTogglesFromMap(): void {
+        const toggles = this.callbacks.getWorldMapRenderLayerToggles();
+        this.developerUI.worldMapProfilingRenderLayerToggles.terrain.checked = toggles.terrain;
+        this.developerUI.worldMapProfilingRenderLayerToggles.character.checked = toggles.character;
+        this.developerUI.worldMapProfilingRenderLayerToggles.locations.checked = toggles.locations;
+        this.developerUI.worldMapProfilingRenderLayerToggles.roads.checked = toggles.roads;
+        this.developerUI.worldMapProfilingRenderLayerToggles.selectionCursor.checked = toggles.selectionCursor;
     }
 
     private ensureWorldMapProfilingPanelSpawnPosition(): void {

--- a/rgfn_game/js/systems/encounter/DeveloperEventTypes.ts
+++ b/rgfn_game/js/systems/encounter/DeveloperEventTypes.ts
@@ -27,6 +27,13 @@ export type DeveloperUI = {
     worldMapProfilingCloseBtn: HTMLButtonElement;
     worldMapProfilingRefreshBtn: HTMLButtonElement;
     worldMapProfilingAutoRefreshToggle: HTMLInputElement;
+    worldMapProfilingRenderLayerToggles: {
+        terrain: HTMLInputElement;
+        character: HTMLInputElement;
+        locations: HTMLInputElement;
+        roads: HTMLInputElement;
+        selectionCursor: HTMLInputElement;
+    };
     worldMapProfilingOutput: HTMLElement;
 };
 
@@ -41,6 +48,20 @@ export type DeveloperCallbacks = {
     isWorldMapDrawProfilingEnabled: () => boolean;
     resetWorldMapDrawProfiling: () => void;
     getWorldMapDrawProfilingSnapshot: () => WorldMapDrawProfilingSnapshot;
+    setWorldMapRenderLayerToggles: (toggles: Partial<{
+        terrain: boolean;
+        character: boolean;
+        locations: boolean;
+        roads: boolean;
+        selectionCursor: boolean;
+    }>) => void;
+    getWorldMapRenderLayerToggles: () => {
+        terrain: boolean;
+        character: boolean;
+        locations: boolean;
+        roads: boolean;
+        selectionCursor: boolean;
+    };
 };
 
 export const ENCOUNTER_LABELS: Record<RandomEncounterType, string> = { monster: 'Monster', item: 'Item', traveler: 'Traveler' };

--- a/rgfn_game/js/systems/game/runtime/GameDeveloperUiFactory.ts
+++ b/rgfn_game/js/systems/game/runtime/GameDeveloperUiFactory.ts
@@ -1,8 +1,15 @@
 import { DeveloperUI } from '../ui/GameUiTypes.js';
 
 export class GameDeveloperUiFactory {
-    // eslint-disable-next-line style-guide/function-length-warning
-    public create = (): DeveloperUI => ({
+    public create = (): DeveloperUI => ({ ...this.createBaseDeveloperUi(), ...this.createProfilingUi() });
+
+    private readonly createBaseDeveloperUi = (): Omit<DeveloperUI, 'worldMapProfilingToggle' | 'worldMapProfilingOpenBtn' | 'worldMapProfilingPanel' | 'worldMapProfilingDragHandle' | 'worldMapProfilingCloseBtn' | 'worldMapProfilingRefreshBtn' | 'worldMapProfilingAutoRefreshToggle' | 'worldMapProfilingRenderLayerToggles' | 'worldMapProfilingOutput'> => ({
+        ...this.createQueueAndEncounterUi(),
+        ...this.createNextRollAndRandomUi(),
+        ...this.createModeAndMapDisplayUi(),
+    });
+
+    private readonly createQueueAndEncounterUi = (): Pick<DeveloperUI, 'modal' | 'closeBtn' | 'eventType' | 'queueList' | 'addBtn' | 'clearBtn' | 'encounterTypeSummary' | 'enableAllEncountersBtn' | 'disableAllEncountersBtn' | 'encounterTypeToggles'> => ({
         modal: document.getElementById('dev-events-modal')!,
         closeBtn: document.getElementById('dev-events-close-btn')! as HTMLButtonElement,
         eventType: document.getElementById('dev-event-type')! as HTMLSelectElement,
@@ -13,6 +20,9 @@ export class GameDeveloperUiFactory {
         enableAllEncountersBtn: document.getElementById('dev-encounter-types-enable-all-btn')! as HTMLButtonElement,
         disableAllEncountersBtn: document.getElementById('dev-encounter-types-disable-all-btn')! as HTMLButtonElement,
         encounterTypeToggles: this.createEncounterTypeToggles(),
+    });
+
+    private readonly createNextRollAndRandomUi = (): Pick<DeveloperUI, 'nextRollOpenBtn' | 'nextRollSummary' | 'nextRollModal' | 'nextRollCloseBtn' | 'nextRollTotal' | 'nextRollStatus' | 'nextRollSaveBtn' | 'nextRollClearBtn' | 'nextRollInputs' | 'randomModeSelect' | 'randomSeedInput' | 'randomSummary' | 'randomStatus' | 'randomApplyBtn'> => ({
         nextRollOpenBtn: document.getElementById('dev-next-roll-open-btn')! as HTMLButtonElement,
         nextRollSummary: document.getElementById('dev-next-roll-summary')!,
         nextRollModal: document.getElementById('dev-next-roll-modal')!,
@@ -27,9 +37,15 @@ export class GameDeveloperUiFactory {
         randomSummary: document.getElementById('dev-random-summary')!,
         randomStatus: document.getElementById('dev-random-status')!,
         randomApplyBtn: document.getElementById('dev-random-apply-btn')! as HTMLButtonElement,
+    });
+
+    private readonly createModeAndMapDisplayUi = (): Pick<DeveloperUI, 'developerModeToggle' | 'everythingDiscoveredToggle' | 'fogOfWarToggle'> => ({
         developerModeToggle: document.getElementById('dev-mode-enabled')! as HTMLInputElement,
         everythingDiscoveredToggle: document.getElementById('dev-map-display-everything-discovered')! as HTMLInputElement,
         fogOfWarToggle: document.getElementById('dev-map-display-fog-of-war')! as HTMLInputElement,
+    });
+
+    private readonly createProfilingUi = (): Pick<DeveloperUI, 'worldMapProfilingToggle' | 'worldMapProfilingOpenBtn' | 'worldMapProfilingPanel' | 'worldMapProfilingDragHandle' | 'worldMapProfilingCloseBtn' | 'worldMapProfilingRefreshBtn' | 'worldMapProfilingAutoRefreshToggle' | 'worldMapProfilingRenderLayerToggles' | 'worldMapProfilingOutput'> => ({
         worldMapProfilingToggle: document.getElementById('dev-world-map-profiling-enabled')! as HTMLInputElement,
         worldMapProfilingOpenBtn: document.getElementById('dev-world-map-profiling-open-btn')! as HTMLButtonElement,
         worldMapProfilingPanel: document.getElementById('dev-world-map-profiling-panel')!,
@@ -37,6 +53,7 @@ export class GameDeveloperUiFactory {
         worldMapProfilingCloseBtn: document.getElementById('dev-world-map-profiling-close-btn')! as HTMLButtonElement,
         worldMapProfilingRefreshBtn: document.getElementById('dev-world-map-profiling-refresh-btn')! as HTMLButtonElement,
         worldMapProfilingAutoRefreshToggle: document.getElementById('dev-world-map-profiling-auto-refresh')! as HTMLInputElement,
+        worldMapProfilingRenderLayerToggles: this.createWorldMapProfilingRenderLayerToggles(),
         worldMapProfilingOutput: document.getElementById('dev-world-map-profiling-output')!,
     });
 
@@ -53,5 +70,13 @@ export class GameDeveloperUiFactory {
         agility: document.getElementById('dev-next-roll-agility')! as HTMLInputElement,
         connection: document.getElementById('dev-next-roll-connection')! as HTMLInputElement,
         intelligence: document.getElementById('dev-next-roll-intelligence')! as HTMLInputElement,
+    });
+
+    private readonly createWorldMapProfilingRenderLayerToggles = (): DeveloperUI['worldMapProfilingRenderLayerToggles'] => ({
+        terrain: document.getElementById('dev-world-map-render-terrain')! as HTMLInputElement,
+        character: document.getElementById('dev-world-map-render-character')! as HTMLInputElement,
+        locations: document.getElementById('dev-world-map-render-locations')! as HTMLInputElement,
+        roads: document.getElementById('dev-world-map-render-roads')! as HTMLInputElement,
+        selectionCursor: document.getElementById('dev-world-map-render-selection-cursor')! as HTMLInputElement,
     });
 }

--- a/rgfn_game/js/systems/game/ui/GameUiDevStatBinder.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiDevStatBinder.ts
@@ -42,6 +42,7 @@ export default class GameUiDevStatBinder {
         this.developerUI.worldMapProfilingToggle.addEventListener('change', () => this.developerEventController.handleWorldMapDrawProfilingToggle(this.developerUI.worldMapProfilingToggle.checked));
         this.developerUI.worldMapProfilingRefreshBtn.addEventListener('click', () => this.developerEventController.handleWorldMapProfilingRefresh());
         this.developerUI.worldMapProfilingAutoRefreshToggle.addEventListener('change', () => this.developerEventController.handleWorldMapProfilingAutoRefreshToggle(this.developerUI.worldMapProfilingAutoRefreshToggle.checked));
+        this.bindWorldMapRenderLayerToggleEvents();
         Object.values(this.developerUI.nextRollInputs).forEach((input) => {
             input.addEventListener('input', () => this.developerEventController.handleNextCharacterRollInputChanged());
         });
@@ -55,6 +56,15 @@ export default class GameUiDevStatBinder {
         Object.entries(this.developerUI.encounterTypeToggles).forEach(([type, input]) => {
             input.addEventListener('change', () => this.developerEventController.handleEncounterTypeToggle(type as RandomEncounterType, input.checked));
         });
+    }
+
+    private bindWorldMapRenderLayerToggleEvents(): void {
+        const toggles = this.developerUI.worldMapProfilingRenderLayerToggles;
+        toggles.terrain.addEventListener('change', () => this.developerEventController.handleWorldMapRenderLayerToggle('terrain', toggles.terrain.checked));
+        toggles.character.addEventListener('change', () => this.developerEventController.handleWorldMapRenderLayerToggle('character', toggles.character.checked));
+        toggles.locations.addEventListener('change', () => this.developerEventController.handleWorldMapRenderLayerToggle('locations', toggles.locations.checked));
+        toggles.roads.addEventListener('change', () => this.developerEventController.handleWorldMapRenderLayerToggle('roads', toggles.roads.checked));
+        toggles.selectionCursor.addEventListener('change', () => this.developerEventController.handleWorldMapRenderLayerToggle('selectionCursor', toggles.selectionCursor.checked));
     }
 
     private handleMapDisplayToggle(type: 'everythingDiscovered' | 'fogOfWar'): void {

--- a/rgfn_game/js/systems/game/ui/GameUiDeveloperModels.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiDeveloperModels.ts
@@ -37,6 +37,13 @@ export class DeveloperUiModel {
     public worldMapProfilingCloseBtn!: HTMLButtonElement;
     public worldMapProfilingRefreshBtn!: HTMLButtonElement;
     public worldMapProfilingAutoRefreshToggle!: HTMLInputElement;
+    public worldMapProfilingRenderLayerToggles!: {
+        terrain: HTMLInputElement;
+        character: HTMLInputElement;
+        locations: HTMLInputElement;
+        roads: HTMLInputElement;
+        selectionCursor: HTMLInputElement;
+    };
     public worldMapProfilingOutput!: HTMLElement;
 }
 

--- a/rgfn_game/js/systems/world/worldMap/WorldMapCore.ts
+++ b/rgfn_game/js/systems/world/worldMap/WorldMapCore.ts
@@ -62,6 +62,14 @@ type DrawProfileStats = {
     lastFrameMs: number;
 };
 
+type WorldMapRenderLayerToggles = {
+    terrain: boolean;
+    roads: boolean;
+    locations: boolean;
+    character: boolean;
+    selectionCursor: boolean;
+};
+
 export default class WorldMapCore {
     private grid: GridMap;
     private playerGridPos: GridPosition;
@@ -90,6 +98,7 @@ export default class WorldMapCore {
     private terrainRevision: number;
     private drawProfilingEnabled: boolean;
     private drawProfileStats: Record<'drawTotal' | 'terrainLayer' | 'roads' | 'locationFeatures' | 'namedLocations' | 'dayNightTint' | 'focusOverlay' | 'markers', DrawProfileStats>;
+    protected renderLayerToggles: WorldMapRenderLayerToggles;
     protected daylightFactor: number;
 
     constructor(columns: number, rows: number, cellSize: number) {
@@ -125,10 +134,18 @@ export default class WorldMapCore {
         this.terrainRevision = 0;
         this.drawProfilingEnabled = false;
         this.drawProfileStats = this.createEmptyDrawProfileStats();
+        this.renderLayerToggles = this.createDefaultRenderLayerToggles();
         this.daylightFactor = 1;
     }
 
     private readonly createEmptyStat = (): DrawProfileStats => ({ frames: 0, totalMs: 0, maxMs: 0, lastFrameMs: 0 });
+    private readonly createDefaultRenderLayerToggles = (): WorldMapRenderLayerToggles => ({
+        terrain: true,
+        roads: true,
+        locations: true,
+        character: true,
+        selectionCursor: true,
+    });
 
     private readonly createEmptyDrawProfileStats = (): Record<'drawTotal' | 'terrainLayer' | 'roads' | 'locationFeatures' | 'namedLocations' | 'dayNightTint' | 'focusOverlay' | 'markers', DrawProfileStats> => ({
         drawTotal: this.createEmptyStat(),
@@ -174,6 +191,12 @@ export default class WorldMapCore {
         });
         return snapshot;
     }
+
+    public setRenderLayerToggles = (toggles: Partial<WorldMapRenderLayerToggles>): void => {
+        this.renderLayerToggles = { ...this.renderLayerToggles, ...toggles };
+    };
+
+    public getRenderLayerToggles = (): WorldMapRenderLayerToggles => ({ ...this.renderLayerToggles });
 
     public setDaylightFactor(factor: number): void {
         if (!Number.isFinite(factor)) {

--- a/rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts
+++ b/rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts
@@ -170,18 +170,58 @@ export default class WorldMapVillageNavigationAndRender extends WorldMapMovement
 
     public draw(ctx: CanvasRenderingContext2D, _renderer: any): void {
         this.profileSection('drawTotal', () => {
-            this.renderer.drawBackground(ctx, this.canvasWidth, this.canvasHeight);
+            if (this.areAllRenderLayersDisabled()) {
+                ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
+                return;
+            }
             const bounds = this.getVisibleBounds();
             const detailLevel = this.getRenderDetailLevel(bounds);
-            this.profileSection('terrainLayer', () => this.drawTerrainLayer(ctx, bounds, detailLevel));
-            this.profileSection('roads', () => this.drawVillageRoads(ctx, bounds));
-            this.profileSection('locationFeatures', () => this.drawLocationFeatures(ctx, bounds));
-            this.profileSection('namedLocations', () => this.drawNamedLocations(ctx, bounds));
-            this.profileSection('dayNightTint', () => this.drawDayNightTint(ctx));
-            this.profileSection('focusOverlay', () => this.drawNamedLocationFocus(ctx));
+            this.renderer.drawBackground(ctx, this.canvasWidth, this.canvasHeight);
+            this.drawOptionalTerrainLayers(ctx, bounds, detailLevel);
+            this.drawOptionalRoadLayer(ctx, bounds);
+            this.drawOptionalLocationLayers(ctx, bounds);
             this.profileSection('markers', () => this.drawMarkers(ctx));
-            this.renderer.drawScaleLegend(ctx, this.grid, `${theme.worldMap.cellTravelMinutes} min walk / cell`, this.canvasWidth, this.canvasHeight);
+            this.drawOptionalScaleLegend(ctx);
         });
+    }
+
+    private readonly areAllRenderLayersDisabled = (): boolean => !this.renderLayerToggles.terrain
+            && !this.renderLayerToggles.roads
+            && !this.renderLayerToggles.locations
+            && !this.renderLayerToggles.character
+            && !this.renderLayerToggles.selectionCursor;
+
+    private drawOptionalTerrainLayers(
+        ctx: CanvasRenderingContext2D,
+        bounds: { startCol: number; endCol: number; startRow: number; endRow: number },
+        detailLevel: 'full' | 'medium' | 'low',
+    ): void {
+        if (!this.renderLayerToggles.terrain) {
+            return;
+        }
+        this.profileSection('terrainLayer', () => this.drawTerrainLayer(ctx, bounds, detailLevel));
+        this.profileSection('dayNightTint', () => this.drawDayNightTint(ctx));
+    }
+
+    private drawOptionalRoadLayer(ctx: CanvasRenderingContext2D, bounds: { startCol: number; endCol: number; startRow: number; endRow: number }): void {
+        if (this.renderLayerToggles.roads) {
+            this.profileSection('roads', () => this.drawVillageRoads(ctx, bounds));
+        }
+    }
+
+    private drawOptionalLocationLayers(ctx: CanvasRenderingContext2D, bounds: { startCol: number; endCol: number; startRow: number; endRow: number }): void {
+        if (!this.renderLayerToggles.locations) {
+            return;
+        }
+        this.profileSection('locationFeatures', () => this.drawLocationFeatures(ctx, bounds));
+        this.profileSection('namedLocations', () => this.drawNamedLocations(ctx, bounds));
+        this.profileSection('focusOverlay', () => this.drawNamedLocationFocus(ctx));
+    }
+
+    private drawOptionalScaleLegend(ctx: CanvasRenderingContext2D): void {
+        if (this.renderLayerToggles.terrain) {
+            this.renderer.drawScaleLegend(ctx, this.grid, `${theme.worldMap.cellTravelMinutes} min walk / cell`, this.canvasWidth, this.canvasHeight);
+        }
     }
 
     private drawDayNightTint(ctx: CanvasRenderingContext2D): void {
@@ -232,10 +272,14 @@ export default class WorldMapVillageNavigationAndRender extends WorldMapMovement
     }
 
     private drawMarkers(ctx: CanvasRenderingContext2D): void {
-        const playerCell = this.grid.getCellAt(this.playerGridPos.col, this.playerGridPos.row);
-        if (playerCell) {this.renderer.drawPlayerMarker(ctx, playerCell);}
+        if (this.renderLayerToggles.character) {
+            const playerCell = this.grid.getCellAt(this.playerGridPos.col, this.playerGridPos.row);
+            if (playerCell) {this.renderer.drawPlayerMarker(ctx, playerCell);}
+        }
         const selectedCell = this.selectedGridPos ? this.grid.getCellAt(this.selectedGridPos.col, this.selectedGridPos.row) : null;
-        if (selectedCell) {this.renderer.drawCursorMarker(ctx, selectedCell, this.isCellVisible(selectedCell.col, selectedCell.row));}
+        if (this.renderLayerToggles.selectionCursor && selectedCell) {
+            this.renderer.drawCursorMarker(ctx, selectedCell, this.isCellVisible(selectedCell.col, selectedCell.row));
+        }
     }
 
 }

--- a/rgfn_game/test/systems/worldMap.test.js
+++ b/rgfn_game/test/systems/worldMap.test.js
@@ -320,6 +320,61 @@ test('WorldMap draw renders visible terrain, fog and grid without throwing on a 
   assert.ok(ctx.calls.some(c => c[0] === 'stroke'));
 });
 
+test('WorldMap render layer toggles can fully blank the global map draw output', () => {
+  const worldMap = new WorldMap(30, 20, theme.worldMap.cellSize.default);
+  worldMap.resizeToCanvas(720, 720);
+  const ctx = createMockCanvasContext();
+  ctx.clearRect = (...args) => ctx.calls.push(['clearRect', ...args]);
+  let drawBackgroundCalls = 0;
+  const originalDrawBackground = worldMap.renderer.drawBackground.bind(worldMap.renderer);
+  worldMap.renderer.drawBackground = (...args) => {
+    drawBackgroundCalls += 1;
+    return originalDrawBackground(...args);
+  };
+
+  worldMap.setRenderLayerToggles({
+    terrain: false,
+    roads: false,
+    locations: false,
+    character: false,
+    selectionCursor: false,
+  });
+
+  worldMap.draw(ctx, null);
+
+  assert.equal(drawBackgroundCalls, 0);
+  assert.ok(ctx.calls.some((call) => call[0] === 'clearRect'));
+});
+
+test('WorldMap render layer toggles independently control character and selection cursor markers', () => {
+  const worldMap = new WorldMap(30, 20, theme.worldMap.cellSize.default);
+  worldMap.resizeToCanvas(720, 720);
+  placePlayerAt(worldMap, 4, 4);
+  worldMap.selectedGridPos = { col: 5, row: 5 };
+  worldMap.setMapDisplayConfig({ everythingDiscovered: true, fogOfWar: false });
+
+  const playerCalls = [];
+  const cursorCalls = [];
+  const originalDrawPlayerMarker = worldMap.renderer.drawPlayerMarker.bind(worldMap.renderer);
+  const originalDrawCursorMarker = worldMap.renderer.drawCursorMarker.bind(worldMap.renderer);
+  worldMap.renderer.drawPlayerMarker = (...args) => {
+    playerCalls.push(args);
+    return originalDrawPlayerMarker(...args);
+  };
+  worldMap.renderer.drawCursorMarker = (...args) => {
+    cursorCalls.push(args);
+    return originalDrawCursorMarker(...args);
+  };
+
+  worldMap.setRenderLayerToggles({ character: false, selectionCursor: true });
+  worldMap.draw(createMockCanvasContext(), null);
+  worldMap.setRenderLayerToggles({ character: true, selectionCursor: false });
+  worldMap.draw(createMockCanvasContext(), null);
+
+  assert.equal(playerCalls.length, 1);
+  assert.equal(cursorCalls.length, 1);
+});
+
 test('WorldMap draw profiling exposes section timing snapshots', () => {
   const worldMap = new WorldMap(60, 45, theme.worldMap.cellSize.default);
   worldMap.resizeToCanvas(720, 720);


### PR DESCRIPTION
### Motivation
- Provide fine-grained control over world-map rendering so profiling can isolate CPU/thermal cost of terrain, locations, roads, character marker and the selection cursor. 
- Allow QA to produce a fully blank global map (all layers off) to measure baseline overhead and to test combinations during thermal/profile sweeps.

### Description
- Added five new checkboxes to the Developer "World map profiling" panel (`dev-world-map-render-terrain`, `dev-world-map-render-character`, `dev-world-map-render-locations`, `dev-world-map-render-roads`, `dev-world-map-render-selection-cursor`) and the related UI factory/binder models. 
- Exposed `setRenderLayerToggles` / `getRenderLayerToggles` on `WorldMapCore` with sensible defaults and used the toggles to gate per-layer draw calls in `WorldMapVillageNavigationAndRender` (terrain, day/night tint, roads, location features, named locations, scale legend, character marker, selection cursor). 
- Short-circuited draw path to `clearRect` and early-return when all five toggles are off so the global map can be fully blank for isolation tests. 
- Extended developer callbacks and runtime wiring so the profiling panel can set/get render-layer state and included the active `renderLayers` object in the profiling JSON payload produced by the developer panel. 
- Added automated tests to verify the blank-map behavior and independent character vs selection-cursor toggling, and updated world-map performance notes with practical profiling recipes and behavior details. 
- Fixed linter warnings raised by the new code (restructured factory helpers and small signature formatting fixes) to keep files lint-clean.

### Testing
- Ran the RGFN build with `npm run build:rgfn` and the build succeeded. 
- Ran the linter on modified files with `npx eslint ...` and addressed reported warnings or errors so the modified files pass the targeted lint checks. 
- Ran the full RGFN test suite with `npm run test:rgfn`; the suite reported one unrelated/faky existing failure in an `EncounterSystem` test (expected battle vs "none") while all world-map related tests passed. 
- Ran the world-map focused tests directly with `node --test rgfn_game/test/systems/worldMap.test.js rgfn_game/test/systems/scenarios/worldMapRenderer.test.js` and the new tests (blank-map gating and marker/cursor toggles) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd4de74648323aa6c44aa0297c034)