### PR TITLE
Decouple Skills and Inventory HUD panels by fixing z-index elevation

### DIFF
--- a/rgfn_game/docs/systems/hud-panels.md
+++ b/rgfn_game/docs/systems/hud-panels.md
@@ -637,3 +637,26 @@ To align interaction behavior with existing HUD windows (`Stats`, `Skills`, etc.
 ### Regression test
 
 - Added scenario test: reopening `Inventory` while `Skills` has high z-index must bring `Inventory` to front.
+
+## Panel spawn reliability hardening (April 15, 2026)
+
+### Additional finding after z-index fix
+
+- In some open/toggle timing paths, a panel could remain at its default offset because initial spawn placement ran while dimensions were still `0x0`.
+- When that happened, multiple panels could appear at the same origin and feel visually coupled (including resize overlap artifacts).
+
+### Implementation update
+
+- `bindPanelSpawnPositioning` now retries spawn placement across animation frames until one of these is true:
+  - panel becomes hidden again, or
+  - `spawnPositioned` is successfully set.
+- This guarantees that delayed layout measurement does not leave a panel un-positioned.
+
+### Why this matters for Skills vs Inventory
+
+- `Inventory` and `Skills` now reliably get their own spawn offsets even if the first measurement frame is zero-sized.
+- This removes a major overlap path that could make panel behavior look mutually dependent.
+
+### Regression test
+
+- Added scenario test ensuring a panel with initial `0x0` bounds is retried and eventually marked `spawnPositioned=true` once measurable.

--- a/rgfn_game/docs/systems/hud-panels.md
+++ b/rgfn_game/docs/systems/hud-panels.md
@@ -602,3 +602,38 @@ To align interaction behavior with existing HUD windows (`Stats`, `Skills`, etc.
    - drag lower-right corner to resize panel width/height.
 5. On mobile breakpoint (`<=920px`):
    - resize affordance should be disabled.
+
+## Skills/Inventory panel decoupling fix (April 14, 2026)
+
+### Reported symptoms
+
+- Resizing/using one panel could make the other appear behaviorally linked.
+- In some overlap states, `Inventory` looked like it would not open unless `Skills` was closed first.
+
+### Root cause
+
+- Panel visibility toggles did not elevate the reopened panel’s z-index.
+- If `Skills` had a previously elevated z-index (after drag/interaction), reopening `Inventory` could keep it visually behind `Skills`.
+- This created a “mutual dependency” illusion:
+  - `Inventory` was technically open, but hidden underneath `Skills`.
+  - User interactions near overlap regions could appear as if both panels were reacting.
+
+### Fix implemented
+
+- `GameUiHudPanelController` now elevates a panel whenever:
+  - the panel header drag begins,
+  - the panel body receives left-click/pointer interaction,
+  - a panel is toggled open from HUD menu buttons.
+- Added z-index synchronization after layout restore:
+  - controller now computes max restored panel z-index and advances `nextPanelZIndex` accordingly.
+  - prevents newly elevated/toggled panels from receiving stale low z-values.
+
+### Why this decouples Skills and Inventory
+
+- Each panel now gets independent stacking ownership on interaction/open.
+- Opening `Inventory` no longer depends on closing `Skills`; it is promoted to top layer immediately.
+- Resizing one panel no longer gets visually conflated with the other due to hidden-under overlap.
+
+### Regression test
+
+- Added scenario test: reopening `Inventory` while `Skills` has high z-index must bring `Inventory` to front.

--- a/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
@@ -134,9 +134,13 @@ export default class GameUiHudPanelController {
             if (event.button !== 0) {
                 return;
             }
+            this.elevatePanel(panel);
             this.startPanelDrag(event, panel, dragHandle);
         });
         panel.addEventListener('pointerdown', (event: PointerEvent) => {
+            if (event.button === 0) {
+                this.elevatePanel(panel);
+            }
             if (!this.shouldStartBorderDrag(event, panel, dragHandle)) {
                 return;
             }
@@ -225,6 +229,7 @@ export default class GameUiHudPanelController {
         this.callbacks.onTogglePanel(panel);
         const panelElement = this.getPanelElement(panel);
         if (panelElement && !panelElement.classList.contains('hidden')) {
+            this.elevatePanel(panelElement);
             requestAnimationFrame(() => this.ensurePanelDragHandleIsReachable(panelElement));
         }
         this.setHudMenuOpen(false);
@@ -274,6 +279,7 @@ export default class GameUiHudPanelController {
         const panelConfigs = this.getPanelConfigs();
         if (!storedLayout) {
             panelConfigs.forEach(({ element }, panelIndex) => this.resetPanelToSpawn(element, panelIndex));
+            this.synchronizeNextPanelZIndex();
             return;
         }
         panelConfigs.forEach(({ key, element, persistenceKey }, panelIndex) => {
@@ -318,6 +324,7 @@ export default class GameUiHudPanelController {
         this.enforceVillagePanelVisibility(this.hudElements.modeIndicator.textContent?.trim() ?? '');
         this.enforceSelectedPanelVisibility(this.hudElements.modeIndicator.textContent?.trim() ?? '');
         this.enforceCombatPanelVisibility(this.activeLayoutContext);
+        this.synchronizeNextPanelZIndex();
     }
     private resetPanelToSpawn(panel: HTMLElement, panelIndex: number): void {
         panel.dataset.offsetX = '0';
@@ -391,6 +398,19 @@ export default class GameUiHudPanelController {
         panel.dataset.spawnPositioned = 'true';
         panel.style.setProperty('--panel-offset-x', `${nextOffsetX}px`);
         panel.style.setProperty('--panel-offset-y', `${nextOffsetY}px`);
+    }
+    private elevatePanel(panel: HTMLElement): void {
+        panel.style.zIndex = String(this.nextPanelZIndex++);
+    }
+    private synchronizeNextPanelZIndex(): void {
+        const maxPanelZIndex = this.getPanelConfigs().reduce((maxZIndex, { element }) => {
+            const zIndex = Number.parseInt(element.style.zIndex || '', 10);
+            if (!Number.isFinite(zIndex)) {
+                return maxZIndex;
+            }
+            return Math.max(maxZIndex, zIndex);
+        }, 9);
+        this.nextPanelZIndex = maxPanelZIndex + 1;
     }
     private keepPanelReachableInViewport(panel: HTMLElement): void {
         if (panel.classList.contains('hidden')) {

--- a/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
@@ -219,7 +219,13 @@ export default class GameUiHudPanelController {
             this.ensurePanelDragHandleIsReachable(panel);
         };
         const scheduleSpawnPlacement = (): void => {
-            requestAnimationFrame(() => placePanelAtSpawn());
+            requestAnimationFrame(() => {
+                placePanelAtSpawn();
+                if (panel.classList.contains('hidden') || panel.dataset.spawnPositioned === 'true') {
+                    return;
+                }
+                scheduleSpawnPlacement();
+            });
         };
         scheduleSpawnPlacement();
         const visibilityObserver = new MutationObserver(() => scheduleSpawnPlacement());

--- a/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
+++ b/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
@@ -555,3 +555,41 @@ test('GameUiHudPanelController keeps bottom-right resize corner behavior higher 
     global.requestAnimationFrame = originalRequestAnimationFrame;
   }
 });
+
+test('GameUiHudPanelController brings a toggled-open panel to front so overlapping panels stay independently accessible', () => {
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalMutationObserver = global.MutationObserver;
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+
+  global.window = { localStorage: createLocalStorage(), innerWidth: 1280, innerHeight: 720 };
+  const hudElements = createHudElements();
+  hudElements.inventoryPanel.classList.add('hidden');
+  global.document = createMockDocument(hudElements);
+  global.requestAnimationFrame = (callback) => callback();
+  global.MutationObserver = class {
+    constructor() {}
+    observe() {}
+  };
+
+  try {
+    const controller = new GameUiHudPanelController(hudElements, {
+      onTogglePanel(panel) {
+        const key = `${panel}Panel`;
+        hudElements[key].classList.toggle('hidden');
+      },
+    });
+    controller.bind();
+
+    hudElements.skillsPanel.style.zIndex = '120';
+    hudElements.toggleInventoryPanelBtn.listeners.click();
+
+    assert.equal(hudElements.inventoryPanel.classList.contains('hidden'), false);
+    assert.ok(Number.parseInt(hudElements.inventoryPanel.style.zIndex, 10) > 120);
+  } finally {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.MutationObserver = originalMutationObserver;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});

--- a/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
+++ b/rgfn_game/test/systems/scenarios/gameUiHudPanelController.test.js
@@ -593,3 +593,53 @@ test('GameUiHudPanelController brings a toggled-open panel to front so overlappi
     global.requestAnimationFrame = originalRequestAnimationFrame;
   }
 });
+
+test('GameUiHudPanelController keeps retrying spawn placement until a newly opened panel has measurable size', () => {
+  const originalWindow = global.window;
+  const originalDocument = global.document;
+  const originalMutationObserver = global.MutationObserver;
+  const originalRequestAnimationFrame = global.requestAnimationFrame;
+  const observers = [];
+
+  global.window = { localStorage: createLocalStorage(), innerWidth: 1280, innerHeight: 720 };
+  const hudElements = createHudElements();
+  hudElements.inventoryPanel.classList.add('hidden');
+  let inventoryRectCallCount = 0;
+  hudElements.inventoryPanel.getBoundingClientRect = () => {
+    inventoryRectCallCount += 1;
+    if (inventoryRectCallCount === 1) {
+      return { left: 0, top: 0, width: 0, height: 0, right: 0, bottom: 0 };
+    }
+    return { left: 0, top: 0, width: 240, height: 180, right: 240, bottom: 180 };
+  };
+  global.document = createMockDocument(hudElements);
+  global.requestAnimationFrame = (callback) => callback();
+  global.MutationObserver = class {
+    constructor(callback) { this.callback = callback; observers.push(this); }
+    observe(target) { this.target = target; }
+    trigger() { this.callback(); }
+  };
+
+  try {
+    const controller = new GameUiHudPanelController(hudElements, {
+      onTogglePanel(panel) {
+        const key = `${panel}Panel`;
+        hudElements[key].classList.toggle('hidden');
+      },
+    });
+    controller.bind();
+
+    hudElements.toggleInventoryPanelBtn.listeners.click();
+    observers
+      .filter((observer) => observer.target === hudElements.inventoryPanel)
+      .forEach((observer) => observer.trigger());
+
+    assert.equal(hudElements.inventoryPanel.dataset.spawnPositioned, 'true');
+    assert.equal(inventoryRectCallCount >= 2, true);
+  } finally {
+    global.window = originalWindow;
+    global.document = originalDocument;
+    global.MutationObserver = originalMutationObserver;
+    global.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});


### PR DESCRIPTION
### Motivation

- Players reported Skills and Inventory panels resizing/visibility appeared linked because reopened panels sometimes rendered underneath others.  
- Root cause: panels were not elevated when toggled or clicked, and restored layouts could contain high z-index values while `nextPanelZIndex` remained stale.  
- Goal: make panels independent so opening/resizing one does not affect the other and panels always appear on top when interacted with.

### Description

- Elevate panel z-index on interaction by promoting the panel during header drag start and left-click pointerdown on the panel body via a new `elevatePanel()` helper.  
- Promote a panel when it is toggled open from the HUD menu so reopened panels come to the front immediately.  
- Add `synchronizeNextPanelZIndex()` to compute the maximum restored z-index after layout restore and bump `nextPanelZIndex` to avoid assigning stale low z-values.  
- Add a scenario test that verifies reopening `Inventory` brings it above an already-elevated `Skills` panel and update `docs/systems/hud-panels.md` with a detailed root-cause/fix note.

### Testing

- Ran `npm run build:rgfn` and the TypeScript build completed successfully.  
- Ran `npm run test:rgfn` and the full RGFN test suite passed (153 tests, 0 failures).  
- Ran `npx eslint rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts` (the touched file) and it reported no errors for the modified file.  
- Repo-wide `npm run lint:ts:rgfn:eslint` still reports many pre-existing unrelated style-guide errors (including generated `dist` files and long-function warnings); these are unrelated to the changes here and were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dead2f94ec832381626a47fac4bdb4)