### PR TITLE
Improve RGFN HUD panel recovery by adding draggable panel borders

### DIFF
--- a/rgfn_game/CODING_GUIDELINES.md
+++ b/rgfn_game/CODING_GUIDELINES.md
@@ -237,6 +237,12 @@ Why: several enemy archetypes reuse shared classes (for example Ninja can be imp
 - On each panel drag/toggle/style change, the active context layout is immediately saved.
 - On mode switches, the previous context is saved first, then the target context is restored.
 - If no saved layout exists for the target context, panels reset to default spawn positions instead of reusing positions from the previous mode.
+- Draggable HUD windows support two drag-entry surfaces:
+  - The panel title bar (`.panel-drag-handle`), as before.
+  - Any edge border strip of the panel (top/right/bottom/left), so partially off-screen windows can still be recovered.
+- Bottom-right resize affordance remains the highest-priority interaction area:
+  - The resize corner does **not** start drag handling.
+  - Native CSS `resize: both` behavior should continue to work unchanged on desktop panels.
 
 ### Pattern 1: Canvas Drawing
 

--- a/rgfn_game/docs/ui/hud-panel-border-dragging-2026-04-12.md
+++ b/rgfn_game/docs/ui/hud-panel-border-dragging-2026-04-12.md
@@ -1,0 +1,41 @@
+# HUD panel border dragging usability update (April 12, 2026)
+
+## Problem statement
+
+- HUD panels were only draggable from the title drag handle area.
+- If a panel was restored or moved so that the title area was out of view, players could hit a dead-end state where:
+  - the panel remained open,
+  - the close button was unreachable,
+  - and the panel could not be moved back into view.
+
+## Behavior change
+
+- Panels now support drag start from **all four panel borders** (top/right/bottom/left) in addition to the existing title handle.
+- This adds a rescue interaction for partially off-screen windows while keeping the familiar title-bar drag model.
+
+## Resize precedence rule
+
+- Bottom-right resize behavior must not regress.
+- A dedicated bottom-right corner zone is treated as resize-priority and excluded from border-drag initiation.
+- Result: users can still resize via the corner as before; border drag applies elsewhere on the edges.
+
+## Implementation notes
+
+- `GameUiHudPanelController` now:
+  - centralizes drag lifecycle in a shared `startPanelDrag(...)` routine,
+  - evaluates border-hit geometry in `shouldStartBorderDrag(...)`,
+  - ignores non-left-click interactions,
+  - skips drag start when interaction lands inside the resize-priority corner,
+  - keeps existing panel reachability + persistence behavior untouched.
+
+## Regression coverage added
+
+- Added scenario coverage that confirms:
+  1. a panel can be moved by initiating pointer drag from a border area,
+  2. pointer down in the bottom-right resize corner does not bind drag movement listeners (resize priority preserved).
+
+## Why this matters
+
+- This avoids "panel stranded off-screen" UX traps.
+- It reduces recovery friction on dynamic viewport changes, zoom/resolution changes, and stale saved offsets.
+- It preserves desktop resize ergonomics while improving overall panel robustness.

--- a/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
@@ -40,6 +40,8 @@ export default class GameUiHudPanelController {
     private nextPanelZIndex = 10;
     private readonly panelSpawnOrigin = { x: 24, y: 96 };
     private readonly panelSpawnStepY = 34;
+    private readonly panelBorderDragThresholdPx = 8;
+    private readonly panelResizeCornerPriorityPx = 18;
     private activeLayoutContext: LayoutContext = 'world';
     constructor(hudElements: HudElements, callbacks: GameUiEventCallbacks) {
         this.hudElements = hudElements;
@@ -131,31 +133,65 @@ export default class GameUiHudPanelController {
             if (event.button !== 0) {
                 return;
             }
-            event.preventDefault();
-            dragHandle.setPointerCapture(event.pointerId);
-            panel.style.zIndex = String(this.nextPanelZIndex++);
-            panel.classList.add('panel-dragging');
-            const startX = event.clientX;
-            const startY = event.clientY;
-            const initialOffsetX = Number.parseFloat(panel.dataset.offsetX ?? '0') || 0;
-            const initialOffsetY = Number.parseFloat(panel.dataset.offsetY ?? '0') || 0;
-            const onPointerMove = (moveEvent: PointerEvent): void => {
-                const nextOffsetX = initialOffsetX + (moveEvent.clientX - startX);
-                const nextOffsetY = initialOffsetY + (moveEvent.clientY - startY);
-                this.applyPanelOffset(panel, nextOffsetX, nextOffsetY);
-                this.keepPanelReachableInViewport(panel);
-                this.persistCurrentContextLayout();
-            };
-            const stopDrag = (): void => {
-                panel.classList.remove('panel-dragging');
-                dragHandle.removeEventListener('pointermove', onPointerMove);
-                dragHandle.removeEventListener('pointerup', stopDrag);
-                dragHandle.removeEventListener('pointercancel', stopDrag);
-            };
-            dragHandle.addEventListener('pointermove', onPointerMove);
-            dragHandle.addEventListener('pointerup', stopDrag);
-            dragHandle.addEventListener('pointercancel', stopDrag);
+            this.startPanelDrag(event, panel, dragHandle);
         });
+        panel.addEventListener('pointerdown', (event: PointerEvent) => {
+            if (!this.shouldStartBorderDrag(event, panel, dragHandle)) {
+                return;
+            }
+            this.startPanelDrag(event, panel, panel);
+        });
+    }
+    private shouldStartBorderDrag(event: PointerEvent, panel: HTMLElement, dragHandle: HTMLElement): boolean {
+        if (event.button !== 0 || event.target === dragHandle) {
+            return false;
+        }
+        const panelRect = panel.getBoundingClientRect();
+        if (panelRect.width <= 0 || panelRect.height <= 0) {
+            return false;
+        }
+        const localX = event.clientX - panelRect.left;
+        const localY = event.clientY - panelRect.top;
+        if (localX < 0 || localY < 0 || localX > panelRect.width || localY > panelRect.height) {
+            return false;
+        }
+        const isInResizePriorityCorner = localX >= (panelRect.width - this.panelResizeCornerPriorityPx)
+            && localY >= (panelRect.height - this.panelResizeCornerPriorityPx);
+        if (isInResizePriorityCorner) {
+            return false;
+        }
+        const threshold = this.panelBorderDragThresholdPx;
+        const isOnBorder = localX <= threshold
+            || localY <= threshold
+            || localX >= (panelRect.width - threshold)
+            || localY >= (panelRect.height - threshold);
+        return isOnBorder;
+    }
+    private startPanelDrag(event: PointerEvent, panel: HTMLElement, dragSurface: HTMLElement): void {
+        event.preventDefault();
+        dragSurface.setPointerCapture(event.pointerId);
+        panel.style.zIndex = String(this.nextPanelZIndex++);
+        panel.classList.add('panel-dragging');
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const initialOffsetX = Number.parseFloat(panel.dataset.offsetX ?? '0') || 0;
+        const initialOffsetY = Number.parseFloat(panel.dataset.offsetY ?? '0') || 0;
+        const onPointerMove = (moveEvent: PointerEvent): void => {
+            const nextOffsetX = initialOffsetX + (moveEvent.clientX - startX);
+            const nextOffsetY = initialOffsetY + (moveEvent.clientY - startY);
+            this.applyPanelOffset(panel, nextOffsetX, nextOffsetY);
+            this.keepPanelReachableInViewport(panel);
+            this.persistCurrentContextLayout();
+        };
+        const stopDrag = (): void => {
+            panel.classList.remove('panel-dragging');
+            dragSurface.removeEventListener('pointermove', onPointerMove);
+            dragSurface.removeEventListener('pointerup', stopDrag);
+            dragSurface.removeEventListener('pointercancel', stopDrag);
+        };
+        dragSurface.addEventListener('pointermove', onPointerMove);
+        dragSurface.addEventListener('pointerup', stopDrag);
+        dragSurface.addEventListener('pointercancel', stopDrag);
     }
     private bindPanelSpawnPositioning(panel: HTMLElement, panelIndex: number): void {
         const placePanelAtSpawn = (): void => {

--- a/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
+++ b/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
@@ -354,3 +354,86 @@ test('GameUiHudPanelController keeps combat actions panel hidden outside battle 
     global.requestAnimationFrame = originalRequestAnimationFrame;
   }
 });
+
+test('GameUiHudPanelController allows dragging panels from any panel border', () => {
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalMutationObserver = global.MutationObserver;
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+
+  global.window = { localStorage: createLocalStorage(), innerWidth: 1280, innerHeight: 720 };
+  const hudElements = createHudElements();
+  global.document = createMockDocument(hudElements);
+  global.requestAnimationFrame = (callback) => callback();
+  global.MutationObserver = class {
+    constructor() {}
+    observe() {}
+  };
+
+  try {
+    const controller = new GameUiHudPanelController(hudElements, { onTogglePanel() {} });
+    controller.bind();
+    const statsPanel = hudElements.statsPanel;
+    statsPanel.getBoundingClientRect = () => ({ left: 24, top: 96, width: 240, height: 180, right: 264, bottom: 276 });
+
+    statsPanel.listeners.pointerdown({
+      button: 0,
+      pointerId: 10,
+      target: statsPanel,
+      clientX: 25,
+      clientY: 120,
+      preventDefault() {},
+    });
+    statsPanel.listeners.pointermove({ clientX: 65, clientY: 150 });
+    statsPanel.listeners.pointerup();
+
+    assert.equal(statsPanel.dataset.offsetX, '64');
+    assert.equal(statsPanel.dataset.offsetY, '126');
+  } finally {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.MutationObserver = originalMutationObserver;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
+test('GameUiHudPanelController keeps bottom-right resize corner behavior higher priority than border drag', () => {
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalMutationObserver = global.MutationObserver;
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+
+  global.window = { localStorage: createLocalStorage(), innerWidth: 1280, innerHeight: 720 };
+  const hudElements = createHudElements();
+  global.document = createMockDocument(hudElements);
+  global.requestAnimationFrame = (callback) => callback();
+  global.MutationObserver = class {
+    constructor() {}
+    observe() {}
+  };
+
+  try {
+    const controller = new GameUiHudPanelController(hudElements, { onTogglePanel() {} });
+    controller.bind();
+    const statsPanel = hudElements.statsPanel;
+    statsPanel.getBoundingClientRect = () => ({ left: 24, top: 96, width: 240, height: 180, right: 264, bottom: 276 });
+
+    statsPanel.listeners.pointerdown({
+      button: 0,
+      pointerId: 11,
+      target: statsPanel,
+      clientX: 260,
+      clientY: 272,
+      preventDefault() {},
+    });
+
+    assert.equal(statsPanel.listeners.pointermove, undefined);
+    assert.equal(statsPanel.dataset.offsetX, '24');
+    assert.equal(statsPanel.dataset.offsetY, '96');
+  } finally {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.MutationObserver = originalMutationObserver;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});


### PR DESCRIPTION
### Motivation
- Prevent HUD panels from becoming unrecoverable when their title bar is off-screen by allowing dragging from panel borders. 
- Preserve existing bottom-right corner resize behavior so native `resize: both` remains usable. 
- Centralize drag lifecycle to avoid duplicated pointer logic and keep persistence/reachability behavior intact. 

### Description
- Add configurable geometry rules (`panelBorderDragThresholdPx`, `panelResizeCornerPriorityPx`) and new helpers `shouldStartBorderDrag(...)` and `startPanelDrag(...)` into `GameUiHudPanelController`. 
- Start border-based drag when pointer down on any panel edge (top/right/bottom/left) while excluding a bottom-right resize-priority corner so resize has precedence. 
- Refactor existing header drag path to reuse the shared `startPanelDrag(...)` routine so header and border drags behave consistently. 
- Add two scenario tests to `gameUiHudPanelController.test.js` that verify border drag updates offsets and that the bottom-right corner does not initiate dragging, and update `CODING_GUIDELINES.md` and add `docs/ui/hud-panel-border-dragging-2026-04-12.md` documenting the change. 

### Testing
- Ran `npm run build:rgfn` and the TypeScript build completed successfully. 
- Ran `npm run test:rgfn` and all tests passed (`142` tests, `0` fails). 
- Ran `npx eslint` against the modified controller file and it passed; running the full `npm run lint:ts:rgfn` reports pre-existing unrelated lint errors across the repo but the touched controller file itself does not introduce new ESLint failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbec02361c83239c5b1b65222048d1)