### PR TITLE
RGFN: hide Selected panel in Village mode and restore on World Map

### DIFF
--- a/rgfn_game/docs/village/village-selected-panel-visibility-2026-04-12.md
+++ b/rgfn_game/docs/village/village-selected-panel-visibility-2026-04-12.md
@@ -1,0 +1,25 @@
+# Village selected-panel visibility rule (2026-04-12)
+
+## Problem
+- The HUD **Selected** panel (`#selected-panel`) stayed visible when the mode switched to **Village**.
+- In village mode, selected-cell inspection is not meaningful because world/battle tile selection is inactive.
+- This caused a persistent empty panel and unnecessary UI noise.
+
+## Implemented behavior
+- Entering **Village** mode now force-hides the **Selected** panel.
+- Leaving village back to **World Map** restores the panel visibility to whatever it was before entering village:
+  - if player had it open in world mode, it reopens;
+  - if player had it hidden in world mode, it stays hidden.
+
+## Persistence details
+- World/battle panel layouts still persist separately.
+- While in village mode, selected-panel persistence writes use the pre-village visibility snapshot, so temporary force-hide does not overwrite player preference.
+
+## Main code touchpoint
+- `rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts`
+
+## Regression coverage
+- Scenario test:
+  - `GameUiHudPanelController hides selected panel in Village mode and restores world visibility on return`
+- File:
+  - `rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js`

--- a/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
@@ -43,6 +43,7 @@ export default class GameUiHudPanelController {
     private readonly panelBorderDragThresholdPx = 8;
     private readonly panelResizeCornerPriorityPx = 18;
     private activeLayoutContext: LayoutContext = 'world';
+    private selectedPanelHiddenBeforeVillage: boolean | null = null;
     constructor(hudElements: HudElements, callbacks: GameUiEventCallbacks) {
         this.hudElements = hudElements;
         this.callbacks = callbacks;
@@ -247,6 +248,7 @@ export default class GameUiHudPanelController {
         const nextContext = this.getLayoutContextFromModeIndicator();
         if (nextContext === this.activeLayoutContext) {
             this.enforceVillagePanelVisibility(modeText);
+            this.enforceSelectedPanelVisibility(modeText);
             this.enforceCombatPanelVisibility(nextContext);
             return;
         }
@@ -254,6 +256,7 @@ export default class GameUiHudPanelController {
         this.activeLayoutContext = nextContext;
         this.restoreLayoutForCurrentContext();
         this.enforceVillagePanelVisibility(modeText);
+        this.enforceSelectedPanelVisibility(modeText);
         this.enforceCombatPanelVisibility(nextContext);
     }
     private getLayoutContextFromModeIndicator(): LayoutContext {
@@ -285,6 +288,7 @@ export default class GameUiHudPanelController {
                 return;
             }
             const shouldForceVillageVisibility = this.shouldForceVillagePanelsVisible() && this.isVillagePanel(layoutKey);
+            const shouldForceSelectedHidden = this.shouldForceSelectedPanelHidden() && this.isSelectedPanel(layoutKey);
             element.dataset.offsetX = String(snapshot.offsetX);
             element.dataset.offsetY = String(snapshot.offsetY);
             element.dataset.spawnPositioned = 'true';
@@ -297,13 +301,14 @@ export default class GameUiHudPanelController {
             } else {
                 element.style.removeProperty('z-index');
             }
-            element.classList.toggle('hidden', shouldForceVillageVisibility ? false : snapshot.hidden);
+            element.classList.toggle('hidden', shouldForceVillageVisibility ? false : shouldForceSelectedHidden ? true : snapshot.hidden);
             if (!element.classList.contains('hidden')) {
                 this.keepPanelReachableInViewport(element);
                 requestAnimationFrame(() => this.ensurePanelDragHandleIsReachable(element));
             }
         });
         this.enforceVillagePanelVisibility(this.hudElements.modeIndicator.textContent?.trim() ?? '');
+        this.enforceSelectedPanelVisibility(this.hudElements.modeIndicator.textContent?.trim() ?? '');
         this.enforceCombatPanelVisibility(this.activeLayoutContext);
     }
     private resetPanelToSpawn(panel: HTMLElement, panelIndex: number): void {
@@ -429,11 +434,14 @@ export default class GameUiHudPanelController {
             const zIndex = Number.parseInt(element.style.zIndex || '', 10);
             const isCombatPanel = layoutKey === GameUiHudPanelController.COMBAT_PANEL_PERSISTENCE_KEY;
             const isForcedVillagePanel = this.shouldForceVillagePanelsVisible() && this.isVillagePanel(layoutKey);
+            const isForcedSelectedPanel = this.shouldForceSelectedPanelHidden() && this.isSelectedPanel(layoutKey);
             const hidden = isCombatPanel
                 ? this.activeLayoutContext !== 'battle'
                 : isForcedVillagePanel
                     ? false
-                    : element.classList.contains('hidden');
+                    : isForcedSelectedPanel
+                        ? (this.selectedPanelHiddenBeforeVillage ?? element.classList.contains('hidden'))
+                        : element.classList.contains('hidden');
             layout[layoutKey] = {
                 offsetX,
                 offsetY,
@@ -473,6 +481,29 @@ export default class GameUiHudPanelController {
         return context === 'battle'
             ? GameUiHudPanelController.BATTLE_LAYOUT_STORAGE_KEY
             : GameUiHudPanelController.WORLD_LAYOUT_STORAGE_KEY;
+    }
+
+    private isSelectedPanel(layoutKey: string): boolean {
+        return layoutKey === 'selected';
+    }
+    private shouldForceSelectedPanelHidden(): boolean {
+        return (this.hudElements.modeIndicator.textContent?.trim() ?? '') === GameUiHudPanelController.MODE_TEXT.village;
+    }
+    private enforceSelectedPanelVisibility(modeText: string): void {
+        if (modeText === GameUiHudPanelController.MODE_TEXT.village) {
+            if (this.selectedPanelHiddenBeforeVillage === null) {
+                this.selectedPanelHiddenBeforeVillage = this.hudElements.selectedPanel.classList.contains('hidden');
+            }
+            this.hudElements.selectedPanel.classList.add('hidden');
+            this.hudElements.toggleSelectedPanelBtn.classList.remove('active');
+            return;
+        }
+        if (this.selectedPanelHiddenBeforeVillage === null) {
+            return;
+        }
+        this.hudElements.selectedPanel.classList.toggle('hidden', this.selectedPanelHiddenBeforeVillage);
+        this.hudElements.toggleSelectedPanelBtn.classList.toggle('active', !this.selectedPanelHiddenBeforeVillage);
+        this.selectedPanelHiddenBeforeVillage = null;
     }
     private isVillagePanel(layoutKey: string): boolean {
         return layoutKey === GameUiHudPanelController.VILLAGE_ACTIONS_PANEL_PERSISTENCE_KEY

--- a/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
+++ b/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
@@ -317,6 +317,46 @@ test('GameUiHudPanelController forces village action and rumors panels visible i
   }
 });
 
+
+test('GameUiHudPanelController hides selected panel in Village mode and restores world visibility on return', () => {
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalMutationObserver = global.MutationObserver;
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+  const observers = [];
+
+  global.window = { localStorage: createLocalStorage(), innerWidth: 1280, innerHeight: 720 };
+  const hudElements = createHudElements();
+  global.document = createMockDocument(hudElements);
+  global.requestAnimationFrame = (callback) => callback();
+  global.MutationObserver = class {
+    constructor(callback) { this.callback = callback; observers.push(this); }
+    observe(target) { this.target = target; }
+    trigger() { this.callback(); }
+  };
+
+  try {
+    const controller = new GameUiHudPanelController(hudElements, { onTogglePanel() {} });
+    controller.bind();
+
+    assert.equal(hudElements.selectedPanel.classList.contains('hidden'), false);
+
+    hudElements.modeIndicator.textContent = 'Village';
+    observers.forEach((observer) => observer.target === hudElements.modeIndicator && observer.trigger());
+    assert.equal(hudElements.selectedPanel.classList.contains('hidden'), true);
+
+    hudElements.modeIndicator.textContent = 'World Map';
+    observers.forEach((observer) => observer.target === hudElements.modeIndicator && observer.trigger());
+    assert.equal(hudElements.selectedPanel.classList.contains('hidden'), false);
+
+  } finally {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.MutationObserver = originalMutationObserver;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
 test('GameUiHudPanelController keeps combat actions panel hidden outside battle mode', () => {
   const originalWindow = global.window;
   const originalDocument = global.document;


### PR DESCRIPTION
### Motivation
- The HUD Selected panel (`#selected-panel`) remained visible while in Village mode where selected-cell inspection is not meaningful, creating visual noise.  
- The goal is to automatically hide that panel when entering a village and restore the player’s previous world-map visibility when leaving village without overwriting stored world preferences.

### Description
- Added state tracking `selectedPanelHiddenBeforeVillage` and new helpers `isSelectedPanel`, `shouldForceSelectedPanelHidden`, and `enforceSelectedPanelVisibility` to `rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts` to remember and restore Selected panel visibility.  
- Updated layout restore and persistence logic in `GameUiHudPanelController` so temporary village-enforced hiding does not overwrite the stored world layout for the Selected panel.  
- Hooked selected-panel enforcement into layout context changes so Village mode force-hides the panel immediately and World Map restores prior visibility.  
- Added a scenario test `GameUiHudPanelController hides selected panel in Village mode and restores world visibility on return` in `rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js` and documentation `rgfn_game/docs/village/village-selected-panel-visibility-2026-04-12.md` describing the rule and persistence notes.

### Testing
- Ran `npm run build:rgfn` to compile the RGFN codebase and it completed successfully. (pass)  
- Ran the focused scenario file with `node --test rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js` and the new test passed along with the other scenarios in that file. (pass)  
- Ran `npx eslint rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js` and the linter returned no errors. (pass)  
- Ran the full RGFN test suite via `npm run test:rgfn`; overall test run shows unrelated pre-existing failure in `EncounterSystem generateMonsterBattleEncounter returns a battle when resolver returns monster battle`, so the full suite reports 141/142 passing with that unrelated test failing. (partial)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf30b5ab883239d067f189f2796c0)