### PR TITLE
Gate barter and defend dialogue buttons to active quest contracts

### DIFF
--- a/rgfn_game/docs/village/village-dialogue-directions.md
+++ b/rgfn_game/docs/village/village-dialogue-directions.md
@@ -73,14 +73,15 @@ Village rumors now support asking about **people**, not only settlements.
 - Lists are deduplicated and sorted alphabetically.
 
 ### Button availability rule (RGFN UX)
-- Core dialogue actions remain available once an NPC is selected:
+- Core non-quest dialogue actions remain available once an NPC is selected:
   - **Ask about location**
   - **Ask about person**
-  - **Ask about barter**
 - Quest-only follow-up actions are now **context-sensitive and hidden by default**:
+  - **Ask about barter** appears only for selected NPCs with an unfinished barter contract in the current village.
   - **I have what you need, let's do our barter** appears only for selected NPCs with an unfinished barter contract in the current village.
   - **Confront for quest item** appears only when the selected NPC is the currently valid recover quest confrontation target and the target has already been revealed.
   - **Join my group** appears only when the selected NPC is currently recruitable for an active escort objective in this village.
+  - **I am ready to defend you** appears only for selected NPCs with an active defend contract in the current village.
 - Goal: prevent dead-end button clicks and show only actionable quest interactions per-NPC.
 
 ### Reliability model (intentionally lower than village directions)

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -188,6 +188,7 @@ export default class VillageActionsController {
         getSelectedNpc: () => this.getSelectedNpc(),
         getSellPrice: (item) => this.stockService.getSellPrice(item),
         isInnkeeper: (role) => this.isInnkeeper(role),
+        shouldShowAskBarterAction: (npcName) => this.hasActiveBarterDealForNpc(npcName),
         shouldShowBarterNowAction: (npcName) => this.hasActiveBarterDealForNpc(npcName),
         shouldShowConfrontRecoverAction: (npcName, villageName) => this.canConfrontRecoverTarget(npcName, villageName),
         shouldShowRecruitEscortAction: (npcName, villageName) => this.canRecruitEscort(npcName, villageName),
@@ -410,7 +411,12 @@ export default class VillageActionsController {
         if (!npcName.trim() || !villageName.trim() || !this.callbacks.onTryStartDefend) {
             return false;
         }
-        return true;
+        const normalizedNpc = npcName.trim().toLocaleLowerCase();
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        return this.defendContracts.some((contract) =>
+            contract.personName.trim().toLocaleLowerCase() === normalizedNpc
+            && contract.villageName.trim().toLocaleLowerCase() === normalizedVillage,
+        );
     }
 
     // eslint-disable-next-line style-guide/function-length-warning

--- a/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
+++ b/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
@@ -13,6 +13,7 @@ type PresenterDeps = {
     getSellPrice: (item: Item) => number;
     isInnkeeper: (role: string) => boolean;
     shouldShowBarterNowAction: (npcName: string) => boolean;
+    shouldShowAskBarterAction: (npcName: string) => boolean;
     shouldShowConfrontRecoverAction: (npcName: string, villageName: string) => boolean;
     shouldShowRecruitEscortAction: (npcName: string, villageName: string) => boolean;
     shouldShowDefendAction: (npcName: string, villageName: string) => boolean;
@@ -50,24 +51,35 @@ export default class VillageUiPresenter {
         this.deps.villageUI.openDialogueBtn.disabled = !hasSelectedNpc;
         this.deps.villageUI.askVillageBtn.disabled = !hasSelectedNpc;
         this.deps.villageUI.askPersonBtn.disabled = !hasSelectedNpc;
-        this.deps.villageUI.askBarterBtn.disabled = !hasSelectedNpc;
         const selectedNpcName = selectedNpc?.name ?? '';
         const currentVillageName = this.deps.getCurrentVillageName();
+        const showAskBarter = hasSelectedNpc && this.deps.shouldShowAskBarterAction(selectedNpcName);
         const showBarterNow = hasSelectedNpc && this.deps.shouldShowBarterNowAction(selectedNpcName);
         const showConfrontRecover = hasSelectedNpc && this.deps.shouldShowConfrontRecoverAction(selectedNpcName, currentVillageName);
         const showRecruitEscort = hasSelectedNpc && this.deps.shouldShowRecruitEscortAction(selectedNpcName, currentVillageName);
         const showDefendVillage = hasSelectedNpc && this.deps.shouldShowDefendAction(selectedNpcName, currentVillageName);
+        this.updateDialogueQuestActionVisibility(showAskBarter, showBarterNow, showConfrontRecover, showRecruitEscort, showDefendVillage);
+        this.deps.villageUI.sleepRoomBtn.disabled = !hasSelectedNpc || !this.deps.isInnkeeper(selectedNpc?.role ?? '');
+    }
 
+    private updateDialogueQuestActionVisibility(
+        showAskBarter: boolean,
+        showBarterNow: boolean,
+        showConfrontRecover: boolean,
+        showRecruitEscort: boolean,
+        showDefendVillage: boolean,
+    ): void {
+        this.deps.villageUI.askBarterBtn.classList.toggle('hidden', !showAskBarter);
         this.deps.villageUI.barterNowBtn.classList.toggle('hidden', !showBarterNow);
         this.deps.villageUI.confrontRecoverBtn.classList.toggle('hidden', !showConfrontRecover);
         this.deps.villageUI.recruitEscortBtn.classList.toggle('hidden', !showRecruitEscort);
         this.deps.villageUI.defendVillageBtn.classList.toggle('hidden', !showDefendVillage);
 
+        this.deps.villageUI.askBarterBtn.disabled = !showAskBarter;
         this.deps.villageUI.barterNowBtn.disabled = !showBarterNow;
         this.deps.villageUI.confrontRecoverBtn.disabled = !showConfrontRecover;
         this.deps.villageUI.recruitEscortBtn.disabled = !showRecruitEscort;
         this.deps.villageUI.defendVillageBtn.disabled = !showDefendVillage;
-        this.deps.villageUI.sleepRoomBtn.disabled = !hasSelectedNpc || !this.deps.isInnkeeper(selectedNpc?.role ?? '');
     }
 
     public renderNpcButtons(npcRoster: VillageNpcProfile[], selectedNpcId: string | null): void {

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -604,12 +604,14 @@ test('VillageActionsController shows contextual dialogue action buttons only whe
   };
 
   controller.enterVillage('Mossbrook');
+  assert.equal(villageUI.askBarterBtn.classList.contains('hidden'), true);
   assert.equal(villageUI.barterNowBtn.classList.contains('hidden'), true);
   assert.equal(villageUI.confrontRecoverBtn.classList.contains('hidden'), true);
   assert.equal(villageUI.recruitEscortBtn.classList.contains('hidden'), true);
 
   const oliveIndex = controller['npcRoster'].findIndex((npc) => npc.name === 'Olive');
   controller.handleSelectNpc(oliveIndex);
+  assert.equal(villageUI.askBarterBtn.classList.contains('hidden'), false);
   assert.equal(villageUI.barterNowBtn.classList.contains('hidden'), false);
   assert.equal(villageUI.recruitEscortBtn.classList.contains('hidden'), false);
   assert.equal(villageUI.confrontRecoverBtn.classList.contains('hidden'), true);
@@ -619,4 +621,35 @@ test('VillageActionsController shows contextual dialogue action buttons only whe
   const recoverIndex = controller['npcRoster'].findIndex((npc) => npc.name === 'Pablo Menéndez');
   controller.handleSelectNpc(recoverIndex);
   assert.equal(villageUI.confrontRecoverBtn.classList.contains('hidden'), false);
+}));
+
+test('VillageActionsController shows defend dialogue action only for NPCs with defend contracts in the current village', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onLeaveVillage: () => {},
+    onTryRecruitEscort: () => 'not-available',
+    onTryStartDefend: () => ({ status: 'inactive' }),
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+  });
+
+  controller.configureQuestDefendContracts([{ personName: 'Olive', villageName: 'Mossbrook', days: 2, enemyPools: [] }]);
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'moss-0', name: 'Mara', role: 'Trader', look: 'cloak', speechStyle: 'calm', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Mossbrook');
+  assert.equal(villageUI.defendVillageBtn.classList.contains('hidden'), true);
+
+  const oliveIndex = controller['npcRoster'].findIndex((npc) => npc.name === 'Olive');
+  controller.handleSelectNpc(oliveIndex);
+  assert.equal(villageUI.defendVillageBtn.classList.contains('hidden'), false);
+
+  const maraIndex = controller['npcRoster'].findIndex((npc) => npc.name === 'Mara');
+  controller.handleSelectNpc(maraIndex);
+  assert.equal(villageUI.defendVillageBtn.classList.contains('hidden'), true);
 }));


### PR DESCRIPTION
### Motivation
- Prevent non-actionable dialogue options from appearing by showing barter and defend follow-ups only when the NPC actually has a relevant quest contract in the current village.
- Reduce player confusion and dead-end clicks by making quest-related UI elements context-sensitive.

### Description
- Added a new `shouldShowAskBarterAction` dependency and wired it into `VillageUiPresenter.updateButtons` so the **Ask about barter** button is hidden unless `hasActiveBarterDealForNpc(...)` returns true.
- Consolidated quest-action visibility into `VillageUiPresenter.updateDialogueQuestActionVisibility(...)` to centralize show/disable logic for barter, confirm-barter, confront-recover, recruit-escort and defend buttons.
- Tightened defend availability logic in `VillageActionsController.canStartDefendObjective(...)` so `I am ready to defend you` only appears when the selected NPC matches a `defend` contract in the current village (previously it could appear whenever the defend callback existed).
- Added/updated unit tests in `rgfn_game/test/systems/scenarios/villageActionsController.test.js` to assert barter button visibility and to cover defend-button visibility switching by selected NPC.
- Updated documentation `rgfn_game/docs/village/village-dialogue-directions.md` to reflect the conditional visibility rules for barter and defend actions.

### Testing
- Ran targeted ESLint on changed files with `npx eslint rgfn_game/js/systems/village/actions/VillageUiPresenter.ts rgfn_game/js/systems/village/VillageActionsController.ts --ext .ts`, which passed for the modified files.
- Built and ran the RGFN test suite with `npm run test:rgfn`, and all tests passed: `157` tests ran, `157` passed, `0` failed.
- Ran full RGFN lint script `npm run lint:ts:rgfn` which reported pre-existing repo-wide issues (139 warnings and 1 error) unrelated to this PR; those style-guide violations remain and are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff705e90c832382ec0f34e91ab77a)