### PR TITLE
docs: enforce no-lint-suppression rule across contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,27 @@ npm test
 
 If lint reports any errors, fix them immediately and rerun lint before publishing the result.
 
+## 🚨 Super Important Rule: Never suppress linter diagnostics
+
+Lint suppressions are prohibited in this repository. This includes any line-level, block-level, file-level, or config-level disabling of linter warnings/errors/rules.
+
+Examples of prohibited patterns (non-exhaustive):
+
+- `eslint-disable`
+- `eslint-disable-next-line`
+- `eslint-disable-line`
+- `@ts-ignore` used to bypass lint/style signals
+- Any equivalent "disable rule" comment for style-guide rules
+
+From now on, when a suppression line is encountered:
+
+1. Remove the suppression line.
+2. Run lint.
+3. Fix the actual reported problem by changing code (refactor/extract/reformat/rename/simplify), not by muting diagnostics.
+4. Re-run lint and tests until clean.
+
+This applies to all tasks and all touched files. Code is not considered done if suppressions remain or if lint warnings/errors are left unresolved in touched code.
+
 Detailed policy and Style Guide mapping: `docs/TypeScript_Linter_Workflow.md`.
 
 ## Game-scoped linting (RGFN-only tasks)

--- a/docs/Agent_PrePR_Checklist.md
+++ b/docs/Agent_PrePR_Checklist.md
@@ -6,6 +6,9 @@ This file is a hard reminder for every future task.
 
 1. Run the correct lint scope for touched code.
 2. Fix all lint errors/warnings that are in scope for the task.
+   - Super important: never disable lint/style rules to make output clean.
+   - Remove any suppression lines you encounter (`eslint-disable*`, equivalent rule-disable comments, etc.).
+   - Fix root causes in code (refactor/extract/reformat) and then re-run lint.
 3. Run style-guide audit and drive these to zero for active RGFN refactor tasks:
    - Rule 3 (file <= 200 lines) violations
    - Rule 2 (named function <= 20 lines) potential violations

--- a/docs/TypeScript_Linter_Workflow.md
+++ b/docs/TypeScript_Linter_Workflow.md
@@ -8,10 +8,23 @@ Mandatory expectation for every change:
 
 1. Run the TypeScript linter.
 2. Review the results.
-3. Fix all blocking lint errors.
+3. Fix all lint warnings/errors in touched code by changing implementation (refactor/extract/reformat), not by disabling rules.
 4. Re-run lint until it is clean.
 5. Run tests.
 6. Only then prepare code for review.
+
+## 🚨 Super Important Rule: No linter suppression policy
+
+Do not disable linter warnings/errors/rules in code or config. Suppression comments are not an acceptable fix.
+
+If you see any suppression line (for example `eslint-disable*`, style-rule disable markers, or similar), treat it as technical debt that must be removed in active work:
+
+1. Delete the suppression line.
+2. Run lint for the proper scope.
+3. Fix root causes (long function/file, arrow style, naming, formatting, extraction, etc.).
+4. Re-run lint and tests until clean.
+
+Policy intent: we improve code through refactoring rather than muting diagnostics, and we keep touched files compliant.
 
 
 ## Non-negotiable pre-result reminder
@@ -64,6 +77,8 @@ Before publishing any code changes:
 5. Include lint/test command output summary in task notes or PR.
 
 If lint reports errors, code is **not ready** for review.
+
+If lint reports warnings in touched code and they are fixable via refactor/formatting, code is also **not ready** for review.
 
 ## How this maps to `docs/Style_Guide.txt` (17 rules)
 


### PR DESCRIPTION
### Motivation

- Make the repository contribution policy unambiguous: linter diagnostics must not be muted and must be addressed by changing the code. 
- Encourage long-term code quality by requiring refactors/formatting/extractions instead of suppression comments when touched files show lint issues.

### Description

- Added a new "Super Important Rule" to `CONTRIBUTING.md` that prohibits any linter suppression comments (for example `eslint-disable*`, `@ts-ignore`) and prescribes removing suppression lines and fixing the root cause in code. 
- Strengthened `docs/TypeScript_Linter_Workflow.md` to require fixing warnings/errors in touched code by changing implementation (refactor/extract/reformat) and added an explicit no-suppression remediation sequence. 
- Updated `docs/Agent_PrePR_Checklist.md` to make removal of suppression lines and root-cause fixes a mandatory pre-PR step. 
- This is a documentation-only change and does not modify runtime code.

### Testing

- Ran `npm run check:ts-style` and observed it complete with lint output, but it failed due to pre-existing repository-wide lint errors/warnings (350 problems reported). 
- Ran `npm test` and observed test failures in the existing baseline caused by missing built `dist/` artifacts and other pre-existing issues; tests did not pass. 
- These failures are baseline repository issues and are unrelated to this docs-only PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbeb3de2d883239a1431c889228d76)