### PR TITLE
Initialize per-entity directional behaviors for human combatants

### DIFF
--- a/rgfn_game/docs/systems/monster-behavior-codex.md
+++ b/rgfn_game/docs/systems/monster-behavior-codex.md
@@ -14,8 +14,12 @@ This system is intentionally designed so players can gradually learn enemy patte
    - If a monster has no codex entry or gets an empty behavior pool, this is now treated as an error.
    - We do this deliberately so configuration gaps fail fast during development.
 2. **Every monster archetype participates** (skeleton, zombie, ninja, darkKnight, dragon).
-3. **Quest-spawned monsters and unique quest mutants use the same rolling model** when they are created in code.
-4. Behavior length is configurable and currently set to **1..5 moves**.
+3. **Humans use per-entity behavior pools.**
+   - Human combatants (`Wanderer`, defend quest combatants like hired blades/defenders, and recover-target humans) now receive directional pools at entity construction time.
+   - The pool is generated from the human move list, but is instance-scoped instead of shared codex-scoped.
+   - This prevents crashes where human entities reached directional combat without an assigned pool.
+4. **Quest-spawned monsters and unique quest mutants use the same rolling model** when they are created in code.
+5. Behavior length is configurable and currently set to **1..5 moves**.
 
 ## Configuration
 
@@ -36,10 +40,11 @@ Current knobs:
 
 ## Runtime Flow
 
-1. At runtime/world initialization, the game generates one codex for all monster archetypes.
-2. Whenever a monster instance is created, it receives the behavior pool matching its archetype.
-3. In directional combat, enemy move resolution uses the monster's next move from its active behavior.
-4. After a behavior finishes, the next behavior is selected with weighted random.
+1. At runtime/world initialization, the game generates one codex for non-human monster archetypes.
+2. Whenever a non-human monster instance is created, it receives the behavior pool matching its archetype.
+3. Human entities generate their own behavior pool immediately on spawn using the same generation knobs and the human move pool.
+4. In directional combat, enemy move resolution uses the monster's next move from its active behavior.
+5. After a behavior finishes, the next behavior is selected with weighted random.
 
 ## Developer Lore Visibility
 
@@ -61,4 +66,5 @@ If combat throws behavior-related errors:
 1. Verify all archetype IDs used by monster spawns exist in `monsterMovePools`.
 2. Verify each pool has at least one valid directional move token.
 3. Confirm runtime world initialization is calling codex generation before encounters/quests.
-4. In developer mode, open Lore panel and inspect generated codex entries.
+4. Confirm human move pool (`human`) exists and is non-empty; human entities now initialize their own pool in `Skeleton`.
+5. In developer mode, open Lore panel and inspect generated codex entries.

--- a/rgfn_game/js/entities/Skeleton.ts
+++ b/rgfn_game/js/entities/Skeleton.ts
@@ -5,6 +5,7 @@ import { balanceConfig } from '../config/balance/balanceConfig.js';
 import { cloneBaseStats, deriveCreatureStats, normalizeCreatureSkills } from '../config/creatureStats.js';
 import { CreatureBaseStats, CreatureSkill, CreatureSkills } from '../config/creatureTypes.js';
 import { CombatBuffSnapshot, CombatMove, CombatStatusState } from '../systems/combat/DirectionalCombat.js';
+import { generateDirectionalBehaviorPool } from '../systems/combat/MonsterBehaviorCodex.js';
 import { MonsterDirectionalBehavior, selectWeightedBehavior } from '../systems/combat/MonsterBehaviorCodex.js';
 import { MonsterMutationEngine } from './monster/MonsterMutationEngine.js';
 import { MonsterStatusEffects } from './monster/MonsterStatusEffects.js';
@@ -108,6 +109,7 @@ export default class Skeleton extends DamageableEntity {
         this.monsterStatusEffects = new MonsterStatusEffects();
         this.monsterVisualRenderer = new MonsterVisualRenderer();
         this.initializeHp(derivedStats.maxHp);
+        this.initializeHumanDirectionalBehaviorPool();
     }
 
     private buildInitialization(enemyConfig?: EnemyConfig): SkeletonInitialization {
@@ -140,6 +142,21 @@ export default class Skeleton extends DamageableEntity {
     private initializeHp(maxHp: number): void {
         const hpMultiplier = Math.max(0, balanceConfig.enemies.hpMultiplier ?? 1);
         (this as any).initDamageable(Math.round(maxHp * hpMultiplier));
+    }
+
+    private initializeHumanDirectionalBehaviorPool(): void {
+        if (this.archetypeId !== 'human') {
+            return;
+        }
+
+        const behaviorGeneration = balanceConfig.combat.enemyBehaviorGeneration;
+        const movePool = behaviorGeneration.monsterMovePools.human;
+        if (!movePool || movePool.length === 0) {
+            throw new Error('Missing directional move pool for human archetype.');
+        }
+        const behaviorPoolId = `human-${this.name.toLocaleLowerCase().replace(/[^a-z0-9]+/g, '-')}-${this.id}`;
+        const behaviorPool = generateDirectionalBehaviorPool(behaviorPoolId, movePool, behaviorGeneration);
+        this.setDirectionalBehaviorPool(behaviorPool);
     }
 
     public takeDamage(amount: number): boolean {

--- a/rgfn_game/js/systems/combat/MonsterBehaviorCodex.ts
+++ b/rgfn_game/js/systems/combat/MonsterBehaviorCodex.ts
@@ -30,26 +30,53 @@ const sanitizeMovePool = (movePool: string[]): CombatMove[] => {
 };
 
 // eslint-disable-next-line style-guide/function-length-warning
+const generateBehaviorPoolFromMovePool = (
+    behaviorPoolId: string,
+    movePool: string[],
+    config: Pick<
+        MonsterBehaviorGenerationConfig,
+        'minBehaviorsPerMonsterType'
+        | 'maxBehaviorsPerMonsterType'
+        | 'minMovesPerBehavior'
+        | 'maxMovesPerBehavior'
+        | 'behaviorWeightMin'
+        | 'behaviorWeightMax'
+    >,
+): MonsterDirectionalBehavior[] => {
+    const sanitizedPool = sanitizeMovePool(movePool);
+    const behaviorCount = randomInt(config.minBehaviorsPerMonsterType, config.maxBehaviorsPerMonsterType);
+    const createBehavior = (behaviorIndex: number): MonsterDirectionalBehavior => {
+        const movesCount = randomInt(config.minMovesPerBehavior, config.maxMovesPerBehavior);
+        const moves = Array.from({ length: movesCount }, () => pickOne(sanitizedPool));
+        const weight = randomInt(config.behaviorWeightMin, config.behaviorWeightMax);
+        return { id: `${behaviorPoolId}-behavior-${behaviorIndex + 1}`, weight, moves };
+    };
+    return Array.from({ length: behaviorCount }, (_, behaviorIndex) => createBehavior(behaviorIndex));
+};
+
 export function generateMonsterDirectionalBehaviorCodex(config: MonsterBehaviorGenerationConfig): MonsterDirectionalBehaviorCodex {
     const codex: MonsterDirectionalBehaviorCodex = {};
 
     Object.entries(config.monsterMovePools).forEach(([monsterType, movePool]) => {
-        const sanitizedPool = sanitizeMovePool(movePool);
-        const behaviorCount = randomInt(config.minBehaviorsPerMonsterType, config.maxBehaviorsPerMonsterType);
-        const behaviors: MonsterDirectionalBehavior[] = [];
-
-        for (let behaviorIndex = 0; behaviorIndex < behaviorCount; behaviorIndex++) {
-            const movesCount = randomInt(config.minMovesPerBehavior, config.maxMovesPerBehavior);
-            const moves: CombatMove[] = Array.from({ length: movesCount }, () => pickOne(sanitizedPool));
-            const weight = randomInt(config.behaviorWeightMin, config.behaviorWeightMax);
-            behaviors.push({ id: `${monsterType}-behavior-${behaviorIndex + 1}`, weight, moves });
-        }
-
-        codex[monsterType] = behaviors;
+        codex[monsterType] = generateBehaviorPoolFromMovePool(monsterType, movePool, config);
     });
 
     return codex;
 }
+
+export const generateDirectionalBehaviorPool = (
+    behaviorPoolId: string,
+    movePool: string[],
+    config: Pick<
+        MonsterBehaviorGenerationConfig,
+        'minBehaviorsPerMonsterType'
+        | 'maxBehaviorsPerMonsterType'
+        | 'minMovesPerBehavior'
+        | 'maxMovesPerBehavior'
+        | 'behaviorWeightMin'
+        | 'behaviorWeightMax'
+    >,
+): MonsterDirectionalBehavior[] => generateBehaviorPoolFromMovePool(behaviorPoolId, movePool, config);
 
 export function selectWeightedBehavior(behaviors: MonsterDirectionalBehavior[]): MonsterDirectionalBehavior | null {
     const totalWeight = behaviors.reduce((sum, behavior) => sum + Math.max(0, behavior.weight), 0);

--- a/rgfn_game/test/systems/monsterBehaviorCodex.test.js
+++ b/rgfn_game/test/systems/monsterBehaviorCodex.test.js
@@ -42,3 +42,15 @@ test('Skeleton directional move roll throws when no behavior pool is assigned (n
 
   assert.throws(() => skeleton.rollDirectionalCombatMove(), /no directional behavior/i);
 });
+
+test('Human archetype entities receive instance-scoped directional behavior pools automatically', () => {
+  const wandererA = new Skeleton(0, 0, { archetypeId: 'human', xpValue: 1, name: 'Wanderer Alpha', width: 10, height: 10 });
+  const wandererB = new Skeleton(0, 0, { archetypeId: 'human', xpValue: 1, name: 'Wanderer Beta', width: 10, height: 10 });
+
+  const validMoves = new Set(['AttackLeft', 'AttackCenter', 'AttackRight', 'Block', 'DodgeLeft', 'DodgeRight']);
+  const firstMoveA = wandererA.rollDirectionalCombatMove();
+  const firstMoveB = wandererB.rollDirectionalCombatMove();
+
+  assert.equal(validMoves.has(firstMoveA), true);
+  assert.equal(validMoves.has(firstMoveB), true);
+});


### PR DESCRIPTION
### Motivation
- Human combatants (wanderers, hired blades, recover targets) could reach directional combat without a behavior pool, causing errors like `Monster "Wanderer Lv.X" has no directional behavior to execute.`
- Humans should be learned individually and not reuse a shared monster codex pool, so each human needs its own instance-scoped behavior pool.

### Description
- Added a reusable `generateDirectionalBehaviorPool(...)` helper to `rgfn_game/js/systems/combat/MonsterBehaviorCodex.ts` and refactored pool generation to reuse that logic. 
- Implemented `initializeHumanDirectionalBehaviorPool()` in `rgfn_game/js/entities/Skeleton.ts` and call it from the constructor so any `human`-archetype entity generates its own instance-scoped behavior pool at spawn time. 
- Added a regression test `Human archetype entities receive instance-scoped directional behavior pools automatically` in `rgfn_game/test/systems/monsterBehaviorCodex.test.js` to assert that human instances can immediately roll valid directional moves. 
- Updated `rgfn_game/docs/systems/monster-behavior-codex.md` to document the per-entity human behavior model and added a debug checklist entry for the human move pool. 
- Fixed linter warnings introduced by the change for the modified files.

### Testing
- Ran `npm run build:rgfn` and the TypeScript build completed successfully. (succeeded)
- Ran the test suite with `npm run test:rgfn` which executed 152 tests and all tests passed. (152 passed, 0 failed)
- Ran targeted linting `npx eslint rgfn_game/js/entities/Skeleton.ts rgfn_game/js/systems/combat/MonsterBehaviorCodex.ts --ext .ts` and resolved warnings for the modified files. (succeeded)
- Note: a full repo lint (`npm run lint:ts:rgfn`) still reports unrelated pre-existing style-guide errors in many files outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1bd25ca883239ee1ac2070084df1)