### PR TITLE
Harden world-map village detection so all mapped villages remain enterable

### DIFF
--- a/rgfn_game/docs/village/village-enterability-fallback-2026-04-13.md
+++ b/rgfn_game/docs/village/village-enterability-fallback-2026-04-13.md
@@ -1,0 +1,46 @@
+# Village enterability fallback (April 13, 2026)
+
+## Issue summary
+
+A world-map village tile could be visible and selectable as a village, but stepping onto it would not always open the village entry popup (`Enter` / `Pass by`).
+
+Observed player symptom:
+- selected panel identified tile as a mapped village;
+- hero stood on the tile;
+- no village entry popup appeared, so village mode could not be entered from that tile.
+
+## Root-cause class
+
+Village enterability checks depended primarily on the location-feature cache (`locationFeatureIndexMap` via `hasLocationFeatureAt(..., 'village')`).
+
+If that cache ever became temporarily inconsistent with the canonical village sets (`villages` and `villageIndexSet`), village prompt logic could reject a valid village tile.
+
+## Fix implemented
+
+`WorldMapVillageNavigationAndRender` now exposes `isVillageAt(col, row)` that treats a tile as village when **any** village source confirms it:
+
+1. location feature cache has `village`, OR
+2. `villageIndexSet` contains tile index, OR
+3. `villages` set contains tile key.
+
+`isPlayerOnVillage()` now uses this unified method.
+
+`WorldMapPersistenceAndSelection.getSelectedCellInfo()` now also uses `isVillageAt(...)` to keep selected-panel classification aligned with the enterability gate.
+
+## Regression test
+
+Added test scenario in `rgfn_game/test/systems/worldMap.test.js`:
+- place player on generated village tile,
+- clear location-feature cache intentionally,
+- assert `worldMap.isPlayerOnVillage()` is still `true`.
+
+This protects the core invariant:
+
+> Any village tile represented in world village state must remain enterable.
+
+## Follow-up guidance
+
+When adding new location features:
+- avoid single-source assumptions for critical interactions;
+- keep prompt gates and HUD selected-cell labels powered by the same village predicate;
+- include tests that simulate stale/missing caches.

--- a/rgfn_game/js/systems/world/worldMap/WorldMapPersistenceAndSelection.ts
+++ b/rgfn_game/js/systems/world/worldMap/WorldMapPersistenceAndSelection.ts
@@ -158,7 +158,7 @@ export default class WorldMapPersistenceAndSelection extends WorldMapRoadNetwork
             return null;
         }
 
-        const isVillage = this.hasLocationFeatureAt(this.selectedGridPos.col, this.selectedGridPos.row, 'village');
+        const isVillage = this.isVillageAt(this.selectedGridPos.col, this.selectedGridPos.row);
         const locationFeatureIds = this.getLocationFeatureIdsAt(this.selectedGridPos.col, this.selectedGridPos.row);
         const isCurrentVillage = isVillage
             && this.selectedGridPos.col === this.playerGridPos.col

--- a/rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts
+++ b/rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts
@@ -104,6 +104,13 @@ export default class WorldMapVillageNavigationAndRender extends WorldMapMovement
     public getCurrentTerrain = (): TerrainData => this.getTerrain(this.playerGridPos.col, this.playerGridPos.row) ?? { type: 'grass', color: theme.worldMap.terrain.grass, pattern: 'plain', elevation: 0.5, moisture: 0.5, heat: 0.5, seed: 0 };
 
     public getVillageNameAtPlayerPosition = (): string => this.getVillageName(this.playerGridPos.col, this.playerGridPos.row);
+    public isVillageAt(col: number, row: number): boolean {
+        const index = this.getCellIndex(col, row);
+        const key = this.getCellKey(col, row);
+        return this.hasLocationFeatureAt(col, row, 'village')
+            || this.villageIndexSet.has(index)
+            || this.villages.has(key);
+    }
     public getKnownVillages = (): KnownVillage[] => Array.from(this.villages.values())
         .map((key) => {
             const [colText, rowText] = key.split(',');
@@ -143,7 +150,7 @@ export default class WorldMapVillageNavigationAndRender extends WorldMapMovement
         return generateVillageName(seed);
     }
 
-    public isPlayerOnVillage = (): boolean => this.hasLocationFeatureAt(this.playerGridPos.col, this.playerGridPos.row, 'village');
+    public isPlayerOnVillage = (): boolean => this.isVillageAt(this.playerGridPos.col, this.playerGridPos.row);
 
     public markVillageAtPlayerPosition(): void {
         const key = this.getCellKey(this.playerGridPos.col, this.playerGridPos.row);

--- a/rgfn_game/test/systems/worldMap.test.js
+++ b/rgfn_game/test/systems/worldMap.test.js
@@ -37,6 +37,20 @@ test('WorldMap generation excludes mountain and desert terrain types', () => wit
   assert.equal(terrainTypes.includes('desert'), false);
 }));
 
+test('WorldMap still treats legacy village cells as enterable when location feature cache is missing', () => withMockedRandom([0.29], () => {
+  const worldMap = new WorldMap(40, 30, 20);
+  const [firstVillageKey] = worldMap.getState().villages;
+  assert.equal(typeof firstVillageKey, 'string');
+
+  const [colText, rowText] = firstVillageKey.split(',');
+  const col = Number(colText);
+  const row = Number(rowText);
+  placePlayerAt(worldMap, col, row);
+
+  worldMap.clearAllLocationFeatures();
+  assert.equal(worldMap.isPlayerOnVillage(), true);
+}));
+
 test('WorldMap generates villages before placing the player into the world', () => withMockedRandom([0.11], () => {
   const worldMap = new WorldMap(40, 30, 20);
   const state = worldMap.getState();


### PR DESCRIPTION
### Motivation
- Players could stand on a mapped village tile but not receive the entry popup because enterability relied on a single location-feature cache that could be stale. This must never happen: every village represented in world state must be enterable.

### Description
- Added a unified predicate `isVillageAt(col, row)` in `WorldMapVillageNavigationAndRender` that treats a cell as a village when any source reports it: `locationFeatureIndexMap`, `villageIndexSet`, or `villages`.
- Switched `isPlayerOnVillage()` to use the new `isVillageAt(...)` so the village entry gate no longer depends on a single cache.
- Aligned selected-cell HUD classification by replacing `hasLocationFeatureAt(..., 'village')` with `isVillageAt(...)` in `WorldMapPersistenceAndSelection.getSelectedCellInfo()` so UI and enterability are consistent.
- Added a regression test in `rgfn_game/test/systems/worldMap.test.js` that clears location-feature cache and verifies a generated village cell remains enterable.
- Added `rgfn_game/docs/village/village-enterability-fallback-2026-04-13.md` documenting the issue class, fix rationale, invariant, and follow-up guidance.

### Testing
- Ran `npm run build:rgfn && node --test rgfn_game/test/systems/worldMap.test.js` and the world-map tests passed (all subtests OK).
- Ran the full RGFN test suite with `npm run test:rgfn` and all tests passed (150 tests, 0 failures).
- Ran linting with `npx eslint` against the modified files and observed no reported lint errors for the touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce5f72a208323924c6c2184227019)