### PR TITLE
Implement village 'defend' quest flow with allied defenders and battle support

### DIFF
--- a/rgfn_game/docs/quest/defend-objective-runtime.md
+++ b/rgfn_game/docs/quest/defend-objective-runtime.md
@@ -16,6 +16,19 @@ This document explains the newly implemented **defend** main-quest leaf flow for
 5. Leaving the village while defense is active rolls the objective back to the initial state (no hard fail for main quest).
 6. After timer expiry, objective is completed and artifact outcome is resolved (retained by NPC or awarded narrative to player side).
 
+## Hard axiom: quest people must exist in world NPC rosters
+
+For defend objectives we now enforce this invariant:
+
+- If a quest references a person (`contactName`) in a village objective, that person must appear in that village NPC roster every time the village is entered.
+- This is implemented by contract projection from quest runtime (`collectDefendContracts`) into village runtime contract wiring and roster reconciliation (`ensureQuestPeoplePresent` + `appendDefendContactIfMissing`).
+- The reconciliation runs:
+  - when a village roster is first created;
+  - when a cached roster is reused;
+  - when defend contracts are refreshed from quest updates.
+
+This makes missing-quest-contact regressions testable and deterministic instead of relying on random NPC generation luck.
+
 ## Combat model used by defend encounters
 
 - Defend encounters can spawn both:
@@ -38,6 +51,11 @@ This document explains the newly implemented **defend** main-quest leaf flow for
 
 - Defend objective state is stored in quest tree objective metadata and therefore persists via existing quest save flow.
 - Defender casualties and remaining HP are written back into defend objective metadata after each village-defense battle.
+
+## Test coverage for the invariant
+
+- `recoverQuestRuntime.test.js`: validates defend contracts are emitted for known active defend objectives.
+- `villageActionsController.test.js`: validates defend contact NPC is injected into the target village roster.
 
 ## Current limitations and follow-up opportunities
 

--- a/rgfn_game/docs/quest/defend-objective-runtime.md
+++ b/rgfn_game/docs/quest/defend-objective-runtime.md
@@ -1,0 +1,46 @@
+# Defend objective runtime (village hold contract)
+
+This document explains the newly implemented **defend** main-quest leaf flow for RGFN.
+
+## Player flow
+
+1. A defend leaf now includes objective metadata (`objectiveData.defend`) with:
+   - target village;
+   - artifact name;
+   - quest-contact NPC name;
+   - duration in days;
+   - active timer state and defender roster.
+2. In a village dialogue, the player can use **"I am ready to defend you"** when speaking to NPCs.
+3. If the NPC matches an active defend contract for the village, the defense starts and the countdown begins.
+4. While advancing time in the village (sleep, barter actions, dialogue actions), periodic attacker waves can trigger.
+5. Leaving the village while defense is active rolls the objective back to the initial state (no hard fail for main quest).
+6. After timer expiry, objective is completed and artifact outcome is resolved (retained by NPC or awarded narrative to player side).
+
+## Combat model used by defend encounters
+
+- Defend encounters can spawn both:
+  - attackers (`Hired Blade N`), and
+  - allied defenders (villager-derived roster).
+- Turn system now supports side-aware teams:
+  - player + allied defenders are on one side;
+  - attackers on the opposing side.
+- Allied defenders take turns with simple AI:
+  - move to nearest hostile;
+  - attack when in range;
+  - can die and be removed from defender roster.
+
+## XP and loot sharing
+
+- Enemy XP is split by player-side participant count (`floor(totalXp / participantCount)`, minimum 1 to player).
+- Loot drops in multi-participant fights are probabilistically claimed by allied defenders to represent split loot.
+
+## Persistence notes
+
+- Defend objective state is stored in quest tree objective metadata and therefore persists via existing quest save flow.
+- Defender casualties and remaining HP are written back into defend objective metadata after each village-defense battle.
+
+## Current limitations and follow-up opportunities
+
+- Villager roster UI removal for dead defenders is currently metadata-driven but can be expanded with explicit village roster pruning hooks.
+- Artifact "awarded to player" branch currently logs reward narrative; if strict inventory reward is required, add deterministic inventory insertion in the completion branch.
+- Defender button visibility currently depends on runtime validation at click time; optional pre-filtering can be added for cleaner UI.

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -327,6 +327,7 @@
                     <button id="village-confirm-barter-btn" class="action-btn hidden">I have what you need, let's do our barter</button>
                     <button id="village-confront-recover-btn" class="action-btn hidden">Confront for quest item</button>
                     <button id="village-recruit-escort-btn" class="action-btn hidden">Join my group</button>
+                    <button id="village-defend-objective-btn" class="action-btn hidden">I am ready to defend you</button>
                 </div>
             </div>
         </div>

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -120,9 +120,10 @@ export class GameFacade implements GameFacadeStateAccess {
             runtime.questGenerator,
             runtime.questUiController,
             () => this.persistenceRuntime.getParsedSaveState()?.quest ?? null,
-            ({ barterContracts, escortContracts }) => {
+            ({ barterContracts, escortContracts, defendContracts }) => {
                 this.villageActionsController.configureQuestBarterContracts(barterContracts);
                 this.villageActionsController.configureQuestEscortContracts(escortContracts);
+                this.villageActionsController.configureQuestDefendContracts(defendContracts);
             },
             this.worldMap,
         );

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -148,6 +148,18 @@ export class GameFacade implements GameFacadeStateAccess {
     ): { status: 'started' | 'inactive' | 'not-target' | 'not-ready'; enemies?: import('../entities/Skeleton.js').default[]; itemName?: string } =>
         this.lifecycle.onTryStartRecoverConfrontation(personName, villageName);
     public onBattleEnded = (result: 'victory' | 'defeat' | 'fled'): void => this.lifecycle.onBattleEnded(result);
+    public onVillageAdvanceTime(minutes: number, fatigueScale: number): void {
+        this.lifecycle.onVillageAdvanceTime(minutes, fatigueScale);
+    }
+    public onVillageLeave(): void {
+        this.lifecycle.onVillageLeave();
+    }
+    public onTryStartDefendObjective = (
+        npcName: string,
+        villageName: string,
+        villagerNames: string[],
+    ): { status: 'started' | 'inactive' | 'not-target' | 'already-active'; objectiveTitle?: string; days?: number } =>
+        this.lifecycle.onTryStartDefendObjective(npcName, villageName, villagerNames);
 
     public tryCreateQuestMonsterEncounter = (): {
         enemies: import('../entities/Skeleton.js').default[];

--- a/rgfn_game/js/game/GameFactoryHelpers.ts
+++ b/rgfn_game/js/game/GameFactoryHelpers.ts
@@ -48,8 +48,8 @@ const createVillageActionsController = (
     hudCoordinator: GameHudCoordinator,
 ): VillageActionsController => new VillageActionsController(player, ui.villageUI, ui.gameLogUI.log, {
     onUpdateHUD: () => hudCoordinator.updateHUD(),
-    onAdvanceTime: (minutes, fatigueScale) => game.advanceTime(minutes, fatigueScale),
-    onLeaveVillage: () => game.stateMachine.transition(MODES.WORLD_MAP),
+    onAdvanceTime: (minutes, fatigueScale) => game.onVillageAdvanceTime(minutes, fatigueScale),
+    onLeaveVillage: () => game.onVillageLeave(),
     getVillageDirectionHint: (name: string) => worldMap.getVillageDirectionHintFromPlayer(name),
     getKnownSettlementNames: () => worldMap.getKnownSettlementNames(),
     getKnownQuestSettlementNames: () => game.questRuntime.getKnownQuestLocationNames(),
@@ -58,6 +58,7 @@ const createVillageActionsController = (
     onRevealRecoverHolder: (villageName, npcName) => game.onRevealRecoverHolder(villageName, npcName),
     onTryStartRecoverConfrontation: (personName, villageName) => game.onTryStartRecoverConfrontation(personName, villageName),
     onStartBattle: (enemies) => game.stateMachine.transition(MODES.BATTLE, { enemies, terrainType: 'grass' }),
+    onTryStartDefend: (npcName, villageName, villagerNames) => game.onTryStartDefendObjective(npcName, villageName, villagerNames),
 });
 
 // eslint-disable-next-line style-guide/function-length-warning

--- a/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
+++ b/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
@@ -153,12 +153,45 @@ export default class GameFacadeLifecycleCoordinator {
         if (result !== 'victory' && result !== 'fled') {
             return;
         }
+        const battleContext = this.state.battleCoordinator.getBattleContext();
+        if (battleContext.kind === 'village-defense' && battleContext.villageName) {
+            const survivors = this.state.battleCoordinator.getCurrentAllies()
+                .filter((ally) => !ally.isDead())
+                .map((ally) => ({ name: ally.name, hp: ally.hp }));
+            const casualtyLines = this.state.questRuntime.applyDefenderBattleResults(battleContext.villageName, survivors);
+            casualtyLines.forEach((line) => this.state.hudCoordinator.addBattleLog(line, 'system-message'));
+        }
         const lines = this.state.questRuntime.resolveRecoverBattle(result, this.state.worldMap, this.state.player);
         lines.forEach((line, index) => this.state.hudCoordinator.addBattleLog(line, index === 0 ? 'system' : 'system-message'));
         if (lines.length > 0) {
             this.refreshGroupPanel();
         }
     }
+
+    public onVillageAdvanceTime(minutes: number, fatigueScale: number): void {
+        this.state.advanceTime(minutes, fatigueScale);
+        const villageName = this.state.villageCoordinator.getVillageName();
+        const defenseTick = this.state.questRuntime.onVillageTimeAdvanced(villageName, minutes);
+        defenseTick.logs.forEach((line) => this.state.hudCoordinator.addBattleLog(line, 'system-message'));
+        if (!defenseTick.triggeredBattle || !defenseTick.attackers) {
+            return;
+        }
+        this.state.hudCoordinator.addBattleLog('Village defense combat starts!', 'system');
+        this.state.stateMachine.transition(MODES.BATTLE, {
+            enemies: defenseTick.attackers,
+            allies: defenseTick.allies ?? [],
+            terrainType: 'grass',
+            battleKind: 'village-defense',
+            villageName,
+        });
+    }
+
+    public onTryStartDefendObjective = (
+        npcName: string,
+        villageName: string,
+        villagerNames: string[],
+    ): { status: 'started' | 'inactive' | 'not-target' | 'already-active'; objectiveTitle?: string; days?: number } =>
+        this.state.questRuntime.tryStartDefendObjective(villageName, npcName, villagerNames);
 
     public onVillageEntered(): void {
         const villageName = this.state.worldMap.getVillageNameAtPlayerPosition();
@@ -225,5 +258,12 @@ export default class GameFacadeLifecycleCoordinator {
         if (this.state.loop.resume()) {
             this.state.hudCoordinator.updateSelectedCell(this.state.worldMap.getSelectedCellInfo());
         }
+    }
+
+    public onVillageLeave(): void {
+        const villageName = this.state.villageCoordinator.getVillageName();
+        const rollbackLines = this.state.questRuntime.rollbackDefendObjectivesForVillage(villageName);
+        rollbackLines.forEach((line) => this.state.hudCoordinator.addBattleLog(line, 'system-message'));
+        this.state.stateMachine.transition(MODES.WORLD_MAP);
     }
 }

--- a/rgfn_game/js/game/runtime/GameFacadeSharedTypes.ts
+++ b/rgfn_game/js/game/runtime/GameFacadeSharedTypes.ts
@@ -36,4 +36,5 @@ export type GameFacadeStateAccess = {
     persistenceRuntime: GamePersistenceRuntime;
     worldInteractionRuntime: GameWorldInteractionRuntime;
     gameTime: GameTimeRuntime;
+    advanceTime: (minutes: number, fatigueScale: number) => void;
 };

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -2,7 +2,7 @@
 /* eslint-disable style-guide/rule17-comma-layout, style-guide/arrow-function-style */
 import QuestProgressTracker from '../../systems/quest/QuestProgressTracker.js';
 import Item from '../../entities/Item.js';
-import { EscortObjectiveData, QuestNode, RecoverObjectiveData } from '../../systems/quest/QuestTypes.js';
+import { DefendObjectiveData, DefendObjectiveDefender, EscortObjectiveData, QuestNode, RecoverObjectiveData } from '../../systems/quest/QuestTypes.js';
 import QuestUiController from '../../systems/quest/ui/QuestUiController.js';
 import QuestGenerator from '../../systems/quest/QuestGenerator.js';
 import WorldMap from '../../systems/world/worldMap/WorldMap.js';
@@ -306,6 +306,199 @@ export default class GameQuestRuntime {
         return true;
     }
 
+    public tryStartDefendObjective(
+        villageName: string,
+        npcName: string,
+        availableVillagerNames: string[],
+    ): { status: 'started' | 'inactive' | 'not-target' | 'already-active'; objectiveTitle?: string; days?: number } {
+        if (!this.activeQuest || !this.questUiController) {
+            return { status: 'inactive' };
+        }
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        const normalizedNpc = npcName.trim().toLocaleLowerCase();
+        if (!normalizedVillage || !normalizedNpc) {
+            return { status: 'not-target' };
+        }
+
+        let startedNode: QuestNode | null = null;
+        let foundMatchingNode = false;
+        this.visitQuestNodes(this.activeQuest, (node) => {
+            if (startedNode || node.objectiveType !== 'defend' || node.children.length > 0 || node.isCompleted) {
+                return;
+            }
+            const defend = node.objectiveData?.defend;
+            if (!defend) {
+                return;
+            }
+            if (defend.villageName.trim().toLocaleLowerCase() !== normalizedVillage || defend.contactName.trim().toLocaleLowerCase() !== normalizedNpc) {
+                return;
+            }
+            foundMatchingNode = true;
+            if (defend.isDefenseActive) {
+                return;
+            }
+            defend.isDefenseActive = true;
+            defend.timeRemainingMinutes = Math.max(1, defend.durationDays * 24 * 60);
+            defend.battleCooldownMinutes = this.rollDefenseCooldownMinutes();
+            defend.defenders = this.createDefenderRoster(availableVillagerNames, defend.contactName);
+            startedNode = node;
+        });
+
+        if (!foundMatchingNode) {
+            return { status: 'not-target' };
+        }
+        if (!startedNode) {
+            return { status: 'already-active' };
+        }
+
+        this.questUiController.renderQuest(this.activeQuest);
+        return {
+            status: 'started',
+            objectiveTitle: startedNode.title,
+            days: startedNode.objectiveData?.defend?.durationDays ?? undefined,
+        };
+    }
+
+    public onVillageTimeAdvanced(
+        villageName: string,
+        minutes: number,
+    ): {
+        stateChanged: boolean;
+        triggeredBattle: boolean;
+        attackers?: Skeleton[];
+        allies?: Skeleton[];
+        logs: string[];
+    } {
+        if (!this.activeQuest || !this.questUiController || minutes <= 0) {
+            return { stateChanged: false, triggeredBattle: false, logs: [] };
+        }
+
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        const logs: string[] = [];
+        let stateChanged = false;
+        let triggeredBattle = false;
+        let attackers: Skeleton[] | undefined;
+        let allies: Skeleton[] | undefined;
+
+        this.visitQuestNodes(this.activeQuest, (node) => {
+            if (triggeredBattle || node.objectiveType !== 'defend' || node.children.length > 0 || node.isCompleted) {
+                return;
+            }
+            const defend = node.objectiveData?.defend;
+            if (!defend?.isDefenseActive) {
+                return;
+            }
+            if (defend.villageName.trim().toLocaleLowerCase() !== normalizedVillage) {
+                return;
+            }
+
+            stateChanged = true;
+            defend.timeRemainingMinutes = Math.max(0, defend.timeRemainingMinutes - minutes);
+            this.regenerateDefenderRoster(defend, minutes);
+            defend.battleCooldownMinutes = Math.max(0, (defend.battleCooldownMinutes ?? 0) - minutes);
+
+            if (defend.timeRemainingMinutes <= 0) {
+                node.isCompleted = true;
+                defend.isDefenseActive = false;
+                this.resolveDefendArtifactOutcome(defend, logs);
+                return;
+            }
+
+            if ((defend.battleCooldownMinutes ?? 0) > 0) {
+                return;
+            }
+
+            const livingDefenders = (defend.defenders ?? []).filter((defender) => !defender.isDead && defender.currentHp > 0);
+            if (livingDefenders.length === 0) {
+                defend.isDefenseActive = false;
+                defend.timeRemainingMinutes = defend.durationDays * 24 * 60;
+                defend.battleCooldownMinutes = 0;
+                defend.defenders = [];
+                logs.push(`Defense line collapsed in ${defend.villageName}. The objective resets: speak with ${defend.contactName} again.`);
+                return;
+            }
+
+            attackers = this.createDefenseAttackers();
+            allies = livingDefenders.map((defender) => this.createVillageCombatant(defender.name, defender.maxHp, defender.currentHp, 4, 5));
+            defend.battleCooldownMinutes = this.rollDefenseCooldownMinutes();
+            logs.push(`Raiders attack ${defend.villageName}! Hold the line until ${defend.artifactName} is secured.`);
+            triggeredBattle = true;
+        });
+
+        if (stateChanged) {
+            this.questProgressTracker?.recomputeCompletion();
+            this.questUiController.renderQuest(this.activeQuest);
+        }
+
+        return { stateChanged, triggeredBattle, attackers, allies, logs };
+    }
+
+    public rollbackDefendObjectivesForVillage(villageName: string): string[] {
+        if (!this.activeQuest || !villageName.trim()) {
+            return [];
+        }
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        const lines: string[] = [];
+        let changed = false;
+        this.visitQuestNodes(this.activeQuest, (node) => {
+            if (node.objectiveType !== 'defend' || node.children.length > 0 || node.isCompleted) {
+                return;
+            }
+            const defend = node.objectiveData?.defend;
+            if (!defend?.isDefenseActive) {
+                return;
+            }
+            if (defend.villageName.trim().toLocaleLowerCase() !== normalizedVillage) {
+                return;
+            }
+            defend.isDefenseActive = false;
+            defend.timeRemainingMinutes = defend.durationDays * 24 * 60;
+            defend.battleCooldownMinutes = 0;
+            defend.defenders = [];
+            lines.push(`You left ${defend.villageName} during the defense. The operation resets; report to ${defend.contactName} again.`);
+            changed = true;
+        });
+        if (changed) {
+            this.questProgressTracker?.recomputeCompletion();
+            this.questUiController?.renderQuest(this.activeQuest);
+        }
+        return lines;
+    }
+
+    public applyDefenderBattleResults(villageName: string, survivors: Array<{ name: string; hp: number }>): string[] {
+        if (!this.activeQuest || !villageName.trim()) {
+            return [];
+        }
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        const hpByName = new Map(survivors.map((survivor) => [survivor.name.trim().toLocaleLowerCase(), survivor.hp]));
+        const lines: string[] = [];
+        this.visitQuestNodes(this.activeQuest, (node) => {
+            if (node.objectiveType !== 'defend' || node.children.length > 0 || node.isCompleted) {
+                return;
+            }
+            const defend = node.objectiveData?.defend;
+            if (!defend?.isDefenseActive || defend.villageName.trim().toLocaleLowerCase() !== normalizedVillage) {
+                return;
+            }
+            (defend.defenders ?? []).forEach((defender) => {
+                const survivorHp = hpByName.get(defender.name.trim().toLocaleLowerCase());
+                if (typeof survivorHp === 'number') {
+                    defender.currentHp = Math.max(0, survivorHp);
+                    defender.isDead = survivorHp <= 0;
+                    return;
+                }
+                defender.currentHp = 0;
+                defender.isDead = true;
+                lines.push(`${defender.name} was killed while defending ${defend.villageName}.`);
+            });
+            defend.defenders = (defend.defenders ?? []).filter((defender) => !defender.isDead);
+        });
+        if (lines.length > 0) {
+            this.questUiController?.renderQuest(this.activeQuest);
+        }
+        return lines;
+    }
+
     public tryCreateQuestMonsterEncounter(worldMap: WorldMap): { enemies: Skeleton[]; hint?: string } | null {
         if (!this.questProgressTracker) {
             return null;
@@ -557,4 +750,93 @@ export default class GameQuestRuntime {
     }
 
     private getEscortMaxHp = (_escort: EscortObjectiveData): number => 6;
+
+    private createDefenderRoster(availableVillagerNames: string[], contactName: string): DefendObjectiveDefender[] {
+        const normalizedContact = contactName.trim().toLocaleLowerCase();
+        const uniqueNames = Array.from(
+            new Set(
+                availableVillagerNames
+                    .map((name) => name.trim())
+                    .filter((name) => name.length > 0),
+            ),
+        );
+        const prioritized = uniqueNames.filter((name) => name.toLocaleLowerCase() !== normalizedContact);
+        const pool = [contactName.trim(), ...prioritized];
+        const defenderCount = Math.min(pool.length, this.randomInt(2, 5));
+        return pool.slice(0, defenderCount).map((name) => {
+            const maxHp = this.randomInt(7, 11);
+            return { name, maxHp, currentHp: maxHp };
+        });
+    }
+
+    private regenerateDefenderRoster(defend: DefendObjectiveData, minutes: number): void {
+        const healAmount = Math.floor(minutes / (8 * 60));
+        if (healAmount <= 0) {
+            return;
+        }
+        (defend.defenders ?? []).forEach((defender) => {
+            if (defender.isDead || defender.currentHp <= 0) {
+                return;
+            }
+            defender.currentHp = Math.min(defender.maxHp, defender.currentHp + healAmount);
+        });
+    }
+
+    private createDefenseAttackers(): Skeleton[] {
+        const count = this.randomInt(1, 6);
+        return Array.from({ length: count }, (_, index) => this.createVillageCombatant(`Hired Blade ${index + 1}`));
+    }
+
+    private createVillageCombatant(name: string, maxHp?: number, currentHp?: number, minDamage: number = 3, maxDamage: number = 6): Skeleton {
+        const defender = new Skeleton(0, 0, {
+            archetypeId: 'human',
+            xpValue: this.randomInt(3, 6),
+            name,
+            width: 30,
+            height: 30,
+            baseStats: {
+                hp: maxHp ?? this.randomInt(7, 11),
+                damage: this.randomInt(minDamage, maxDamage),
+                armor: this.randomInt(0, 2),
+                mana: this.randomInt(0, 3),
+            },
+            skills: {
+                vitality: this.randomInt(0, 3),
+                toughness: this.randomInt(0, 3),
+                strength: this.randomInt(0, 3),
+                agility: this.randomInt(0, 3),
+                connection: this.randomInt(0, 2),
+                intelligence: this.randomInt(0, 2),
+            },
+        });
+        if (typeof currentHp === 'number') {
+            defender.hp = Math.max(0, Math.min(defender.maxHp, currentHp));
+            if (defender.hp <= 0) {
+                defender.active = false;
+            }
+        }
+        return defender;
+    }
+
+    private resolveDefendArtifactOutcome(defend: DefendObjectiveData, logs: string[]): void {
+        const staysWithNpc = Math.random() < 0.5;
+        if (staysWithNpc) {
+            logs.push(`${defend.contactName} keeps ${defend.artifactName} under guard in ${defend.villageName}.`);
+            return;
+        }
+        const added = this.createRecoverQuestItem(defend.artifactName);
+        logs.push(`${defend.artifactName} is completed and awarded to you.`);
+        logs.push(`Quest reward prepared: ${added.name}.`);
+    }
+
+    private rollDefenseCooldownMinutes(): number {
+        const dayPortion = this.randomInt(4, 12);
+        return dayPortion * 60;
+    }
+
+    private randomInt(min: number, max: number): number {
+        const lower = Math.ceil(Math.min(min, max));
+        const upper = Math.floor(Math.max(min, max));
+        return lower + Math.floor(Math.random() * ((upper - lower) + 1));
+    }
 }

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -20,6 +20,7 @@ type QuestContractsReadyPayload = {
         contractType: 'barter' | 'deliver' | 'recover';
     }>;
     escortContracts: Array<{ personName: string; sourceVillage: string; destinationVillage: string }>;
+    defendContracts: Array<{ personName: string; villageName: string; artifactName: string }>;
 };
 
 export default class GameQuestRuntime {
@@ -44,7 +45,11 @@ export default class GameQuestRuntime {
         this.questProgressTracker = new QuestProgressTracker(quest);
         this.onContractsUpdated = onContractsReady;
         this.worldMap = worldMap;
-        onContractsReady({ barterContracts: this.collectBarterContracts(quest), escortContracts: this.collectEscortContracts(quest) });
+        onContractsReady({
+            barterContracts: this.collectBarterContracts(quest),
+            escortContracts: this.collectEscortContracts(quest),
+            defendContracts: this.collectDefendContracts(quest),
+        });
         this.syncKnownQuestLocations();
         questUiController.renderQuest(quest);
         if (!savedQuest && getDeveloperModeConfig().questIntroEnabled) {
@@ -634,7 +639,28 @@ export default class GameQuestRuntime {
         this.onContractsUpdated({
             barterContracts: this.collectBarterContracts(this.activeQuest),
             escortContracts: this.collectEscortContracts(this.activeQuest),
+            defendContracts: this.collectDefendContracts(this.activeQuest),
         });
+    }
+
+    private collectDefendContracts(quest: QuestNode): Array<{ personName: string; villageName: string; artifactName: string }> {
+        const contracts: Array<{ personName: string; villageName: string; artifactName: string }> = [];
+        const knownNodes = collectKnownQuestNodes(quest);
+        this.visitQuestNodes(quest, (node) => {
+            if (!knownNodes.has(node) || node.objectiveType !== 'defend' || node.children.length > 0 || node.isCompleted) {
+                return;
+            }
+            const defend = node.objectiveData?.defend;
+            if (!defend?.contactName || !defend.villageName) {
+                return;
+            }
+            contracts.push({
+                personName: defend.contactName,
+                villageName: defend.villageName,
+                artifactName: defend.artifactName,
+            });
+        });
+        return contracts;
     }
 
     private updateRecoverObjectiveText(node: QuestNode): void {

--- a/rgfn_game/js/game/runtime/GameRuntimeStateMachineFactory.ts
+++ b/rgfn_game/js/game/runtime/GameRuntimeStateMachineFactory.ts
@@ -8,7 +8,7 @@ import { GameFacade, UIBundle } from '../GameFacade.js';
 
 export default class GameRuntimeStateMachineFactory {
     public static readonly create = (game: GameFacade, ui: UIBundle, worldMap: WorldMap, villageCoordinator: GameVillageCoordinator): StateMachine =>
-        new GameModeStateMachine<{ enemies: Skeleton[]; terrainType: TerrainType }>({
+        new GameModeStateMachine<{ enemies: Skeleton[]; allies?: Skeleton[]; terrainType: TerrainType; battleKind?: 'default' | 'village-defense'; villageName?: string }>({
             onEnterWorld: () => game.worldModeController.enterWorldMode(
                 ui.hudElements.modeIndicator,
                 ui.worldUI.sidebar,
@@ -18,7 +18,13 @@ export default class GameRuntimeStateMachineFactory {
                 ui.villageUI.rumorsPanel,
             ),
             onUpdateWorld: () => game.worldModeController.updateWorldMode(),
-            onEnterBattle: (battleData) => game.battleCoordinator.enterBattleMode(battleData.enemies, battleData.terrainType),
+            onEnterBattle: (battleData) => game.battleCoordinator.enterBattleMode(
+                battleData.enemies,
+                battleData.terrainType,
+                battleData.allies ?? [],
+                battleData.battleKind ?? 'default',
+                battleData.villageName,
+            ),
             onUpdateBattle: () => game.battleCoordinator.updateBattleMode(),
             onExitBattle: () => game.battleCoordinator.exitBattleMode(),
             onEnterVillage: () => game.onVillageEntered(worldMap, villageCoordinator),

--- a/rgfn_game/js/systems/combat/BattleMap.ts
+++ b/rgfn_game/js/systems/combat/BattleMap.ts
@@ -27,13 +27,15 @@ export default class BattleMap {
         this.obstacleGenerator = new BattleMapObstacleGenerator(this.grid);
     }
 
-    public setup(player: CombatEntity, enemies: CombatEntity[], terrainType: TerrainType = 'grass'): void {
+    public setup(player: CombatEntity, enemies: CombatEntity[], terrainType: TerrainType = 'grass', allies: CombatEntity[] = []): void {
         this.entities = [];
         this.terrainType = terrainType;
         const playerSpawn = this.getPlayerSpawnPosition();
         const enemySpawns = this.getEnemySpawnPositions(enemies.length);
+        const allySpawns = this.getAllySpawnPositions(allies.length, playerSpawn);
         this.obstacles = this.obstacleGenerator.generate(terrainType, playerSpawn, enemySpawns);
         this.placeEntity(player, playerSpawn.col, playerSpawn.row);
+        allies.forEach((ally, index) => this.placeEntity(ally, allySpawns[index].col, allySpawns[index].row));
         enemies.forEach((enemy, index) => this.placeEntity(enemy, enemySpawns[index].col, enemySpawns[index].row));
     }
 
@@ -120,6 +122,21 @@ export default class BattleMap {
         const formationWidth = Math.max(1, ((clampedCount - 1) * spacing) + 1);
         const startCol = Math.max(1, Math.floor((this.grid.columns - formationWidth) / 2));
         return Array.from({ length: clampedCount }, (_, index) => ({ col: Math.min(this.grid.columns - 2, startCol + (index * spacing)), row: 1 }));
+    }
+
+    private getAllySpawnPositions(allyCount: number, playerSpawn: GridPosition): GridPosition[] {
+        const clampedCount = Math.max(0, allyCount);
+        if (clampedCount === 0) {
+            return [];
+        }
+        const positions: GridPosition[] = [];
+        for (let index = 0; index < clampedCount; index += 1) {
+            const colOffset = (index % 2 === 0 ? -1 : 1) * (Math.floor(index / 2) + 1);
+            const col = Math.max(1, Math.min(this.grid.columns - 2, playerSpawn.col + colOffset));
+            const row = Math.max(1, Math.min(this.grid.rows - 2, playerSpawn.row - 1));
+            positions.push({ col, row });
+        }
+        return positions;
     }
 
     private placeEntity(entity: CombatEntity, col: number, row: number): void {

--- a/rgfn_game/js/systems/combat/TurnManager.ts
+++ b/rgfn_game/js/systems/combat/TurnManager.ts
@@ -4,19 +4,34 @@ export default class TurnManager {
     private entities: CombatEntity[];
     private currentTurnIndex: number;
     private consumedTurnCountsByEntityId: Map<number, number>;
+    private teamByEntityId: Map<number, 'player' | 'enemy'>;
+    private playerEntityId: number | null;
     public waitingForPlayer: boolean;
 
     constructor() {
         this.entities = [];
         this.currentTurnIndex = 0;
         this.consumedTurnCountsByEntityId = new Map();
+        this.teamByEntityId = new Map();
+        this.playerEntityId = null;
         this.waitingForPlayer = false;
     }
 
-    public initializeTurns(entities: CombatEntity[]): void {
+    public initializeTurns(entities: CombatEntity[], teams?: { player: CombatEntity; allies?: CombatEntity[]; enemies?: CombatEntity[] }): void {
         this.entities = entities.filter(e => e.active && !e.isDead());
         this.currentTurnIndex = 0;
         this.consumedTurnCountsByEntityId.clear();
+        this.teamByEntityId.clear();
+        const fallbackPlayer = this.entities.find((entity) => entity.constructor.name === 'Player');
+        this.playerEntityId = teams?.player?.id ?? fallbackPlayer?.id ?? null;
+        if (teams?.player) {
+            this.teamByEntityId.set(teams.player.id, 'player');
+        }
+        (teams?.allies ?? []).forEach((ally) => this.teamByEntityId.set(ally.id, 'player'));
+        (teams?.enemies ?? []).forEach((enemy) => this.teamByEntityId.set(enemy.id, 'enemy'));
+        this.entities
+            .filter((entity) => !this.teamByEntityId.has(entity.id))
+            .forEach((entity) => this.teamByEntityId.set(entity.id, entity.constructor.name === 'Player' ? 'player' : 'enemy'));
         this.waitingForPlayer = false;
     }
 
@@ -29,7 +44,7 @@ export default class TurnManager {
 
     public isPlayerTurn(): boolean {
         const current = this.getCurrentEntity();
-        return current !== null && current.constructor.name === 'Player';
+        return current !== null && this.playerEntityId !== null && current.id === this.playerEntityId;
     }
 
     public nextTurn(): CombatEntity | null {
@@ -89,10 +104,26 @@ export default class TurnManager {
     }
 
     public hasActiveCombatants(): boolean {
-        const players = this.entities.filter(e => e.constructor.name === 'Player' && !e.isDead());
-        const enemies = this.entities.filter(e => e.constructor.name !== 'Player' && !e.isDead());
+        const players = this.entities.filter((entity) => !entity.isDead() && this.getTeam(entity) === 'player');
+        const enemies = this.entities.filter((entity) => !entity.isDead() && this.getTeam(entity) === 'enemy');
         return players.length > 0 && enemies.length > 0;
     }
 
-    public getActiveEnemies = (): CombatEntity[] => this.entities.filter(e => e.constructor.name !== 'Player' && !e.isDead());
+    public getActiveEnemies = (): CombatEntity[] => this.entities.filter((entity) => this.getTeam(entity) === 'enemy' && !entity.isDead());
+
+    public getOpponentsOf(entity: CombatEntity): CombatEntity[] {
+        const team = this.getTeam(entity);
+        return this.entities.filter((candidate) => this.getTeam(candidate) !== team && !candidate.isDead());
+    }
+
+    public isAlly(entity: CombatEntity): boolean {
+        if (this.playerEntityId === null) {
+            return false;
+        }
+        return this.getTeam(entity) === 'player' && entity.id !== this.playerEntityId;
+    }
+
+    public getPlayerSideParticipantCount = (): number => this.entities.filter((entity) => this.getTeam(entity) === 'player' && !entity.isDead()).length;
+
+    private getTeam = (entity: CombatEntity): 'player' | 'enemy' => this.teamByEntityId.get(entity.id) ?? (entity.constructor.name === 'Player' ? 'player' : 'enemy');
 }

--- a/rgfn_game/js/systems/game/BattleCommandController.ts
+++ b/rgfn_game/js/systems/game/BattleCommandController.ts
@@ -180,7 +180,7 @@ export default class BattleCommandController {
     };
 
     private handleTargetDefeated = (target: Skeleton): void => {
-        this.lootManager.handleKillRewards(target, this.player, this.callbacks);
+        this.lootManager.handleKillRewards(target, this.player, this.callbacks, this.turnManager.getPlayerSideParticipantCount());
     };
 
     private handlePotionUse(fromBattleControls: boolean, usePotion: () => boolean, emptyMessage: string, successMessage: string): void {

--- a/rgfn_game/js/systems/game/BattleLootManager.ts
+++ b/rgfn_game/js/systems/game/BattleLootManager.ts
@@ -15,20 +15,22 @@ type LootCallbacks = {
 export default class BattleLootManager {
     private pendingLoot: Item[] = [];
 
-    public handleKillRewards(target: Skeleton, player: Player, callbacks: LootCallbacks): void {
+    public handleKillRewards(target: Skeleton, player: Player, callbacks: LootCallbacks, participantCount: number = 1): void {
         callbacks.onAddBattleLog(`${target.name} defeated!`, 'system');
         callbacks.onEnemyDefeated?.(target);
 
         if (target.xpValue && target.xpValue > 0) {
-            const leveledUp = player.addXp(target.xpValue);
-            callbacks.onAddBattleLog(`Gained ${target.xpValue} XP!`, 'system');
+            const shareCount = Math.max(1, Math.floor(participantCount));
+            const playerShare = Math.max(1, Math.floor(target.xpValue / shareCount));
+            const leveledUp = player.addXp(playerShare);
+            callbacks.onAddBattleLog(`Gained ${playerShare} XP (${target.xpValue} total split across ${shareCount} allies).`, 'system');
             if (leveledUp) {
                 callbacks.onAddBattleLog(`LEVEL UP! Now level ${player.level}!`, 'system');
                 callbacks.onAddBattleLog(`Gained ${balanceConfig.leveling.skillPointsPerLevel} skill points! HP and mana fully restored!`, 'system');
             }
         }
 
-        this.collectLoot(target, callbacks);
+        this.collectLoot(target, callbacks, Math.max(1, Math.floor(participantCount)));
         if (callbacks.getSelectedEnemy() === target) {
             callbacks.setSelectedEnemy(null);
         }
@@ -56,7 +58,7 @@ export default class BattleLootManager {
         this.pendingLoot = [];
     };
 
-    private collectLoot(target: Skeleton, callbacks: LootCallbacks): void {
+    private collectLoot(target: Skeleton, callbacks: LootCallbacks, participantCount: number): void {
         const loot: Item[] = [];
         const lootable = target as Skeleton & { getLootItems?: () => Item[] };
 
@@ -72,6 +74,10 @@ export default class BattleLootManager {
         }
 
         for (const item of loot) {
+            if (participantCount > 1 && Math.random() > (1 / participantCount)) {
+                callbacks.onAddBattleLog(`${item.name} was claimed by allied defenders.`, 'system-message');
+                continue;
+            }
             this.pendingLoot.push(item);
             callbacks.onAddBattleLog(`${item.name} dropped. It will be collected after battle.`, 'system');
         }

--- a/rgfn_game/js/systems/game/BattleTurnController.ts
+++ b/rgfn_game/js/systems/game/BattleTurnController.ts
@@ -57,42 +57,52 @@ export default class BattleTurnController {
         }
 
         this.callbacks.onEnableBattleButtons(false);
-        this.executeEnemyTurn(currentEntity as Skeleton);
+        this.executeAiTurn(currentEntity as Skeleton);
     }
 
-    private executeEnemyTurn(enemy: Skeleton): void {
+    private executeAiTurn(actor: Skeleton): void {
         setTimeout(() => {
-            if (enemy.shouldSkipTurnFromSlow()) {
-                const effectMessages = enemy.consumeTurnEffects();
-                effectMessages.forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
-                this.turnManager.nextTurn();
-                setTimeout(() => this.processTurn(), timingConfig.battle.enemyTurnDelay);
+            if (actor.shouldSkipTurnFromSlow()) {
+                const effectMessages = actor.consumeTurnEffects();
+                this.completeAiTurn(effectMessages);
                 return;
             }
 
-            const effectMessages = enemy.consumeTurnEffects();
+            const effectMessages = actor.consumeTurnEffects();
             effectMessages
                 .filter((message) => !message.includes('skips this turn'))
                 .forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
 
-            const attackRange = this.getEnemyAttackRange(enemy);
-            const inRange = this.battleMap.isInAttackRange(enemy, this.player, attackRange);
+            const target = this.selectAiTarget(actor);
+            if (!target) {
+                this.completeAiTurn();
+                return;
+            }
+
+            const attackRange = this.getEnemyAttackRange(actor);
+            const inRange = this.battleMap.isInAttackRange(actor, target, attackRange);
 
             if (inRange) {
-                this.performEnemyAttack(enemy);
+                this.performAiAttack(actor, target);
                 if (this.player.isDead()) {
                     this.callbacks.onAddBattleLog('You have been defeated!', 'system');
                     setTimeout(() => this.callbacks.onBattleEnd('defeat'), timingConfig.battle.defeatEndDelay);
                     return;
                 }
             } else {
-                this.battleMap.moveEntityToward(enemy, this.player, attackRange);
-                this.callbacks.onAddBattleLog(`${enemy.name} moves closer...`, 'enemy');
+                this.battleMap.moveEntityToward(actor, target, attackRange);
+                this.callbacks.onAddBattleLog(`${actor.name} moves closer...`, this.turnManager.isAlly(actor) ? 'system-message' : 'enemy');
             }
 
             this.turnManager.nextTurn();
             setTimeout(() => this.processTurn(), timingConfig.battle.enemyTurnDelay);
         }, timingConfig.battle.enemyActionStartDelay);
+    }
+
+    private completeAiTurn(logs: string[] = []): void {
+        logs.forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
+        this.turnManager.nextTurn();
+        setTimeout(() => this.processTurn(), timingConfig.battle.enemyTurnDelay);
     }
 
 
@@ -101,47 +111,45 @@ export default class BattleTurnController {
         return rangedEnemy.getAttackRange ? rangedEnemy.getAttackRange() : 1;
     }
 
-    private performEnemyAttack(enemy: Skeleton): void {
-        if (this.tryPerformEnemyMagicAttack(enemy)) {
+    private performAiAttack(attacker: Skeleton, target: Player | Skeleton): void {
+        if (this.tryPerformEnemyMagicAttack(attacker, target)) {
             return;
         }
 
-        this.callbacks.onAddBattleLog(`${enemy.name} attacks!`, 'enemy');
-        enemy.consumeDirectionalAttackBonuses().forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
-        if (Math.random() < this.player.avoidChance) {
-            this.callbacks.onAddBattleLog('You swiftly evade the hit!', 'system');
+        const logType = this.turnManager.isAlly(attacker) ? 'system-message' : 'enemy';
+        this.callbacks.onAddBattleLog(`${attacker.name} attacks!`, logType);
+        attacker.consumeDirectionalAttackBonuses().forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
+        if (Math.random() < (target instanceof Player ? this.player.avoidChance : target.avoidChance)) {
+            this.callbacks.onAddBattleLog(`${target instanceof Player ? 'You' : target.name} evade${target instanceof Player ? '' : 's'} the hit!`, 'system');
             return;
         }
 
-        const damageBeforeArmor = enemy.getAttackDamage();
-        const escortResult = this.callbacks.onTryApplyEscortDamage?.(enemy.name, damageBeforeArmor) ?? { applied: false };
-        if (escortResult.applied) {
-            this.callbacks.onAddBattleLog(`${enemy.name} strikes ${escortResult.targetName} for ${damageBeforeArmor} damage!`, 'enemy');
-            if (escortResult.died) {
-                this.callbacks.onAddBattleLog(`${escortResult.targetName} falls in battle. Escort objective failed.`, 'system');
+        const damageBeforeArmor = attacker.getAttackDamage();
+        if (target instanceof Player) {
+            const escortResult = this.callbacks.onTryApplyEscortDamage?.(attacker.name, damageBeforeArmor) ?? { applied: false };
+            if (escortResult.applied) {
+                this.callbacks.onAddBattleLog(`${attacker.name} strikes ${escortResult.targetName} for ${damageBeforeArmor} damage!`, 'enemy');
+                if (escortResult.died) {
+                    this.callbacks.onAddBattleLog(`${escortResult.targetName} falls in battle. Escort objective failed.`, 'system');
+                }
+                this.callbacks.onUpdateHUD();
+                return;
             }
-            this.callbacks.onUpdateHUD();
-            return;
         }
-
-        const damageAfterArmor = damageBeforeArmor <= 0 ? 0 : Math.max(balanceConfig.combat.minDamageAfterArmor, damageBeforeArmor - this.player.armor);
-        this.player.takeDamage(damageBeforeArmor);
-
-        if (damageBeforeArmor > enemy.damage) {
-            this.callbacks.onAddBattleLog(`${enemy.name} lands a devastating strike!`, 'enemy');
-        }
-
-        if (this.player.armor > 0 && damageAfterArmor < damageBeforeArmor) {
-            this.callbacks.onAddBattleLog(`Player takes ${damageAfterArmor} damage (${damageBeforeArmor - damageAfterArmor} blocked by armor)!`, 'damage');
+        const targetArmor = target instanceof Player ? this.player.armor : target.armor;
+        const damageAfterArmor = damageBeforeArmor <= 0 ? 0 : Math.max(balanceConfig.combat.minDamageAfterArmor, damageBeforeArmor - targetArmor);
+        target.takeDamage(damageBeforeArmor);
+        if (targetArmor > 0 && damageAfterArmor < damageBeforeArmor) {
+            this.callbacks.onAddBattleLog(`${target instanceof Player ? 'Player' : target.name} takes ${damageAfterArmor} damage (${damageBeforeArmor - damageAfterArmor} blocked by armor)!`, 'damage');
         } else {
-            this.callbacks.onAddBattleLog(`Player takes ${damageAfterArmor} damage!`, 'damage');
+            this.callbacks.onAddBattleLog(`${target instanceof Player ? 'Player' : target.name} takes ${damageAfterArmor} damage!`, 'damage');
         }
 
         this.callbacks.onUpdateHUD();
     }
 
-    private tryPerformEnemyMagicAttack(enemy: Skeleton): boolean {
-        const caster = enemy as Skeleton & {
+    private tryPerformEnemyMagicAttack(attacker: Skeleton, target: Player | Skeleton): boolean {
+        const caster = attacker as Skeleton & {
             canUseMagic?: () => boolean;
             getMagicManaCost?: () => number;
             getMagicDamage?: () => number;
@@ -150,13 +158,30 @@ export default class BattleTurnController {
         if (!caster.canUseMagic || !caster.canUseMagic() || Math.random() >= 0.35) {
             return false;
         }
-        enemy.expireDirectionalBonusesWithoutAttack().forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
-        const magicDamage = caster.getMagicDamage ? caster.getMagicDamage() : enemy.damage;
+        attacker.expireDirectionalBonusesWithoutAttack().forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
+        const magicDamage = caster.getMagicDamage ? caster.getMagicDamage() : attacker.damage;
         const manaCost = caster.getMagicManaCost ? caster.getMagicManaCost() : 0;
         caster.spendMana?.(manaCost);
-        this.player.takeMagicDamage(magicDamage);
-        this.callbacks.onAddBattleLog(`${enemy.name} casts a spell for ${magicDamage} damage!`, 'enemy');
+        target.takeMagicDamage ? target.takeMagicDamage(magicDamage) : target.takeDamage(magicDamage);
+        this.callbacks.onAddBattleLog(`${attacker.name} casts a spell for ${magicDamage} damage!`, this.turnManager.isAlly(attacker) ? 'system-message' : 'enemy');
         this.callbacks.onUpdateHUD();
         return true;
+    }
+
+    private selectAiTarget(actor: Skeleton): Player | Skeleton | null {
+        const opponents = this.turnManager.getOpponentsOf(actor) as Array<Player | Skeleton>;
+        if (opponents.length === 0) {
+            return null;
+        }
+        return opponents
+            .map((candidate) => ({ candidate, distance: this.distanceBetween(actor, candidate) }))
+            .sort((left, right) => left.distance - right.distance)[0]?.candidate ?? null;
+    }
+
+    private distanceBetween(source: Skeleton, target: Player | Skeleton): number {
+        if (source.gridCol === undefined || source.gridRow === undefined || target.gridCol === undefined || target.gridRow === undefined) {
+            return Number.MAX_SAFE_INTEGER;
+        }
+        return Math.abs(source.gridCol - target.gridCol) + Math.abs(source.gridRow - target.gridRow);
     }
 }

--- a/rgfn_game/js/systems/game/runtime/GameBattleCoordinator.ts
+++ b/rgfn_game/js/systems/game/runtime/GameBattleCoordinator.ts
@@ -51,8 +51,14 @@ export default class GameBattleCoordinator {
         this.runtimeFlow = new GameBattleRuntimeFlow({ stateMachine, ...deps, callbacks, controllers, onStartBattle: () => this.startBattle() });
     }
 
-    public enterBattleMode(enemies: Skeleton[], terrainType: TerrainType = 'grass'): void {
-        this.runtimeFlow.enterBattleMode(enemies, terrainType);
+    public enterBattleMode(
+        enemies: Skeleton[],
+        terrainType: TerrainType = 'grass',
+        allies: Skeleton[] = [],
+        battleKind: 'default' | 'village-defense' = 'default',
+        villageName?: string,
+    ): void {
+        this.runtimeFlow.enterBattleMode(enemies, terrainType, allies, battleKind, villageName);
     }
 
     public updateBattleMode(): void {
@@ -141,6 +147,8 @@ export default class GameBattleCoordinator {
     }
 
     public getCurrentEnemies = (): Skeleton[] => this.runtimeFlow.getCurrentEnemies();
+    public getCurrentAllies = (): Skeleton[] => this.runtimeFlow.getCurrentAllies();
+    public getBattleContext = (): { kind: 'default' | 'village-defense'; villageName: string | null } => this.runtimeFlow.getBattleContext();
 
     public getSelectedEnemy = (): Skeleton | null => this.controllers.battlePlayerActionController.getSelectedEnemy();
 

--- a/rgfn_game/js/systems/game/runtime/GameBattleRuntimeFlow.ts
+++ b/rgfn_game/js/systems/game/runtime/GameBattleRuntimeFlow.ts
@@ -43,13 +43,22 @@ export default class GameBattleRuntimeFlow {
     private readonly deps: Deps;
     private turnTransitioning = false;
     private currentEnemies: Skeleton[] = [];
+    private currentAllies: Skeleton[] = [];
     private currentTerrainType: TerrainType = 'grass';
+    private currentBattleKind: 'default' | 'village-defense' = 'default';
+    private currentVillageName: string | null = null;
 
     constructor(deps: Deps) {
         this.deps = deps;
     }
 
-    public enterBattleMode(enemies: Skeleton[], terrainType: TerrainType = 'grass'): void {
+    public enterBattleMode(
+        enemies: Skeleton[],
+        terrainType: TerrainType = 'grass',
+        allies: Skeleton[] = [],
+        battleKind: 'default' | 'village-defense' = 'default',
+        villageName?: string,
+    ): void {
         this.turnTransitioning = true;
         this.deps.hudElements.modeIndicator.textContent = 'Battle!';
         this.deps.worldUI.sidebar.classList.add('hidden');
@@ -59,7 +68,10 @@ export default class GameBattleRuntimeFlow {
         this.deps.villageUI.rumorsPanel.classList.add('hidden');
         this.deps.controllers.battleCommandController.clearPendingLoot();
         this.currentEnemies = enemies;
+        this.currentAllies = allies;
         this.currentTerrainType = terrainType;
+        this.currentBattleKind = battleKind;
+        this.currentVillageName = villageName ?? null;
         this.deps.controllers.battlePlayerActionController.setSelectedEnemy(null);
         this.deps.battleMap.clearSelectedCell();
         this.deps.battleSplash.showBattleStart(enemies.length, this.deps.onStartBattle);
@@ -70,7 +82,7 @@ export default class GameBattleRuntimeFlow {
         this.deps.callbacks.onBattleEnded(result);
         if (result === 'fled') {
             this.deps.controllers.battleCommandController.clearPendingLoot();
-            this.deps.stateMachine.transition(MODES.WORLD_MAP);
+            this.deps.stateMachine.transition(this.currentBattleKind === 'village-defense' ? MODES.VILLAGE : MODES.WORLD_MAP);
             return;
         }
         if (result === 'defeat') {
@@ -81,12 +93,19 @@ export default class GameBattleRuntimeFlow {
         }
         this.deps.controllers.battleCommandController.resolvePendingLoot();
         this.deps.callbacks.onAddBattleLog('Victory!', 'system');
-        this.deps.battleSplash.showBattleEnd('victory', () => this.deps.stateMachine.transition(MODES.WORLD_MAP));
+        this.deps.battleSplash.showBattleEnd(
+            'victory',
+            () => this.deps.stateMachine.transition(this.currentBattleKind === 'village-defense' ? MODES.VILLAGE : MODES.WORLD_MAP),
+        );
     }
 
     public startBattle(): void {
-        this.deps.battleMap.setup(this.deps.player, this.currentEnemies, this.currentTerrainType);
-        this.deps.turnManager.initializeTurns([this.deps.player, ...this.currentEnemies]);
+        this.deps.battleMap.setup(this.deps.player, this.currentEnemies, this.currentTerrainType, this.currentAllies);
+        this.deps.turnManager.initializeTurns([this.deps.player, ...this.currentAllies, ...this.currentEnemies], {
+            player: this.deps.player,
+            allies: this.currentAllies,
+            enemies: this.currentEnemies,
+        });
         this.turnTransitioning = false;
         this.deps.callbacks.onClearBattleLog();
         const encounter = this.deps.callbacks.onDescribeEncounter(this.currentEnemies);
@@ -97,7 +116,10 @@ export default class GameBattleRuntimeFlow {
     public exitBattleMode(): void {
         this.turnTransitioning = false;
         this.currentEnemies = [];
+        this.currentAllies = [];
         this.currentTerrainType = 'grass';
+        this.currentBattleKind = 'default';
+        this.currentVillageName = null;
         this.deps.battleMap.clearSelectedCell();
     }
 
@@ -108,4 +130,9 @@ export default class GameBattleRuntimeFlow {
     public isTurnTransitioning = (): boolean => this.turnTransitioning;
 
     public getCurrentEnemies = (): Skeleton[] => this.currentEnemies;
+
+    public getCurrentAllies = (): Skeleton[] => this.currentAllies;
+
+    public getBattleContext = (): { kind: 'default' | 'village-defense'; villageName: string | null } =>
+        ({ kind: this.currentBattleKind, villageName: this.currentVillageName });
 }

--- a/rgfn_game/js/systems/game/ui/GameUiFactory.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiFactory.ts
@@ -102,6 +102,7 @@ export default class GameUiFactory {
         barterNowBtn: document.getElementById('village-confirm-barter-btn')! as HTMLButtonElement,
         confrontRecoverBtn: document.getElementById('village-confront-recover-btn')! as HTMLButtonElement,
         recruitEscortBtn: document.getElementById('village-recruit-escort-btn')! as HTMLButtonElement,
+        defendVillageBtn: document.getElementById('village-defend-objective-btn')! as HTMLButtonElement,
         leaveBtn: document.getElementById('village-leave-btn')! as HTMLButtonElement,
     });
 

--- a/rgfn_game/js/systems/game/ui/GameUiPrimaryEventBinder.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiPrimaryEventBinder.ts
@@ -124,6 +124,7 @@ export default class GameUiPrimaryEventBinder {
         this.villageUI.barterNowBtn.addEventListener('click', () => this.villageActionsController.handleConfirmBarter());
         this.villageUI.confrontRecoverBtn.addEventListener('click', () => this.villageActionsController.handleConfrontRecoverTarget());
         this.villageUI.recruitEscortBtn.addEventListener('click', () => this.villageActionsController.handleRecruitEscort());
+        this.villageUI.defendVillageBtn.addEventListener('click', () => this.villageActionsController.handleStartDefendObjective());
         this.villageUI.sleepRoomBtn.addEventListener('click', () => this.villageActionsController.handleSleepInRoom());
         this.villageUI.leaveBtn.addEventListener('click', () => this.villageActionsController.handleLeave());
     }

--- a/rgfn_game/js/systems/game/ui/GameUiSceneModels.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiSceneModels.ts
@@ -74,6 +74,7 @@ export class VillageUiModel {
     public barterNowBtn!: HTMLButtonElement;
     public confrontRecoverBtn!: HTMLButtonElement;
     public recruitEscortBtn!: HTMLButtonElement;
+    public defendVillageBtn!: HTMLButtonElement;
     public leaveBtn!: HTMLButtonElement;
 }
 

--- a/rgfn_game/js/systems/quest/QuestTypes.ts
+++ b/rgfn_game/js/systems/quest/QuestTypes.ts
@@ -89,9 +89,28 @@ export type RecoverObjectiveData = {
     enemyProfile?: RecoverEnemyProfile;
 };
 
+export type DefendObjectiveDefender = {
+    name: string;
+    maxHp: number;
+    currentHp: number;
+    isDead?: boolean;
+};
+
+export type DefendObjectiveData = {
+    villageName: string;
+    artifactName: string;
+    contactName: string;
+    durationDays: number;
+    timeRemainingMinutes: number;
+    isDefenseActive?: boolean;
+    defenders?: DefendObjectiveDefender[];
+    battleCooldownMinutes?: number;
+};
+
 export type QuestObjectiveData = {
     deliver?: DeliverObjectiveData;
     monster?: MonsterObjectiveData;
     escort?: EscortObjectiveData;
     recover?: RecoverObjectiveData;
+    defend?: DefendObjectiveData;
 };

--- a/rgfn_game/js/systems/quest/generation/QuestLeafFactory.ts
+++ b/rgfn_game/js/systems/quest/generation/QuestLeafFactory.ts
@@ -179,13 +179,27 @@ export default class QuestLeafFactory {
     private async createDefendNode(id: string): Promise<QuestNode> {
         const location = await this.generateName('location');
         const artifact = await this.generateName('artifact');
+        const contact = await this.generateName('character');
+        const durationDays = this.random.nextInt(3, 7);
         return this.contentBuilder.node(
             id,
             `Defend ${location.text}`,
-            `Hold ${location.text} until the ${this.contentBuilder.label(artifact)} is secured.`,
-            `Prevent the fall of ${location.text} while securing ${this.contentBuilder.label(artifact)}.`,
+            `${contact.text} asks you to hold ${location.text} until the ${this.contentBuilder.label(artifact)} is secured.`,
+            `Speak with ${contact.text} in ${location.text}, then Prevent the fall of ${location.text} for ${durationDays} day${durationDays === 1 ? '' : 's'} while securing ${this.contentBuilder.label(artifact)}.`,
             'defend',
-            this.contentBuilder.entities(location, artifact),
+            this.contentBuilder.entities(location, artifact, contact),
+            {
+                defend: {
+                    villageName: location.text,
+                    artifactName: artifact.text,
+                    contactName: contact.text,
+                    durationDays,
+                    timeRemainingMinutes: durationDays * 24 * 60,
+                    isDefenseActive: false,
+                    defenders: [],
+                    battleCooldownMinutes: 0,
+                },
+            },
         );
     }
 

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -6,7 +6,7 @@ import VillageStockService from './actions/VillageStockService.js';
 import VillageUiPresenter from './actions/VillageUiPresenter.js';
 import VillageTradeInteractionService from './actions/VillageTradeInteractionService.js';
 import VillageDialogueInteractionService from './actions/VillageDialogueInteractionService.js';
-import { QuestBarterContract, QuestEscortContract, VillageActionsCallbacks, VillageUI } from './actions/VillageActionsTypes.js';
+import { QuestBarterContract, QuestDefendContract, QuestEscortContract, VillageActionsCallbacks, VillageUI } from './actions/VillageActionsTypes.js';
 import { isDeveloperModeEnabled } from '../../utils/DeveloperModeConfig.js';
 export default class VillageActionsController {
     private readonly villageUI: VillageUI;
@@ -22,6 +22,7 @@ export default class VillageActionsController {
     private villageNpcRosters: Map<string, VillageNpcProfile[]> = new Map();
     private selectedNpcId: string | null = null;
     private escortContracts: QuestEscortContract[] = [];
+    private defendContracts: QuestDefendContract[] = [];
     private knownNpcNames: Set<string> = new Set();
     private joinedEscortNpcKeys: Set<string> = new Set();
 
@@ -52,6 +53,14 @@ export default class VillageActionsController {
     public configureQuestEscortContracts = (contracts: QuestEscortContract[]): void => {
         this.escortContracts = contracts;
         this.refreshDialogueTargetOptions();
+    };
+    public configureQuestDefendContracts = (contracts: QuestDefendContract[]): void => {
+        this.defendContracts = contracts;
+        this.villageNpcRosters.forEach((roster, villageName) => this.ensureQuestPeoplePresent(roster, villageName));
+        if (this.currentVillageName.trim()) {
+            this.npcRoster = this.getOrCreateVillageNpcRoster(this.currentVillageName);
+            this.refreshNpcUi();
+        }
     };
     public exitVillage(): void {
         this.villageUI.sidebar.classList.add('hidden');
@@ -218,16 +227,24 @@ export default class VillageActionsController {
     private getOrCreateVillageNpcRoster(villageName: string): VillageNpcProfile[] {
         const cachedRoster = this.villageNpcRosters.get(villageName);
         if (cachedRoster) {
+            this.ensureQuestPeoplePresent(cachedRoster, villageName);
             return cachedRoster;
         }
 
         const roster = this.dialogueEngine.createNpcRoster(villageName);
+        this.ensureQuestPeoplePresent(roster, villageName);
+        this.villageNpcRosters.set(villageName, roster);
+        return roster;
+    }
+
+    private ensureQuestPeoplePresent(roster: VillageNpcProfile[], villageName: string): void {
         this.barterService.getVillageContractTraders(villageName).forEach((traderName) => this.appendTraderIfMissing(roster, villageName, traderName));
         this.escortContracts
             .filter((contract) => contract.sourceVillage.trim().toLocaleLowerCase() === villageName.trim().toLocaleLowerCase())
             .forEach((contract) => this.appendEscortIfMissing(roster, villageName, contract));
-        this.villageNpcRosters.set(villageName, roster);
-        return roster;
+        this.defendContracts
+            .filter((contract) => contract.villageName.trim().toLocaleLowerCase() === villageName.trim().toLocaleLowerCase())
+            .forEach((contract) => this.appendDefendContactIfMissing(roster, villageName, contract));
     }
 
     private appendEscortIfMissing(roster: VillageNpcProfile[], villageName: string, contract: QuestEscortContract): void {
@@ -257,6 +274,21 @@ export default class VillageActionsController {
             role: 'Barter Broker',
             look: 'emerald scarf, ledger satchel, watchful eyes',
             speechStyle: 'steady and transactional',
+            disposition: 'truthful',
+        });
+    }
+
+    private appendDefendContactIfMissing(roster: VillageNpcProfile[], villageName: string, contract: QuestDefendContract): void {
+        const exists = roster.some((npc) => npc.name.toLocaleLowerCase() === contract.personName.toLocaleLowerCase());
+        if (exists) {
+            return;
+        }
+        roster.unshift({
+            id: `${villageName.toLowerCase()}-${contract.personName.toLocaleLowerCase()}-defend`,
+            name: contract.personName,
+            role: `Artifact Custodian (${contract.artifactName})`,
+            look: 'dusty gloves, encrypted satchel, sleepless eyes',
+            speechStyle: 'urgent and strategic',
             disposition: 'truthful',
         });
     }

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -104,6 +104,27 @@ export default class VillageActionsController {
     public handleAskAboutBarter(): void { this.dialogueInteraction.handleAskAboutBarter(); this.callbacks.onAdvanceTime(16, 0.12); }
     public handleConfirmBarter(): void { this.dialogueInteraction.handleConfirmBarter(); this.callbacks.onAdvanceTime(18, 0.15); }
     public handleConfrontRecoverTarget(): void { this.dialogueInteraction.handleConfrontRecoverTarget(); this.callbacks.onAdvanceTime(18, 0.15); }
+    public handleStartDefendObjective(): void {
+        const npc = this.getSelectedNpc();
+        if (!npc) {
+            this.addLog('Choose an NPC before committing to village defense duty.', 'system');
+            return;
+        }
+        const status = this.callbacks.onTryStartDefend?.(npc.name, this.currentVillageName, this.npcRoster.map((villager) => villager.name))
+            ?? { status: 'inactive' as const };
+        if (status.status === 'started') {
+            this.addLog(`You tell ${npc.name}: "I am ready to defend you as we agreed upon earlier."`, 'player');
+            this.addLog(`${npc.name}: "Hold this village for ${status.days ?? '?'} days while we secure the artifact."`, 'system');
+            this.callbacks.onAdvanceTime(20, 0.15);
+            this.updateButtons();
+            return;
+        }
+        if (status.status === 'already-active') {
+            this.addLog(`${npc.name} says the defense operation is already underway. Stay in the village and keep watch.`, 'system-message');
+            return;
+        }
+        this.addLog(`${npc.name} has no defense assignment for you in this village.`, 'system-message');
+    }
     // eslint-disable-next-line style-guide/function-length-warning
     public handleRecruitEscort(): void {
         const npc = this.getSelectedNpc();
@@ -156,6 +177,7 @@ export default class VillageActionsController {
         shouldShowBarterNowAction: (npcName) => this.hasActiveBarterDealForNpc(npcName),
         shouldShowConfrontRecoverAction: (npcName, villageName) => this.canConfrontRecoverTarget(npcName, villageName),
         shouldShowRecruitEscortAction: (npcName, villageName) => this.canRecruitEscort(npcName, villageName),
+        shouldShowDefendAction: (npcName, villageName) => this.canStartDefendObjective(npcName, villageName),
         getCurrentVillageName: () => this.currentVillageName,
     });
 
@@ -315,6 +337,13 @@ export default class VillageActionsController {
     }
 
     private getEscortNpcKey = (npcName: string, villageName: string): string => `${villageName.trim().toLocaleLowerCase()}::${npcName.trim().toLocaleLowerCase()}`;
+
+    private canStartDefendObjective(npcName: string, villageName: string): boolean {
+        if (!npcName.trim() || !villageName.trim() || !this.callbacks.onTryStartDefend) {
+            return false;
+        }
+        return true;
+    }
 
     private getKnownSettlementNames(): string[] {
         const knownFromMap = this.callbacks.getKnownSettlementNames?.() ?? [];

--- a/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
+++ b/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
@@ -62,6 +62,12 @@ export type QuestEscortContract = {
     destinationVillage: string;
 };
 
+export type QuestDefendContract = {
+    personName: string;
+    villageName: string;
+    artifactName: string;
+};
+
 export type QuestBarterContract = {
     traderName: string;
     itemName: string;

--- a/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
+++ b/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
@@ -31,6 +31,7 @@ export type VillageUI = {
     barterNowBtn: HTMLButtonElement;
     confrontRecoverBtn: HTMLButtonElement;
     recruitEscortBtn: HTMLButtonElement;
+    defendVillageBtn: HTMLButtonElement;
 };
 
 export type VillageActionsCallbacks = {
@@ -48,6 +49,11 @@ export type VillageActionsCallbacks = {
         villageName: string,
     ) => { status: 'started' | 'inactive' | 'not-target' | 'not-ready'; enemies?: Skeleton[]; itemName?: string };
     onStartBattle?: (enemies: Skeleton[]) => void;
+    onTryStartDefend?: (
+        npcName: string,
+        villageName: string,
+        villagerNames: string[],
+    ) => { status: 'started' | 'inactive' | 'not-target' | 'already-active'; objectiveTitle?: string; days?: number };
 };
 
 export type QuestEscortContract = {

--- a/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
+++ b/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
@@ -15,6 +15,7 @@ type PresenterDeps = {
     shouldShowBarterNowAction: (npcName: string) => boolean;
     shouldShowConfrontRecoverAction: (npcName: string, villageName: string) => boolean;
     shouldShowRecruitEscortAction: (npcName: string, villageName: string) => boolean;
+    shouldShowDefendAction: (npcName: string, villageName: string) => boolean;
     getCurrentVillageName: () => string;
 };
 
@@ -55,14 +56,17 @@ export default class VillageUiPresenter {
         const showBarterNow = hasSelectedNpc && this.deps.shouldShowBarterNowAction(selectedNpcName);
         const showConfrontRecover = hasSelectedNpc && this.deps.shouldShowConfrontRecoverAction(selectedNpcName, currentVillageName);
         const showRecruitEscort = hasSelectedNpc && this.deps.shouldShowRecruitEscortAction(selectedNpcName, currentVillageName);
+        const showDefendVillage = hasSelectedNpc && this.deps.shouldShowDefendAction(selectedNpcName, currentVillageName);
 
         this.deps.villageUI.barterNowBtn.classList.toggle('hidden', !showBarterNow);
         this.deps.villageUI.confrontRecoverBtn.classList.toggle('hidden', !showConfrontRecover);
         this.deps.villageUI.recruitEscortBtn.classList.toggle('hidden', !showRecruitEscort);
+        this.deps.villageUI.defendVillageBtn.classList.toggle('hidden', !showDefendVillage);
 
         this.deps.villageUI.barterNowBtn.disabled = !showBarterNow;
         this.deps.villageUI.confrontRecoverBtn.disabled = !showConfrontRecover;
         this.deps.villageUI.recruitEscortBtn.disabled = !showRecruitEscort;
+        this.deps.villageUI.defendVillageBtn.disabled = !showDefendVillage;
         this.deps.villageUI.sleepRoomBtn.disabled = !hasSelectedNpc || !this.deps.isInnkeeper(selectedNpc?.role ?? '');
     }
 

--- a/rgfn_game/test/systems/recoverQuestRuntime.test.js
+++ b/rgfn_game/test/systems/recoverQuestRuntime.test.js
@@ -87,6 +87,43 @@ function createQuestWithKnownAndUnknownContracts() {
   };
 }
 
+function createKnownDefendQuest() {
+  return {
+    id: 'main',
+    title: 'Main',
+    description: '',
+    conditionText: '',
+    objectiveType: 'scout',
+    entities: [],
+    children: [
+      {
+        id: 'defend-active',
+        title: 'Defend Heights Gate',
+        description: '',
+        conditionText: '',
+        objectiveType: 'defend',
+        entities: [
+          { text: 'Heights Gate', type: 'location' },
+          { text: 'Quinn Evans', type: 'person' },
+        ],
+        objectiveData: {
+          defend: {
+            villageName: 'Heights Gate',
+            artifactName: 'Allies Coverage',
+            contactName: 'Quinn Evans',
+            durationDays: 3,
+            timeRemainingMinutes: 4320,
+            isDefenseActive: false,
+          },
+        },
+        children: [],
+        isCompleted: false,
+      },
+    ],
+    isCompleted: false,
+  };
+}
+
 test('GameQuestRuntime revealRecoverHolder confirms target person when speaking with another villager', () => {
   const runtime = new GameQuestRuntime();
   const quest = createRecoverQuest();
@@ -176,4 +213,19 @@ test('GameQuestRuntime exposes only known quest location names for dialogue know
   const locations = runtime.getKnownQuestLocationNames();
 
   assert.deepEqual(locations, ['Farwatch']);
+});
+
+test('GameQuestRuntime exposes defend contracts for known active defend objectives', () => {
+  const runtime = new GameQuestRuntime();
+  const quest = createKnownDefendQuest();
+
+  const defendContracts = runtime['collectDefendContracts'](quest);
+
+  assert.deepEqual(defendContracts, [
+    {
+      personName: 'Quinn Evans',
+      villageName: 'Heights Gate',
+      artifactName: 'Allies Coverage',
+    },
+  ]);
 });

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -96,6 +96,7 @@ function createVillageUi() {
     barterNowBtn: createElement('button'),
     confrontRecoverBtn: createElement('button'),
     recruitEscortBtn: createElement('button'),
+    defendVillageBtn: createElement('button'),
     leaveBtn: createElement('button'),
   };
 }
@@ -288,6 +289,32 @@ test('VillageActionsController binds dynamically generated barter trader names w
   const hint = controller['barterService'].getPersonDirectionHint('Veyra', controller['callbacks'].getVillageDirectionHint);
   assert.equal(hint.exists, true);
   assert.equal(hint.villageName, 'Mossbrook');
+}));
+
+test('VillageActionsController injects defend contact NPC into the target village roster', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onAdvanceTime: () => {},
+    onLeaveVillage: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: true, direction: 'north', distanceCells: 3 }),
+    onVillageBarterCompleted: () => {},
+    onTryStartDefend: () => ({ status: 'inactive' }),
+  });
+
+  controller.configureQuestDefendContracts([
+    { personName: 'Quinn Evans', villageName: 'Heights Gate', artifactName: 'Allies Coverage' },
+  ]);
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'heights-0', name: 'Mara', role: 'Carpenter', look: 'cloak', speechStyle: 'calm', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Heights Gate');
+  const names = controller['npcRoster'].map((npc) => npc.name);
+  assert.equal(names.includes('Quinn Evans'), true);
 }));
 
 test('VillageActionsController adds revealed recover holder into current village roster immediately', () => withDocumentStub(() => {


### PR DESCRIPTION
### Motivation

- Add a defend-type quest flow so players can agree with a village NPC to hold a village while an artifact is produced and face intermittent raids. 
- Preserve main-quest safety by rolling the objective back if the player leaves the village, rather than failing it.
- Enable allied combatants in battle so village defenders can participate alongside the player.

### Description

- Added structured defend objective types and runtime metadata (`DefendObjectiveData`, `DefendObjectiveDefender`) to `QuestTypes.ts`. 
- Generate defend quest nodes with contact, artifact, duration and runtime fields in `QuestLeafFactory.ts`. 
- Exposed a new village dialogue UI button and wiring (`I am ready to defend you`) to start defend objectives in `index.html`, `GameUiFactory.ts`, `GameUiPrimaryEventBinder.ts`, `GameUiSceneModels.ts`, and `VillageUiPresenter.ts`. 
- Added controller flow to trigger defend start from the village UI (`VillageActionsController`) and callbacks to the game runtime via `GameFactoryHelpers.ts`. 
- Implemented defend lifecycle and mechanics in `GameQuestRuntime.ts`: starting defense, village-time ticks (`onVillageTimeAdvanced`), periodic attacker wave spawning with allied defender roster creation, defender HP regeneration over time, rollback when player leaves village, and persistence of defender casualties. 
- Extended battle startup/context to accept optional `allies` and battle `kind`/village name and to return to Village mode after village-defense battles in `GameRuntimeStateMachineFactory.ts`, `GameBattleRuntimeFlow.ts`, and `GameBattleCoordinator.ts`. 
- Added team-aware turn management and helper APIs (`teamByEntityId`, `isAlly`, `getPlayerSideParticipantCount`, opponents lookup) in `TurnManager.ts`. 
- Placed allies on the battle map and provided ally spawn positions in `BattleMap.ts`. 
- Implemented simple allied AI and target selection and made enemy AI respect allies in `BattleTurnController.ts`. 
- Adjusted XP and loot handling to split XP and probabilistically attribute loot to allied defenders in `BattleLootManager.ts` and propagate participant count usage in `BattleCommandController.ts`. 
- Added lifecycle hooks to start defense ticks and rollbacks on village leave in `GameFacadeLifecycleCoordinator.ts` and small facade helper methods in `GameFacade.ts` and shared types in `GameFacadeSharedTypes.ts`. 
- Documented the new defend runtime in `rgfn_game/docs/quest/defend-objective-runtime.md`.

### Testing

- Ran build: `npm run build:rgfn` and it succeeded. 
- Ran unit tests: `npm run test:rgfn` and all repository tests passed (144/144). 
- Ran lint on changed files: `eslint` reported no new lint errors in the modified TypeScript files; repo-wide style warnings remain from existing baseline rules but no new blocking errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc08c8cf888323ada86883640055ca)