### PR TITLE
Fix village HUD panel leakage outside village mode

### DIFF
--- a/rgfn_game/docs/village/village-panel-mode-isolation-2026-04-12.md
+++ b/rgfn_game/docs/village/village-panel-mode-isolation-2026-04-12.md
@@ -1,0 +1,52 @@
+# Village panel mode isolation hardening (April 12, 2026)
+
+## Problem statement
+- Some fresh runs could display **Village Actions** and **Village Rumors** while not actually in village mode (for example on the global map, and potentially during/after other mode transitions).
+- These panels must be treated as **village-only HUD surfaces**.
+
+## Root cause
+`GameUiHudPanelController` persists draggable panel visibility in a shared "world layout" context used by both:
+- `modeIndicator = "World Map"`
+- `modeIndicator = "Village"`
+
+That meant a previously saved village-panel visibility state could leak into World Map restore paths.
+
+## Strict invariant introduced
+Village-only panels (`#village-actions`, `#village-rumors-section`) now have a strict mode gate:
+- **Village mode** (`modeIndicator === "Village"`): always visible.
+- **Any non-village mode** (`"World Map"`, `"Battle!"`, or anything else): always hidden.
+
+This is enforced in two places so persistence cannot bypass it:
+1. During layout restore.
+2. During layout persistence and mode-change enforcement.
+
+## Implementation notes
+Updated in `GameUiHudPanelController`:
+- Added explicit `shouldForceVillagePanelsHidden()` companion to the existing village-visible predicate.
+- `restoreLayoutForCurrentContext()` now force-hides village panels when not in Village mode, even if stored snapshot says `hidden: false`.
+- `persistCurrentContextLayout()` now writes village panel hidden state as forced hidden outside Village mode.
+- `enforceVillagePanelVisibility()` now performs both sides of the rule:
+  - shows in Village mode
+  - hides otherwise
+
+## Regression tests
+Added scenario tests in `rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js`:
+1. **Mode transition hard gate test**
+   - Start in Village mode, verify panels visible.
+   - Switch to World Map, verify both hidden.
+   - Switch to Battle, verify both remain hidden.
+2. **Stale storage immunity test**
+   - Seed `WORLD_KEY` with `villageActions.hidden = false` and `villageRumors.hidden = false`.
+   - Bind controller in World Map mode.
+   - Verify both panels are still hidden (stored visibility cannot leak).
+
+## Why this is the strictest practical approach
+- It does not rely only on transition order.
+- It does not rely only on state machine callbacks.
+- It guards against stale localStorage, panel dragging side effects, and mode text observer timing.
+- It encodes rules in both restore and persistence paths plus runtime enforcement.
+
+## Verification commands
+- `npm run build:rgfn`
+- `npm run test:rgfn`
+- `npx eslint rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js`

--- a/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
@@ -288,6 +288,7 @@ export default class GameUiHudPanelController {
                 return;
             }
             const shouldForceVillageVisibility = this.shouldForceVillagePanelsVisible() && this.isVillagePanel(layoutKey);
+            const shouldForceVillageHidden = this.shouldForceVillagePanelsHidden() && this.isVillagePanel(layoutKey);
             const shouldForceSelectedHidden = this.shouldForceSelectedPanelHidden() && this.isSelectedPanel(layoutKey);
             element.dataset.offsetX = String(snapshot.offsetX);
             element.dataset.offsetY = String(snapshot.offsetY);
@@ -301,7 +302,14 @@ export default class GameUiHudPanelController {
             } else {
                 element.style.removeProperty('z-index');
             }
-            element.classList.toggle('hidden', shouldForceVillageVisibility ? false : shouldForceSelectedHidden ? true : snapshot.hidden);
+            const shouldHide = shouldForceVillageVisibility
+                ? false
+                : shouldForceVillageHidden
+                    ? true
+                    : shouldForceSelectedHidden
+                        ? true
+                        : snapshot.hidden;
+            element.classList.toggle('hidden', shouldHide);
             if (!element.classList.contains('hidden')) {
                 this.keepPanelReachableInViewport(element);
                 requestAnimationFrame(() => this.ensurePanelDragHandleIsReachable(element));
@@ -434,14 +442,18 @@ export default class GameUiHudPanelController {
             const zIndex = Number.parseInt(element.style.zIndex || '', 10);
             const isCombatPanel = layoutKey === GameUiHudPanelController.COMBAT_PANEL_PERSISTENCE_KEY;
             const isForcedVillagePanel = this.shouldForceVillagePanelsVisible() && this.isVillagePanel(layoutKey);
+            const isForcedHiddenVillagePanel = this.shouldForceVillagePanelsHidden() && this.isVillagePanel(layoutKey);
             const isForcedSelectedPanel = this.shouldForceSelectedPanelHidden() && this.isSelectedPanel(layoutKey);
-            const hidden = isCombatPanel
-                ? this.activeLayoutContext !== 'battle'
-                : isForcedVillagePanel
-                    ? false
-                    : isForcedSelectedPanel
-                        ? (this.selectedPanelHiddenBeforeVillage ?? element.classList.contains('hidden'))
-                        : element.classList.contains('hidden');
+            let hidden = element.classList.contains('hidden');
+            if (isCombatPanel) {
+                hidden = this.activeLayoutContext !== 'battle';
+            } else if (isForcedVillagePanel) {
+                hidden = false;
+            } else if (isForcedHiddenVillagePanel) {
+                hidden = true;
+            } else if (isForcedSelectedPanel) {
+                hidden = this.selectedPanelHiddenBeforeVillage ?? element.classList.contains('hidden');
+            }
             layout[layoutKey] = {
                 offsetX,
                 offsetY,
@@ -512,12 +524,16 @@ export default class GameUiHudPanelController {
     private shouldForceVillagePanelsVisible(): boolean {
         return (this.hudElements.modeIndicator.textContent?.trim() ?? '') === GameUiHudPanelController.MODE_TEXT.village;
     }
+    private shouldForceVillagePanelsHidden(): boolean {
+        return !this.shouldForceVillagePanelsVisible();
+    }
     private enforceVillagePanelVisibility(modeText: string): void {
-        if (modeText !== GameUiHudPanelController.MODE_TEXT.village) {
-            return;
-        }
         this.getPanelConfigs().forEach(({ element, persistenceKey }) => {
             if (!persistenceKey || !this.isVillagePanel(persistenceKey)) {
+                return;
+            }
+            if (modeText !== GameUiHudPanelController.MODE_TEXT.village) {
+                element.classList.add('hidden');
                 return;
             }
             element.classList.remove('hidden');

--- a/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
+++ b/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
@@ -317,6 +317,84 @@ test('GameUiHudPanelController forces village action and rumors panels visible i
   }
 });
 
+test('GameUiHudPanelController force-hides village actions and rumors panels outside Village mode', () => {
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalMutationObserver = global.MutationObserver;
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+  const observers = [];
+
+  global.window = { localStorage: createLocalStorage(), innerWidth: 1280, innerHeight: 720 };
+  const hudElements = createHudElements();
+  hudElements.modeIndicator.textContent = 'Village';
+  global.document = createMockDocument(hudElements);
+  global.requestAnimationFrame = (callback) => callback();
+  global.MutationObserver = class {
+    constructor(callback) { this.callback = callback; observers.push(this); }
+    observe(target) { this.target = target; }
+    trigger() { this.callback(); }
+  };
+
+  try {
+    const controller = new GameUiHudPanelController(hudElements, { onTogglePanel() {} });
+    controller.bind();
+
+    assert.equal(hudElements.villageActionsPanel.classList.contains('hidden'), false);
+    assert.equal(hudElements.villageRumorsPanel.classList.contains('hidden'), false);
+
+    hudElements.modeIndicator.textContent = 'World Map';
+    observers.forEach((observer) => observer.target === hudElements.modeIndicator && observer.trigger());
+    assert.equal(hudElements.villageActionsPanel.classList.contains('hidden'), true);
+    assert.equal(hudElements.villageRumorsPanel.classList.contains('hidden'), true);
+
+    hudElements.modeIndicator.textContent = 'Battle!';
+    observers.forEach((observer) => observer.target === hudElements.modeIndicator && observer.trigger());
+    assert.equal(hudElements.villageActionsPanel.classList.contains('hidden'), true);
+    assert.equal(hudElements.villageRumorsPanel.classList.contains('hidden'), true);
+  } finally {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.MutationObserver = originalMutationObserver;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
+test('GameUiHudPanelController ignores stale world-layout visibility for village panels when mode is not Village', () => {
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalMutationObserver = global.MutationObserver;
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+
+  const storage = createLocalStorage();
+  storage.setItem(WORLD_KEY, JSON.stringify({
+    villageActions: { offsetX: 12, offsetY: 22, width: null, height: null, hidden: false, zIndex: null },
+    villageRumors: { offsetX: 24, offsetY: 44, width: null, height: null, hidden: false, zIndex: null },
+  }));
+
+  global.window = { localStorage: storage, innerWidth: 1280, innerHeight: 720 };
+  const hudElements = createHudElements();
+  hudElements.modeIndicator.textContent = 'World Map';
+  global.document = createMockDocument(hudElements);
+  global.requestAnimationFrame = (callback) => callback();
+  global.MutationObserver = class {
+    constructor() {}
+    observe() {}
+  };
+
+  try {
+    const controller = new GameUiHudPanelController(hudElements, { onTogglePanel() {} });
+    controller.bind();
+
+    assert.equal(hudElements.villageActionsPanel.classList.contains('hidden'), true);
+    assert.equal(hudElements.villageRumorsPanel.classList.contains('hidden'), true);
+  } finally {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.MutationObserver = originalMutationObserver;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
 
 test('GameUiHudPanelController hides selected panel in Village mode and restores world visibility on return', () => {
   const originalWindow = global.window;


### PR DESCRIPTION
### Motivation
- Village-only HUD panels (`#village-actions`, `#village-rumors-section`) could become visible outside Village mode (World Map / Battle), leaking rumors and actions into other modes and causing confusing/unsafe UI states. 
- The fix enforces a strict, programmatic mode gate so village panels are only ever visible in Village mode, and also prevents stale persisted layout from re-enabling them outside Village.

### Description
- Hardened `GameUiHudPanelController` to enforce a strict village-only visibility invariant by adding `shouldForceVillagePanelsHidden()` and applying forced hide/show logic in `restoreLayoutForCurrentContext()`, `persistCurrentContextLayout()`, and `enforceVillagePanelVisibility()` so persisted snapshots cannot leak village-panel visibility. (file: `rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts`)
- When restoring or persisting layouts the controller now writes and respects forced hidden state for village panels outside Village mode so localStorage cannot re-enable village UI on other modes. (file: `rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts`)
- Added regression tests that validate the invariant across mode transitions and stale storage: `GameUiHudPanelController force-hides village actions and rumors panels outside Village mode` and `ignores stale world-layout visibility for village panels when mode is not Village`. (file: `rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js`)
- Added documentation describing the incident, root cause, invariant, implementation notes and verification commands. (file: `rgfn_game/docs/village/village-panel-mode-isolation-2026-04-12.md`)

### Testing
- Ran `npm run build:rgfn` and then `npm run test:rgfn`, and the full rgfn test suite completed with all tests passing (`145` tests, `0` failures). 
- Ran targeted ESLint on the changed files with `npx eslint rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js` with no new issues reported for the touched files. 
- Note: `npm run lint:ts:rgfn` reports pre-existing repo-wide lint/config issues unrelated to the touched code (errors originate from other files under `dist/` and other modules), so those were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc16434964832391c549fe724bf98e)