### PR TITLE
Harden BattleTurnController to recover from AI-turn failures (fix ally deadlock)

### DIFF
--- a/rgfn_game/docs/quests/defend-village-turn-deadlock-recovery-2026-04-13.md
+++ b/rgfn_game/docs/quests/defend-village-turn-deadlock-recovery-2026-04-13.md
@@ -1,0 +1,63 @@
+# Defend Village: Turn Deadlock Recovery (2026-04-13)
+
+## Problem summary
+
+During **village-defense battles** (`player + defenders` vs `Hired Blade` attackers), rare runtime errors in a non-player combatant turn could stop turn progression while battle controls remained disabled. 
+
+Observed player-facing symptom:
+
+- No usable combat actions.
+- Battle appears frozen or unclear whose turn it is.
+- Most visible in ally-heavy encounters because there are more AI turns per round.
+
+## Root cause
+
+`BattleTurnController.executeAiTurn()` assumed every AI-turn step would succeed. If any AI call threw (for example: status-effect processing, targeting edge cases, or future AI extension regressions), the asynchronous turn callback exited early and never advanced to the next turn.
+
+Because player controls are disabled during non-player turns, this resulted in a deadlock-like state.
+
+## Fix implemented
+
+### 1) AI turn fail-safe recovery
+
+Added guarded execution around AI turn logic in `BattleTurnController`:
+
+- On AI turn exception, we now:
+  - log a system line (`"<name> hesitates, and the turn advances."`),
+  - force `turnManager.nextTurn()`,
+  - schedule `processTurn()` again.
+
+This guarantees progression even if one AI actor fails for one frame.
+
+### 2) Player-turn button reset hardening
+
+On player-turn entry, controls are explicitly toggled off then on in the same flow before returning. This prevents stale disabled-button state from prior transitions from persisting.
+
+## Regression tests
+
+Added a new scenario test:
+
+- `BattleTurnController recovers from AI turn errors and still returns control to the player`
+
+Test setup:
+
+- turn order: `Player -> Ally Defender -> Hired Blade`.
+- ally throws from `consumeTurnEffects()`.
+
+Assertions:
+
+- recovery log is emitted,
+- control returns to player turn,
+- `waitingForPlayer === true`,
+- battle buttons are re-enabled,
+- player-ready callback is fired exactly once.
+
+## Why this is safe
+
+- Normal AI behavior is unchanged.
+- Recovery path runs only on thrown AI-turn errors.
+- Turn sequencing remains deterministic: failure consumes exactly one actor turn and continues.
+
+## Follow-up recommendation
+
+If new ally/enemy actor types are added, keep AI-turn operations exception-safe (or validate required methods upfront) to preserve battle loop liveness.

--- a/rgfn_game/js/systems/game/BattleTurnController.ts
+++ b/rgfn_game/js/systems/game/BattleTurnController.ts
@@ -48,6 +48,7 @@ export default class BattleTurnController {
         }
 
         if (this.turnManager.isPlayerTurn()) {
+            this.callbacks.onEnableBattleButtons(false);
             const playerEffectMessages = this.player.consumePlayerTurnEffects();
             playerEffectMessages.forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
             this.turnManager.waitingForPlayer = true;
@@ -62,49 +63,60 @@ export default class BattleTurnController {
 
     private executeAiTurn(actor: Skeleton): void {
         setTimeout(() => {
-            if (actor.shouldSkipTurnFromSlow()) {
-                const effectMessages = actor.consumeTurnEffects();
-                this.completeAiTurn(effectMessages);
-                return;
-            }
-
-            const effectMessages = actor.consumeTurnEffects();
-            effectMessages
-                .filter((message) => !message.includes('skips this turn'))
-                .forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
-
-            const target = this.selectAiTarget(actor);
-            if (!target) {
-                this.completeAiTurn();
-                return;
-            }
-
-            const attackRange = this.getEnemyAttackRange(actor);
-            const inRange = this.battleMap.isInAttackRange(actor, target, attackRange);
-
-            if (inRange) {
-                this.performAiAttack(actor, target);
-                if (this.player.isDead()) {
-                    this.callbacks.onAddBattleLog('You have been defeated!', 'system');
-                    setTimeout(() => this.callbacks.onBattleEnd('defeat'), timingConfig.battle.defeatEndDelay);
+            try {
+                if (this.processAiTurn(actor)) {
                     return;
                 }
-            } else {
-                this.battleMap.moveEntityToward(actor, target, attackRange);
-                this.callbacks.onAddBattleLog(`${actor.name} moves closer...`, this.turnManager.isAlly(actor) ? 'system-message' : 'enemy');
+            } catch {
+                this.callbacks.onAddBattleLog(`${actor.name} hesitates, and the turn advances.`, 'system');
+                this.advanceTurnLoop();
             }
-
-            this.turnManager.nextTurn();
-            setTimeout(() => this.processTurn(), timingConfig.battle.enemyTurnDelay);
         }, timingConfig.battle.enemyActionStartDelay);
+    }
+
+    private processAiTurn(actor: Skeleton): boolean {
+        if (actor.shouldSkipTurnFromSlow()) {
+            const effectMessages = actor.consumeTurnEffects();
+            this.completeAiTurn(effectMessages);
+            return true;
+        }
+        this.logAiTurnEffects(actor.consumeTurnEffects());
+        const target = this.selectAiTarget(actor);
+        if (!target) {
+            this.completeAiTurn();
+            return true;
+        }
+        const attackRange = this.getEnemyAttackRange(actor);
+        if (this.battleMap.isInAttackRange(actor, target, attackRange)) {
+            this.performAiAttack(actor, target);
+            if (this.player.isDead()) {
+                this.callbacks.onAddBattleLog('You have been defeated!', 'system');
+                setTimeout(() => this.callbacks.onBattleEnd('defeat'), timingConfig.battle.defeatEndDelay);
+                return true;
+            }
+        } else {
+            this.battleMap.moveEntityToward(actor, target, attackRange);
+            this.callbacks.onAddBattleLog(`${actor.name} moves closer...`, this.turnManager.isAlly(actor) ? 'system-message' : 'enemy');
+        }
+        this.advanceTurnLoop();
+        return true;
     }
 
     private completeAiTurn(logs: string[] = []): void {
         logs.forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
+        this.advanceTurnLoop();
+    }
+
+    private advanceTurnLoop(): void {
         this.turnManager.nextTurn();
         setTimeout(() => this.processTurn(), timingConfig.battle.enemyTurnDelay);
     }
 
+    private logAiTurnEffects(effectMessages: string[]): void {
+        effectMessages
+            .filter((message) => !message.includes('skips this turn'))
+            .forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
+    }
 
     private getEnemyAttackRange(enemy: Skeleton): number {
         const rangedEnemy = enemy as Skeleton & { getAttackRange?: () => number };
@@ -167,7 +179,6 @@ export default class BattleTurnController {
         this.callbacks.onUpdateHUD();
         return true;
     }
-
     private selectAiTarget(actor: Skeleton): Player | Skeleton | null {
         const opponents = this.turnManager.getOpponentsOf(actor) as Array<Player | Skeleton>;
         if (opponents.length === 0) {

--- a/rgfn_game/test/systems/scenarios/battleTurnController.test.js
+++ b/rgfn_game/test/systems/scenarios/battleTurnController.test.js
@@ -120,3 +120,56 @@ test('BattleTurnController immediately re-enables player actions on player turn'
   assert.equal(playerReadyCount, 1);
   assert.deepEqual(logs, []);
 });
+
+test('BattleTurnController recovers from AI turn errors and still returns control to the player', async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (callback) => {
+    callback();
+    return 0;
+  };
+
+  try {
+    const player = new Player();
+    const ally = new Skeleton(2, 'Defender');
+    ally.consumeTurnEffects = () => {
+      throw new Error('ai effect failure');
+    };
+    const enemy = new Skeleton(3, 'Hired Blade 1');
+    const turnManager = new TurnManager();
+    turnManager.initializeTurns([player, ally, enemy], {
+      player,
+      allies: [ally],
+      enemies: [enemy],
+    });
+    turnManager.nextTurn();
+
+    const logs = [];
+    let buttonsEnabled = false;
+    let playerReadyCount = 0;
+    const battleTurnController = new BattleTurnController(
+      {
+        isInAttackRange: () => false,
+        moveEntityToward: () => {},
+      },
+      turnManager,
+      player,
+      {
+        onAddBattleLog: (message) => logs.push(message),
+        onUpdateHUD: () => {},
+        onEnableBattleButtons: (enabled) => { buttonsEnabled = enabled; },
+        onBattleEnd: () => {},
+        onPlayerTurnReady: () => { playerReadyCount += 1; },
+      }
+    );
+
+    battleTurnController.processTurn();
+
+    assert.equal(logs.includes('Defender hesitates, and the turn advances.'), true);
+    assert.equal(turnManager.isPlayerTurn(), true);
+    assert.equal(turnManager.waitingForPlayer, true);
+    assert.equal(buttonsEnabled, true);
+    assert.equal(playerReadyCount, 1);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+});


### PR DESCRIPTION
### Motivation

- Fix a freeze/deadlock in village-defense battles where an AI (usually an allied defender/hired blade) throwing during its turn could leave the battle with disabled player controls and no available actions.

### Description

- Wrapped AI-turn execution in `BattleTurnController` with a guarded path and added helpers `processAiTurn`, `advanceTurnLoop`, and `logAiTurnEffects` so any AI exception logs a recovery message and forces the turn to advance instead of stalling (`rgfn_game/js/systems/game/BattleTurnController.ts`).
- Hardened player-turn entry by explicitly toggling battle buttons off then on to avoid stale disabled-state carryover (`rgfn_game/js/systems/game/BattleTurnController.ts`).
- Added a regression scenario test `BattleTurnController recovers from AI turn errors and still returns control to the player` that simulates an allied defender throwing from `consumeTurnEffects()` and asserts recovery behavior (`rgfn_game/test/systems/scenarios/battleTurnController.test.js`).
- Documented the bug, root cause, fix strategy, test coverage and follow-up guidance in `rgfn_game/docs/quests/defend-village-turn-deadlock-recovery-2026-04-13.md`.

### Testing

- Ran `npm run build:rgfn` and `npm run test:rgfn` and the full RGFN test suite passed (151 tests, 0 failures).
- Ran `npx eslint` against the modified files (`BattleTurnController.ts` and its test) which reported only a style warning for file length and no new errors.
- Ran the repository lint script `npm run lint:ts:rgfn` which failed due to pre-existing repo-wide lint rule definitions and `dist/` issues unrelated to this change; the failure is baseline noise and did not indicate regressions in the changed code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0ec793748323b5a37f4c5b463e8a)