### PR TITLE
Side quest expansion: new local leaf types, local-anchored generation, and reward metadata

### DIFF
--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -55,3 +55,27 @@
 - The current integration auto-accepts offers on NPC selection for flow simplicity.
 - If explicit UI acceptance is needed later, wire a dedicated village action button and call the same callbacks.
 - Reward handling currently returns reward text; economic/item granting is expected to be layered by caller.
+
+## 2026-04-15: Side quest generation expansion
+
+- `QuestObjectiveType` now includes side-focused objective leaves:
+  - `localDelivery`
+  - `gather`
+  - `repair`
+  - `patrol`
+- `QuestObjectiveData` now carries dedicated payload shapes for those types:
+  - `localDelivery` → village + source NPC + recipient NPC + item + completion flag.
+  - `gather` → village + item + required/current amount.
+  - `repair` → village + structure + required/repaired materials + completion flag.
+  - `patrol` → village + checkpoint list + visited checkpoints + completion flag.
+- Leaf pools are now split:
+  - **Main quest leaf pool** remains unchanged (existing quest objective family only).
+  - **Side quest leaf pool** includes all existing objective leaves plus new side-only leaves.
+- Side quest leaf generation supports local constraints:
+  - A side quest can pass `villageName` and `giverNpcName`.
+  - Existing objective types (`deliver`, `travel`, `barter`, etc.) still generate, but are anchored locally to the giver context when generated as side quests.
+- Side quest root metadata now includes reward metadata:
+  - `rewardMetadata: { xp, gold, itemName, requiresTurnIn: true }`
+  - Human-readable `reward` text remains for dialogue/UI continuity.
+- Reward claim timing remains unchanged:
+  - Rewards are still represented as claimable on giver turn-in (`readyToTurnIn` → `completed`) and not auto-claimed at objective completion.

--- a/rgfn_game/js/systems/quest/QuestGenerator.ts
+++ b/rgfn_game/js/systems/quest/QuestGenerator.ts
@@ -1,7 +1,7 @@
 import QuestLeafFactory from './generation/QuestLeafFactory.js';
 import QuestPackService from './generation/QuestPackService.js';
 import { DefaultQuestRandom, QuestRandom } from './generation/QuestRandom.js';
-import { QuestNode } from './QuestTypes.js';
+import { QuestNode, QuestRewardMetadata } from './QuestTypes.js';
 import { theme } from '../../config/ThemeConfig.js';
 
 type GenerationContext = { depth: number; idPrefix: string };
@@ -26,6 +26,15 @@ export default class QuestGenerator {
         const title = await this.packService.generateName('mainQuest', theme.quest.nameGeneration.maxWordsByDomain.mainQuest);
         const children = await this.generateChildren();
         return this.node('main', title.text, DEFAULT_DESCRIPTION, DEFAULT_CONDITION, children);
+    }
+
+    public async generateSideQuest(id: string, giverNpcName: string, giverVillageName: string): Promise<QuestNode> {
+        const rootId = id.trim();
+        const giverName = giverNpcName.trim();
+        const villageName = giverVillageName.trim();
+        const leaf = await this.leafFactory.createSide(`${rootId}.1`, { villageName, giverNpcName: giverName });
+        const rewardMetadata = this.generateSideQuestRewardMetadata();
+        return this.createSideQuestRootNode(rootId, giverName, villageName, leaf, rewardMetadata);
     }
 
     private async generateChildren(): Promise<QuestNode[]> {
@@ -63,5 +72,23 @@ export default class QuestGenerator {
         objectiveType: 'scout',
         entities: [],
         children,
+    });
+
+    private generateSideQuestRewardMetadata(): QuestRewardMetadata {
+        const xp = this.random.nextInt(12, 30);
+        const gold = this.random.nextInt(10, 45);
+        const itemName = this.random.pick(['Repair Kit', 'Hunter Tonic', 'Scout Charm', 'Trail Rations']);
+        return { xp, gold, itemName, requiresTurnIn: true };
+    }
+
+    private renderRewardText = (rewardMetadata: QuestRewardMetadata): string =>
+        `${rewardMetadata.xp} XP, ${rewardMetadata.gold}g, ${rewardMetadata.itemName}`;
+
+    private createSideQuestRootNode = (id: string, giverNpcName: string, giverVillageName: string, leaf: QuestNode, rewardMetadata: QuestRewardMetadata): QuestNode => ({
+        id, objectiveType: 'scout', entities: [], children: [leaf], track: 'side', giverNpcName, giverVillageName, rewardMetadata, status: 'available',
+        title: `${giverNpcName}'s Request`,
+        description: `Assist ${giverNpcName} with a local task in ${giverVillageName}.`,
+        conditionText: 'Complete the listed task and return to the quest giver.',
+        reward: this.renderRewardText(rewardMetadata),
     });
 }

--- a/rgfn_game/js/systems/quest/QuestTypes.ts
+++ b/rgfn_game/js/systems/quest/QuestTypes.ts
@@ -1,13 +1,17 @@
 export type QuestObjectiveType =
     | 'eliminate'
     | 'deliver'
+    | 'localDelivery'
     | 'travel'
     | 'barter'
     | 'scout'
     | 'hunt'
     | 'recover'
     | 'escort'
-    | 'defend';
+    | 'defend'
+    | 'gather'
+    | 'repair'
+    | 'patrol';
 
 export type QuestNameDomain = 'location' | 'artifact' | 'character' | 'monster' | 'mainQuest';
 
@@ -29,6 +33,7 @@ export type QuestNode = {
     giverNpcName?: string;
     giverVillageName?: string;
     reward?: string;
+    rewardMetadata?: QuestRewardMetadata;
     status?: QuestStatus;
 };
 
@@ -38,6 +43,14 @@ export type DeliverObjectiveData = {
     destinationVillage: string;
     itemName: string;
     isPickedUp?: boolean;
+};
+
+export type LocalDeliveryObjectiveData = {
+    villageName: string;
+    sourceNpcName: string;
+    recipientNpcName: string;
+    itemName: string;
+    isDelivered?: boolean;
 };
 
 export type GeneratedName = {
@@ -131,10 +144,43 @@ export type DefendObjectiveData = {
     remainingBattles?: number;
 };
 
+export type GatherObjectiveData = {
+    villageName: string;
+    itemName: string;
+    requiredAmount: number;
+    currentAmount?: number;
+};
+
+export type RepairObjectiveData = {
+    villageName: string;
+    structureName: string;
+    requiredMaterials: string[];
+    repairedMaterials?: string[];
+    isRepaired?: boolean;
+};
+
+export type PatrolObjectiveData = {
+    villageName: string;
+    checkpoints: string[];
+    visitedCheckpoints?: string[];
+    isPatrolComplete?: boolean;
+};
+
+export type QuestRewardMetadata = {
+    xp: number;
+    gold: number;
+    itemName: string;
+    requiresTurnIn: true;
+};
+
 export type QuestObjectiveData = {
     deliver?: DeliverObjectiveData;
+    localDelivery?: LocalDeliveryObjectiveData;
     monster?: MonsterObjectiveData;
     escort?: EscortObjectiveData;
     recover?: RecoverObjectiveData;
     defend?: DefendObjectiveData;
+    gather?: GatherObjectiveData;
+    repair?: RepairObjectiveData;
+    patrol?: PatrolObjectiveData;
 };

--- a/rgfn_game/js/systems/quest/generation/QuestLeafFactory.ts
+++ b/rgfn_game/js/systems/quest/generation/QuestLeafFactory.ts
@@ -2,10 +2,26 @@
 import QuestPackService from './QuestPackService.js';
 import { QuestRandom } from './QuestRandom.js';
 import { theme } from '../../../config/ThemeConfig.js';
-import { DeliverObjectiveData, GeneratedName, QuestNode, QuestObjectiveType } from '../QuestTypes.js';
+import { DeliverObjectiveData, GeneratedName, QuestNameDomain, QuestNode, QuestObjectiveType } from '../QuestTypes.js';
 import QuestLeafContentBuilder from './QuestLeafContentBuilder.js';
 
-const LEAF_TYPES: QuestObjectiveType[] = ['eliminate', 'deliver', 'travel', 'barter', 'scout', 'hunt', 'recover', 'escort', 'defend'];
+type SideQuestConstraints = {
+    villageName?: string;
+    giverNpcName?: string;
+};
+
+type LeafGenerationContext = {
+    localVillageName?: string;
+    localNpcName?: string;
+};
+
+const MAIN_LEAF_TYPES: QuestObjectiveType[] = ['eliminate', 'deliver', 'travel', 'barter', 'scout', 'hunt', 'recover', 'escort', 'defend'];
+const SIDE_ONLY_LEAF_TYPES: QuestObjectiveType[] = ['localDelivery', 'gather', 'repair', 'patrol'];
+const SIDE_LEAF_TYPES: QuestObjectiveType[] = [...MAIN_LEAF_TYPES, ...SIDE_ONLY_LEAF_TYPES];
+const REPAIR_STRUCTURES = ['Well Pump', 'Palisade Gate', 'Watchtower Winch', 'Granary Roof'];
+const GATHER_ITEMS = ['Medicinal Herbs', 'Iron Scrap', 'Lantern Oil', 'Timber Bundles'];
+const LOCAL_DELIVERY_ITEMS = ['Ration Crate', 'Treated Bandages', 'Signal Flare Kit', 'Courier Satchel'];
+const PATROL_CHECKPOINTS = ['North Gate', 'Market Square', 'River Watch', 'Old Shrine', 'South Wall'];
 
 export default class QuestLeafFactory {
     private readonly packService: QuestPackService;
@@ -20,16 +36,33 @@ export default class QuestLeafFactory {
     }
 
     public async create(id: string): Promise<QuestNode> {
-        const type = this.random.pick(LEAF_TYPES);
+        const type = this.random.pick(MAIN_LEAF_TYPES);
+        return this.createFromType(id, type);
+    }
+
+    public async createSide(id: string, constraints: SideQuestConstraints = {}): Promise<QuestNode> {
+        const type = this.random.pick(SIDE_LEAF_TYPES);
+        const context: LeafGenerationContext = {
+            localVillageName: constraints.villageName?.trim() || undefined,
+            localNpcName: constraints.giverNpcName?.trim() || undefined,
+        };
+        return this.createFromType(id, type, context);
+    }
+
+    private createFromType(id: string, type: QuestObjectiveType, context?: LeafGenerationContext): Promise<QuestNode> {
         if (type === 'eliminate') { return this.createEliminateNode(id); }
-        if (type === 'deliver') { return this.createDeliverNode(id); }
-        if (type === 'travel') { return this.createTravelNode(id); }
-        if (type === 'barter') { return this.createBarterNode(id); }
-        if (type === 'scout') { return this.createScoutNode(id); }
-        if (type === 'hunt') { return this.createHuntNode(id); }
-        if (type === 'recover') { return this.createRecoverNode(id); }
-        if (type === 'escort') { return this.createEscortNode(id); }
-        return this.createDefendNode(id);
+        if (type === 'deliver') { return this.createDeliverNode(id, context); }
+        if (type === 'travel') { return this.createTravelNode(id, context); }
+        if (type === 'barter') { return this.createBarterNode(id, context); }
+        if (type === 'scout') { return this.createScoutNode(id, context); }
+        if (type === 'hunt') { return this.createHuntNode(id, context); }
+        if (type === 'recover') { return this.createRecoverNode(id, context); }
+        if (type === 'escort') { return this.createEscortNode(id, context); }
+        if (type === 'defend') { return this.createDefendNode(id, context); }
+        if (type === 'localDelivery') { return this.createLocalDeliveryNode(id, context); }
+        if (type === 'gather') { return this.createGatherNode(id, context); }
+        if (type === 'repair') { return this.createRepairNode(id, context); }
+        return this.createPatrolNode(id, context);
     }
 
     private async createEliminateNode(id: string): Promise<QuestNode> {
@@ -51,11 +84,11 @@ export default class QuestLeafFactory {
         );
     }
 
-    private async createDeliverNode(id: string): Promise<QuestNode> {
+    private async createDeliverNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
         const artifact = await this.generateName('artifact');
-        const sourceTrader = await this.generateName('character');
-        const sourceVillage = await this.generateName('location');
-        const destination = await this.resolveDestination(sourceVillage);
+        const sourceTrader = await this.resolveTrader(context);
+        const sourceVillage = await this.resolveVillage(context);
+        const destination = await this.resolveDestination(sourceVillage, context);
         const objectiveData: DeliverObjectiveData = {
             sourceVillage: sourceVillage.text,
             sourceTrader: sourceTrader.text,
@@ -75,8 +108,8 @@ export default class QuestLeafFactory {
         );
     }
 
-    private async createTravelNode(id: string): Promise<QuestNode> {
-        const destination = await this.generateName('location');
+    private async createTravelNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const destination = await this.resolveVillage(context);
         return this.contentBuilder.node(
             id,
             `Scout ${destination.text}`,
@@ -87,8 +120,8 @@ export default class QuestLeafFactory {
         );
     }
 
-    private async createBarterNode(id: string): Promise<QuestNode> {
-        const trader = await this.generateName('character');
+    private async createBarterNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const trader = await this.resolveTrader(context);
         const artifact = await this.generateName('artifact');
         return this.contentBuilder.node(
             id,
@@ -100,8 +133,8 @@ export default class QuestLeafFactory {
         );
     }
 
-    private async createScoutNode(id: string): Promise<QuestNode> {
-        const destination = await this.generateName('location');
+    private async createScoutNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const destination = await this.resolveVillage(context);
         return this.contentBuilder.node(
             id,
             `Investigate ${destination.text}`,
@@ -112,9 +145,9 @@ export default class QuestLeafFactory {
         );
     }
 
-    private async createHuntNode(id: string): Promise<QuestNode> {
+    private async createHuntNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
         const profile = await this.contentBuilder.rareMonsterProfile(() => this.generateName('monster'));
-        const location = await this.generateName('location');
+        const location = await this.resolveVillage(context);
         const details = `Origin: mutated from ${profile.mutatedFrom}. `
             + `Stats: ${profile.stats.join(', ')}. `
             + `Effects: ${profile.effects.join(', ')}. `
@@ -138,10 +171,10 @@ export default class QuestLeafFactory {
         );
     }
 
-    private async createRecoverNode(id: string): Promise<QuestNode> {
+    private async createRecoverNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
         const artifact = await this.generateName('artifact');
-        const location = await this.generateName('location');
-        const person = await this.generateName('character');
+        const location = await this.resolveVillage(context);
+        const person = await this.resolveTrader(context);
         return this.contentBuilder.node(
             id,
             `Recover ${artifact.text}`,
@@ -162,10 +195,10 @@ export default class QuestLeafFactory {
         );
     }
 
-    private async createEscortNode(id: string): Promise<QuestNode> {
-        const character = await this.generateName('character');
-        const source = await this.generateName('location');
-        const destination = await this.resolveDestination(source);
+    private async createEscortNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const character = await this.resolveTrader(context);
+        const source = await this.resolveVillage(context);
+        const destination = await this.resolveDestination(source, context);
         return this.contentBuilder.node(
             id,
             `Escort ${character.text}`,
@@ -177,10 +210,10 @@ export default class QuestLeafFactory {
         );
     }
 
-    private async createDefendNode(id: string): Promise<QuestNode> {
-        const location = await this.generateName('location');
+    private async createDefendNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const location = await this.resolveVillage(context);
         const artifact = await this.generateName('artifact');
-        const contact = await this.generateName('character');
+        const contact = await this.resolveTrader(context);
         const durationDays = this.random.nextInt(3, 7);
         return this.contentBuilder.node(
             id,
@@ -205,16 +238,117 @@ export default class QuestLeafFactory {
         );
     }
 
+    public async createLocalDeliveryNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const village = await this.resolveVillage(context);
+        const sourceNpc = await this.resolveTrader(context);
+        const recipient = await this.generateName('character');
+        const itemName = this.random.pick(LOCAL_DELIVERY_ITEMS);
+        return this.contentBuilder.node(
+            id,
+            `Local Delivery: ${itemName}`,
+            `Collect ${itemName} from ${sourceNpc.text} and hand it to ${recipient.text} in ${village.text}.`,
+            `Deliver ${itemName} to ${recipient.text} in ${village.text}.`,
+            'localDelivery',
+            this.contentBuilder.entities(sourceNpc, recipient, village, this.localName(itemName, 'artifact')),
+            {
+                localDelivery: { villageName: village.text, sourceNpcName: sourceNpc.text, recipientNpcName: recipient.text, itemName, isDelivered: false },
+            },
+        );
+    }
+
+    public async createGatherNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const village = await this.resolveVillage(context);
+        const itemName = this.random.pick(GATHER_ITEMS);
+        const requiredAmount = this.random.nextInt(2, 5);
+        return this.contentBuilder.node(
+            id,
+            `Gather ${itemName}`,
+            `Collect ${requiredAmount} bundles of ${itemName} for stores in ${village.text}.`,
+            `Bring ${requiredAmount} ${itemName} to ${village.text}.`,
+            'gather',
+            this.contentBuilder.entities(village, this.localName(itemName, 'artifact')),
+            {
+                gather: { villageName: village.text, itemName, requiredAmount, currentAmount: 0 },
+            },
+        );
+    }
+
+    public async createRepairNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const village = await this.resolveVillage(context);
+        const structureName = this.random.pick(REPAIR_STRUCTURES);
+        const requiredMaterials = [this.random.pick(['Timber', 'Iron Nails', 'Resin', 'Rope']), this.random.pick(['Stone Slabs', 'Canvas', 'Pitch'])];
+        return this.contentBuilder.node(
+            id,
+            `Repair ${structureName}`,
+            `Use local supplies to repair the ${structureName} in ${village.text}.`,
+            `Restore the ${structureName} in ${village.text}.`,
+            'repair',
+            this.contentBuilder.entities(village, this.localName(structureName, 'artifact')),
+            {
+                repair: { villageName: village.text, structureName, requiredMaterials, repairedMaterials: [], isRepaired: false },
+            },
+        );
+    }
+
+    public async createPatrolNode(id: string, context?: LeafGenerationContext): Promise<QuestNode> {
+        const village = await this.resolveVillage(context);
+        const checkpoints = this.pickUniqueStrings(PATROL_CHECKPOINTS, this.random.nextInt(2, 4));
+        return this.contentBuilder.node(
+            id,
+            `Patrol ${village.text}`,
+            `Sweep ${village.text} and report at checkpoints: ${checkpoints.join(', ')}.`,
+            `Visit all patrol checkpoints in ${village.text}.`,
+            'patrol',
+            this.contentBuilder.entities(village, ...checkpoints.map((checkpoint) => this.localName(checkpoint, 'location'))),
+            {
+                patrol: { villageName: village.text, checkpoints, visitedCheckpoints: [], isPatrolComplete: false },
+            },
+        );
+    }
+
     private generateName = (
         domain: 'location' | 'artifact' | 'character' | 'monster',
     ): Promise<GeneratedName> => this.packService.generateName(domain, this.maxWordsByDomain[domain]);
 
-    private async resolveDestination(sourceVillage: GeneratedName): Promise<GeneratedName> {
+    private async resolveDestination(sourceVillage: GeneratedName, context?: LeafGenerationContext): Promise<GeneratedName> {
+        if (context?.localVillageName) {
+            return sourceVillage;
+        }
         let destination = await this.generateName('location');
         const source = sourceVillage.text.trim().toLocaleLowerCase();
         if (destination.text.trim().toLocaleLowerCase() === source) {
             destination = await this.generateName('location');
         }
         return destination;
+    }
+
+    private async resolveVillage(context?: LeafGenerationContext): Promise<GeneratedName> {
+        if (context?.localVillageName) {
+            return this.localName(context.localVillageName, 'location');
+        }
+        return this.generateName('location');
+    }
+
+    private async resolveTrader(context?: LeafGenerationContext): Promise<GeneratedName> {
+        if (context?.localNpcName) {
+            return this.localName(context.localNpcName, 'character');
+        }
+        return this.generateName('character');
+    }
+
+    private localName = (text: string, domain: QuestNameDomain): GeneratedName => ({ text, domain, sourceTypes: ['local-pattern'] });
+
+    private pickUniqueStrings(values: string[], count: number): string[] {
+        const local = [...values];
+        const selected: string[] = [];
+        while (local.length > 0 && selected.length < count) {
+            const choice = this.random.pick(local);
+            selected.push(choice);
+            const index = local.findIndex((entry) => entry === choice);
+            if (index >= 0) {
+                local.splice(index, 1);
+            }
+        }
+        return selected;
     }
 }

--- a/rgfn_game/test/systems/questGenerator.test.js
+++ b/rgfn_game/test/systems/questGenerator.test.js
@@ -79,6 +79,31 @@ test('QuestLeafFactory supports the four added leaf quest types', async () => {
   assert.equal(travel.objectiveType, 'travel');
 });
 
+test('QuestLeafFactory can create side-only local objective types', async () => {
+  const packService = new FakeQuestPackService(createNames());
+  const random = new ScriptedQuestRandom({
+    ints: [3, 2],
+    picks: ['localDelivery', 'Ration Crate', 'gather', 'Medicinal Herbs', 'repair', 'Well Pump', 'Timber', 'Canvas', 'patrol', 'North Gate', 'South Wall'],
+  });
+  const factory = new QuestLeafFactory(packService, random);
+  const context = { villageName: 'Ashford', giverNpcName: 'Mira' };
+
+  const localDelivery = await factory.createSide('side.1', context);
+  const gather = await factory.createSide('side.2', context);
+  const repair = await factory.createSide('side.3', context);
+  const patrol = await factory.createSide('side.4', context);
+
+  assert.equal(localDelivery.objectiveType, 'localDelivery');
+  assert.equal(localDelivery.objectiveData.localDelivery.villageName, 'Ashford');
+  assert.equal(localDelivery.objectiveData.localDelivery.sourceNpcName, 'Mira');
+  assert.equal(gather.objectiveType, 'gather');
+  assert.equal(gather.objectiveData.gather.villageName, 'Ashford');
+  assert.equal(repair.objectiveType, 'repair');
+  assert.equal(repair.objectiveData.repair.villageName, 'Ashford');
+  assert.equal(patrol.objectiveType, 'patrol');
+  assert.equal(patrol.objectiveData.patrol.villageName, 'Ashford');
+});
+
 test('QuestLeafFactory delivery quests include pickup source person and village in text and objective data', async () => {
   const packService = new FakeQuestPackService(createNames());
   const random = new ScriptedQuestRandom({ picks: ['deliver'] });
@@ -110,4 +135,23 @@ test('QuestLeafFactory purge objectives include anchored village intel and monst
   assert.match(node.conditionText, /near Old Well/);
   assert.equal(node.entities.some((entity) => entity.type === 'monster' && entity.text === 'Rift Wyrm'), true);
   assert.equal(node.objectiveData?.monster?.villageName, 'Old Well');
+});
+
+test('QuestGenerator creates side quests with reward metadata claimable on giver turn-in', async () => {
+  const packService = new FakeQuestPackService(createNames());
+  const random = new ScriptedQuestRandom({ ints: [24, 35], picks: ['localDelivery', 'Ration Crate', 'Nomad Broker', 'Scout Charm'] });
+  const generator = new QuestGenerator({ packService, random });
+
+  const sideQuest = await generator.generateSideQuest('side.99', 'Mira Vale', 'Old Well');
+
+  assert.equal(sideQuest.track, 'side');
+  assert.equal(sideQuest.giverNpcName, 'Mira Vale');
+  assert.equal(sideQuest.giverVillageName, 'Old Well');
+  assert.equal(sideQuest.status, 'available');
+  assert.equal(sideQuest.children.length, 1);
+  assert.equal(sideQuest.children[0].objectiveType, 'localDelivery');
+  assert.equal(sideQuest.rewardMetadata.requiresTurnIn, true);
+  assert.equal(sideQuest.rewardMetadata.xp, 24);
+  assert.equal(sideQuest.rewardMetadata.gold, 35);
+  assert.match(sideQuest.reward, /24 XP, 35g/);
 });


### PR DESCRIPTION
### Motivation
- Provide richer, local-focused side quests by adding four side-only objective types and payloads so villages/NPCs can offer small, local tasks. 
- Keep main-quest leaf generation unchanged while letting side quests reuse existing objective types but anchored to a giver's local context. 
- Add explicit, typed reward metadata for side-quest roots so rewards can be presented and remain claimable only on giver turn-in.

### Description
- Extended `QuestObjectiveType` with `localDelivery`, `gather`, `repair`, and `patrol`, and added typed objective payloads for each in `rgfn_game/js/systems/quest/QuestTypes.ts` (plus `QuestRewardMetadata`).
- Split leaf generation pools in `rgfn_game/js/systems/quest/generation/QuestLeafFactory.ts` into a `MAIN_LEAF_TYPES` (unchanged) and a `SIDE_LEAF_TYPES` (main + side-only), added `createSide(...)`, a `createFromType(...)` dispatcher, and implemented `createLocalDeliveryNode`, `createGatherNode`, `createRepairNode`, and `createPatrolNode` with compact objective payloads and local defaults.
- Added local-anchoring helpers (`resolveVillage`, `resolveTrader`, `localName`) and optional `LeafGenerationContext` so side leaves can be generated using the giver's village/NPC when provided; existing leaf builders still work but accept the same context.
- Added `QuestGenerator.generateSideQuest(...)` to build a side quest root (sets `track='side'`, `giverNpcName`, `giverVillageName`, `status='available'`) and attach `rewardMetadata` with `xp`, `gold`, `itemName` and a human-friendly `reward` string.
- Updated tests in `rgfn_game/test/systems/questGenerator.test.js` to cover side-only leaf creation, context anchoring, and side root reward metadata generation; and updated docs `rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md` with a 2026-04-15 section describing changes.

### Testing
- Ran TypeScript build via `npm run build:rgfn` which completed successfully. 
- Ran full test suite via `npm run test:rgfn` and all tests passed (157/157). 
- Ran targeted ESLint checks for the modified files with `npx eslint ...` showing no errors for the touched files and only minor warnings addressed. 
- A repo-wide `npm run lint:ts:rgfn:eslint` still reports pre-existing rule-definition issues unrelated to this change and therefore was not used to block the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfea2874f483239a90082e2c7ecbb8)