### PR TITLE
Add configurable multi-enchantment weapons for RGFN

### DIFF
--- a/rgfn_game/docs/enchantment-system-2026-04-15.md
+++ b/rgfn_game/docs/enchantment-system-2026-04-15.md
@@ -1,0 +1,58 @@
+# Weapon enchantment system (RGFN)
+
+## Summary
+This update adds Diablo/Pixel-Dungeon style random weapon enchantments for **RGFN** (`rgfn_game`) and wires them into:
+
+- random item encounters,
+- random monster drops,
+- village market offers (including a configurable special enchanted-weapon offer),
+- combat effects and pricing.
+
+## Enchantments
+Implemented weapon enchantment effects:
+
+- **plasma**: `+N` direct damage and delayed `N/2` damage next turn,
+- **wormhole**: `M%` chance to crit for `2x` total attack damage,
+- **confusion**: `P%` chance to stun for 1 turn (target skips turn),
+- **doubt**: `+Q` damage per second for `R` seconds.
+
+Multiple enchantments can appear on the same weapon.
+
+## Balance knobs
+Added under `balanceConfig.items.enchantments` (`rgfn_game/js/config/balance/itemsEncountersBalance.ts`):
+
+- `chanceOnRandomWeapon` – chance a randomly generated weapon is enchanted,
+- `chanceForExtraEnchantment` – chance to roll an additional enchantment,
+- `maxEnchantmentsPerWeapon` – hard cap for multi-enchant rolls,
+- `villageSpecialOfferChance` – probability a village stock refresh includes a special enchanted weapon offer,
+- `priceMultiplierPerScore` – scales value from rolled enchantment strength,
+- per-enchantment value ranges (`plasma`, `wormhole`, `confusion`, `doubt`).
+
+## Generation/runtime design
+- Random enchantment rolling lives in `rgfn_game/js/entities/items/WeaponEnchantments.ts`.
+- Effects are attached to per-instance `Item` data (`item.enchantments`), not base registry definitions.
+- Generated items now pass through enchantment application in:
+  - `EncounterResolver` (item discoveries),
+  - `BattleLootManager` (monster drops),
+  - `VillageTradeInteractionService` (village purchases).
+- Village stock now has optional "Enchanted Weapon" special offer insertion in `VillageStockService`.
+
+## Combat integration
+- Attack-time enchantment processing lives in `rgfn_game/js/systems/game/WeaponEnchantmentCombat.ts`.
+- Player attack flows (normal + directional) now resolve enchantment procs.
+- Monster status effects gained:
+  - turn-based stun support,
+  - generalized damage-over-time support,
+  - consumption of DoT/stun during turn processing.
+
+## Persistence
+To preserve randomized enchantments through saves:
+
+- item snapshots are now serialized in player state alongside legacy item-id fields,
+- restore path prefers snapshots when present and falls back to legacy id-based restore,
+- this keeps backward compatibility for older saves.
+
+## Notes for future tuning
+- If village enchanted offers feel too common/rare, tune `villageSpecialOfferChance`.
+- If total weapon economy inflates too quickly, reduce `priceMultiplierPerScore` and/or enchant ranges.
+- If DoT feels too oppressive, lower `doubt` ranges first (especially duration).

--- a/rgfn_game/js/config/balance/itemsEncountersBalance.ts
+++ b/rgfn_game/js/config/balance/itemsEncountersBalance.ts
@@ -1,5 +1,16 @@
 export const itemBalance = {
     monsterDropChance: 0.35,
+    enchantments: {
+        chanceOnRandomWeapon: 0.28,
+        chanceForExtraEnchantment: 0.33,
+        maxEnchantmentsPerWeapon: 3,
+        villageSpecialOfferChance: 0.3,
+        priceMultiplierPerScore: 0.35,
+        plasma: { minBonusDamage: 1, maxBonusDamage: 6 },
+        wormhole: { minCritChance: 10, maxCritChance: 35 },
+        confusion: { minStunChance: 8, maxStunChance: 30 },
+        doubt: { minDamagePerSecond: 1, maxDamagePerSecond: 4, minDurationSeconds: 2, maxDurationSeconds: 5 },
+    },
     discoveryPool: [
         { id: 'healingPotion', weight: 4 },
         { id: 'knife_t1', weight: 10 },

--- a/rgfn_game/js/entities/Item.ts
+++ b/rgfn_game/js/entities/Item.ts
@@ -7,6 +7,7 @@ import type {
     ItemData,
     ItemEffects,
     ItemRequirements,
+    WeaponEnchantment,
 } from './ItemDeclarations.js';
 import { getAllItemData, getDiscoverableItemData, getItemDataById } from './items/ItemRegistry.js';
 
@@ -16,6 +17,7 @@ export type {
     ItemData,
     ItemEffects,
     ItemRequirements,
+    WeaponEnchantment,
 } from './ItemDeclarations.js';
 
 export default class Item {
@@ -32,6 +34,7 @@ export default class Item {
     public isRanged: boolean;
     public spriteClass: string;
     public effects: ItemEffects;
+    public enchantments: WeaponEnchantment[];
 
     constructor(data: ItemData) {
         this.id = data.id;
@@ -47,7 +50,30 @@ export default class Item {
         this.isRanged = data.isRanged ?? false;
         this.spriteClass = data.spriteClass ?? 'unknown-item-sprite';
         this.effects = data.effects ?? {};
+        this.enchantments = Array.isArray(data.enchantments) ? data.enchantments.map((enchantment) => ({ ...enchantment })) : [];
     }
+
+    public getPlasmaBonusDamage = (): number =>
+        this.enchantments
+            .filter((enchantment) => enchantment.type === 'plasma')
+            .reduce((sum, enchantment) => sum + (enchantment.plasmaBonusDamage ?? 0), 0);
+
+    public toItemData = (): ItemData => ({
+        id: this.id,
+        name: this.name,
+        description: this.description,
+        type: this.type,
+        attackRange: this.attackRange,
+        handsRequired: this.handsRequired,
+        damageBonus: this.damageBonus,
+        requirements: { ...this.requirements },
+        goldValue: this.goldValue,
+        findWeight: this.findWeight,
+        isRanged: this.isRanged,
+        spriteClass: this.spriteClass,
+        effects: { ...this.effects },
+        enchantments: this.enchantments.map((enchantment) => ({ ...enchantment })),
+    });
 }
 
 export const ITEM_LIBRARY: ItemData[] = getAllItemData();

--- a/rgfn_game/js/entities/ItemDeclarations.ts
+++ b/rgfn_game/js/entities/ItemDeclarations.ts
@@ -15,6 +15,17 @@ export interface ItemEffects {
     maxAbsorbHp?: number;
 }
 
+export type WeaponEnchantmentType = 'plasma' | 'wormhole' | 'confusion' | 'doubt';
+
+export type WeaponEnchantment = {
+    type: WeaponEnchantmentType;
+    plasmaBonusDamage?: number;
+    wormholeCritChance?: number;
+    confusionStunChance?: number;
+    doubtDamagePerSecond?: number;
+    doubtDurationSeconds?: number;
+};
+
 export interface ItemData {
     id: string;
     name: string;
@@ -29,4 +40,5 @@ export interface ItemData {
     isRanged?: boolean;
     spriteClass?: string;
     effects?: ItemEffects;
+    enchantments?: WeaponEnchantment[];
 }

--- a/rgfn_game/js/entities/Skeleton.ts
+++ b/rgfn_game/js/entities/Skeleton.ts
@@ -176,6 +176,16 @@ export default class Skeleton extends DamageableEntity {
 
     public shouldSkipTurnFromSlow = (): boolean => this.monsterStatusEffects.shouldSkipTurnFromSlow();
 
+    public shouldSkipTurn = (): boolean => this.monsterStatusEffects.shouldSkipTurn();
+
+    public applyStun(duration: number): void {
+        this.monsterStatusEffects.applyStun(duration);
+    }
+
+    public applyDamageOverTime(damagePerTurn: number, duration: number, sourceLabel: string): void {
+        this.monsterStatusEffects.applyDamageOverTime(damagePerTurn, duration, sourceLabel);
+    }
+
     public getDirectionalCombatBuffSnapshot = (): CombatBuffSnapshot => this.monsterStatusEffects.getDirectionalCombatBuffSnapshot();
 
     public applyDirectionalCombatRewards = (rewards: CombatStatusState): string[] => this.monsterStatusEffects.applyDirectionalCombatRewards(rewards, this.name);
@@ -184,7 +194,7 @@ export default class Skeleton extends DamageableEntity {
 
     public expireDirectionalBonusesWithoutAttack = (): string[] => this.monsterStatusEffects.expireDirectionalBonusesWithoutAttack(this.name);
 
-    public consumeTurnEffects = (): string[] => this.monsterStatusEffects.consumeTurnEffects(this.name);
+    public consumeTurnEffects = (): string[] => this.monsterStatusEffects.consumeTurnEffects(this.name, (amount) => void this.applyIncomingDamage(Math.max(0, amount)));
 
     public getSkillRecord = (): CreatureSkills => normalizeCreatureSkills(this.skills);
 

--- a/rgfn_game/js/entities/items/WeaponEnchantments.ts
+++ b/rgfn_game/js/entities/items/WeaponEnchantments.ts
@@ -1,0 +1,152 @@
+import { balanceConfig } from '../../config/balance/balanceConfig.js';
+import Item, { DISCOVERABLE_ITEM_LIBRARY } from '../Item.js';
+import { WeaponEnchantment, WeaponEnchantmentType } from '../ItemDeclarations.js';
+
+const ENCHANTMENT_POOL: WeaponEnchantmentType[] = ['plasma', 'wormhole', 'confusion', 'doubt'];
+
+const clampPercent = (value: number): number => Math.max(0, Math.min(100, Math.round(value)));
+
+const randomIntInclusive = (min: number, max: number): number => {
+    const safeMin = Math.min(min, max);
+    const safeMax = Math.max(min, max);
+    return safeMin + Math.floor(Math.random() * (safeMax - safeMin + 1));
+};
+
+const formatPercent = (value: number): string => `${clampPercent(value)}%`;
+
+const formatEnchantmentName = (type: WeaponEnchantmentType): string => {
+    switch (type) {
+        case 'plasma':
+            return 'Plasma';
+        case 'wormhole':
+            return 'Wormhole';
+        case 'confusion':
+            return 'Confusion';
+        case 'doubt':
+            return 'Doubt';
+        default:
+            return type;
+    }
+};
+
+const createRandomEnchantment = (type: WeaponEnchantmentType): WeaponEnchantment => {
+    const config = balanceConfig.items.enchantments;
+    if (type === 'plasma') {
+        return { type, plasmaBonusDamage: randomIntInclusive(config.plasma.minBonusDamage, config.plasma.maxBonusDamage) };
+    }
+    if (type === 'wormhole') {
+        return { type, wormholeCritChance: clampPercent(randomIntInclusive(config.wormhole.minCritChance, config.wormhole.maxCritChance)) };
+    }
+    if (type === 'confusion') {
+        return { type, confusionStunChance: clampPercent(randomIntInclusive(config.confusion.minStunChance, config.confusion.maxStunChance)) };
+    }
+
+    return {
+        type,
+        doubtDamagePerSecond: randomIntInclusive(config.doubt.minDamagePerSecond, config.doubt.maxDamagePerSecond),
+        doubtDurationSeconds: randomIntInclusive(config.doubt.minDurationSeconds, config.doubt.maxDurationSeconds),
+    };
+};
+
+export const getEnchantmentScore = (enchantment: WeaponEnchantment): number => {
+    if (enchantment.type === 'plasma') {
+        const bonus = enchantment.plasmaBonusDamage ?? 0;
+        return bonus * 1.5;
+    }
+    if (enchantment.type === 'wormhole') {
+        const critChance = clampPercent(enchantment.wormholeCritChance ?? 0);
+        return (critChance / 100) * 4;
+    }
+    if (enchantment.type === 'confusion') {
+        const stunChance = clampPercent(enchantment.confusionStunChance ?? 0);
+        return (stunChance / 100) * 3;
+    }
+    const dps = enchantment.doubtDamagePerSecond ?? 0;
+    const duration = enchantment.doubtDurationSeconds ?? 0;
+    return dps * duration * 0.75;
+};
+
+const getItemEnchantmentScore = (enchantments: WeaponEnchantment[]): number =>
+    enchantments.reduce((sum, enchantment) => sum + getEnchantmentScore(enchantment), 0);
+
+const buildEnchantmentDescriptionLine = (enchantment: WeaponEnchantment): string => {
+    if (enchantment.type === 'plasma') {
+        const bonus = enchantment.plasmaBonusDamage ?? 0;
+        const delayed = Math.max(1, Math.floor(bonus / 2));
+        return `Plasma: +${bonus} damage and +${delayed} delayed damage on next turn.`;
+    }
+    if (enchantment.type === 'wormhole') {
+        return `Wormhole: ${formatPercent(enchantment.wormholeCritChance ?? 0)} chance to crit for 2x damage.`;
+    }
+    if (enchantment.type === 'confusion') {
+        return `Confusion: ${formatPercent(enchantment.confusionStunChance ?? 0)} chance to stun target for 1 turn.`;
+    }
+    return `Doubt: +${enchantment.doubtDamagePerSecond ?? 0} damage/sec for ${enchantment.doubtDurationSeconds ?? 0}s.`;
+};
+
+const buildEnchantedName = (baseName: string, enchantments: WeaponEnchantment[]): string => {
+    const prefixes = enchantments.slice(0, 2).map((enchantment) => formatEnchantmentName(enchantment.type));
+    return `${prefixes.join('-')} ${baseName}`;
+};
+
+const applyEnchantmentsToItem = (item: Item, enchantments: WeaponEnchantment[]): Item => {
+    if (enchantments.length === 0) {
+        return item;
+    }
+
+    const score = getItemEnchantmentScore(enchantments);
+    const priceMultiplier = 1 + (score * balanceConfig.items.enchantments.priceMultiplierPerScore);
+    item.enchantments = enchantments;
+    item.name = buildEnchantedName(item.name, enchantments);
+    item.goldValue = Math.max(item.goldValue + enchantments.length, Math.ceil(item.goldValue * priceMultiplier));
+    item.description = `${item.description} Enchantments: ${enchantments.map((enchantment) => buildEnchantmentDescriptionLine(enchantment)).join(' ')}`;
+    return item;
+};
+
+const rollEnchantmentList = (): WeaponEnchantment[] => {
+    const config = balanceConfig.items.enchantments;
+    const pool = [...ENCHANTMENT_POOL];
+    const enchantments: WeaponEnchantment[] = [];
+    const maxEnchantments = Math.max(1, config.maxEnchantmentsPerWeapon);
+    while (pool.length > 0 && enchantments.length < maxEnchantments) {
+        if (enchantments.length > 0 && Math.random() >= config.chanceForExtraEnchantment) {
+            break;
+        }
+        const index = Math.floor(Math.random() * pool.length);
+        const [selected] = pool.splice(index, 1);
+        if (!selected) {
+            break;
+        }
+        enchantments.push(createRandomEnchantment(selected));
+    }
+    return enchantments;
+};
+
+export const rollRandomWeaponEnchantments = (item: Item, forceEnchanted: boolean = false): Item => {
+    if (item.type !== 'weapon') {
+        return item;
+    }
+
+    const config = balanceConfig.items.enchantments;
+    if (!forceEnchanted && Math.random() >= config.chanceOnRandomWeapon) {
+        item.enchantments = [];
+        return item;
+    }
+    return applyEnchantmentsToItem(item, rollEnchantmentList());
+};
+
+export const buildRandomDiscoverableWeapon = (): Item | null => {
+    const weaponPool = DISCOVERABLE_ITEM_LIBRARY.filter((itemData) => itemData.type === 'weapon');
+    if (weaponPool.length === 0) {
+        return null;
+    }
+
+    const selected = weaponPool[Math.floor(Math.random() * weaponPool.length)];
+    if (!selected) {
+        return null;
+    }
+
+    return rollRandomWeaponEnchantments(new Item(selected), true);
+};
+
+export const applyRandomEnchantmentsToGeneratedItem = (item: Item): Item => rollRandomWeaponEnchantments(item, false);

--- a/rgfn_game/js/entities/monster/MonsterStatusEffects.ts
+++ b/rgfn_game/js/entities/monster/MonsterStatusEffects.ts
@@ -5,6 +5,8 @@ export class MonsterStatusEffects {
     private cursedArmorReduction: number = 0;
     private curseTurns: number = 0;
     private slowTurns: number = 0;
+    private stunTurns: number = 0;
+    private damageOverTimeEffects: Array<{ damagePerTurn: number; turnsRemaining: number; sourceLabel: string }> = [];
     private blockAdvantage: boolean = false;
     private successfulDodgeMultiplier: number | null = null;
 
@@ -26,6 +28,17 @@ export class MonsterStatusEffects {
     public applySlow = (duration: number): void => void (this.slowTurns = Math.max(this.slowTurns, duration));
 
     public shouldSkipTurnFromSlow = (): boolean => this.slowTurns > 0;
+
+    public applyStun = (duration: number): void => void (this.stunTurns = Math.max(this.stunTurns, duration));
+
+    public shouldSkipTurn = (): boolean => this.stunTurns > 0 || this.slowTurns > 0;
+
+    public applyDamageOverTime(damagePerTurn: number, duration: number, sourceLabel: string): void {
+        if (damagePerTurn <= 0 || duration <= 0) {
+            return;
+        }
+        this.damageOverTimeEffects.push({ damagePerTurn, turnsRemaining: duration, sourceLabel });
+    }
 
     public getDirectionalCombatBuffSnapshot = (): CombatBuffSnapshot => ({
         hasBlockAdvantage: this.blockAdvantage,
@@ -76,11 +89,34 @@ export class MonsterStatusEffects {
         return events;
     }
 
-    public consumeTurnEffects(name: string): string[] {
+    public consumeTurnEffects(name: string, applyDamage: (amount: number) => void): string[] {
         const events: string[] = [];
+        this.consumeDamageOverTime(name, applyDamage, events);
+        this.consumeStun(name, events);
         this.consumeSlow(name, events);
         this.consumeCurse(name, events);
         return events;
+    }
+
+    private consumeDamageOverTime(name: string, applyDamage: (amount: number) => void, events: string[]): void {
+        const remainingEffects: Array<{ damagePerTurn: number; turnsRemaining: number; sourceLabel: string }> = [];
+        this.damageOverTimeEffects.forEach((effect) => {
+            applyDamage(effect.damagePerTurn);
+            events.push(`${name} suffers ${effect.damagePerTurn} ${effect.sourceLabel} damage.`);
+            const turnsRemaining = effect.turnsRemaining - 1;
+            if (turnsRemaining > 0) {
+                remainingEffects.push({ ...effect, turnsRemaining });
+            }
+        });
+        this.damageOverTimeEffects = remainingEffects;
+    }
+
+    private consumeStun(name: string, events: string[]): void {
+        if (this.stunTurns <= 0) {
+            return;
+        }
+        this.stunTurns -= 1;
+        events.push(`${name} is stunned and skips this turn.`);
     }
 
     private consumeSlow(name: string, events: string[]): void {

--- a/rgfn_game/js/entities/player/core/PlayerBase.ts
+++ b/rgfn_game/js/entities/player/core/PlayerBase.ts
@@ -65,13 +65,7 @@ export default class PlayerBase extends DamageableEntity {
         this.width = balanceConfig.player.width;
         this.height = balanceConfig.player.height;
         this.initializePrimaryStats(options.startingSkillAllocation ?? null);
-        this.inventorySystem = new PlayerInventory({
-            getInventoryCapacity: () => this.getInventoryCapacity(),
-            onEquipmentChanged: () => this.updateStats(),
-            onHealingPotionUsed: () => this.heal(5),
-            onManaPotionUsed: () => this.restoreMana(balanceConfig.combat.manaPotionRestore),
-            canEquip: (item) => this.canEquipItem(item),
-        });
+        this.inventorySystem = this.createInventorySystem();
         this.renderer = new PlayerRenderer();
         this.updateStats();
         this.mana = this.maxMana;
@@ -127,9 +121,16 @@ export default class PlayerBase extends DamageableEntity {
         const mainWeapon = this.equippedMainWeapon;
         const offhandWeapon = this.equippedOffhandWeapon;
         if (!mainWeapon && !offhandWeapon) { this.damage = fist * 2 + (meleeBonus * 2); return; }
-        if (mainWeapon?.handsRequired === 2) { this.damage = mainWeapon.damageBonus + (mainWeapon.isRanged ? rangedBonus : meleeBonus); return; }
-        const main = mainWeapon ? mainWeapon.damageBonus + (mainWeapon.isRanged ? rangedBonus : meleeBonus) : fist + meleeBonus;
-        const off = offhandWeapon ? offhandWeapon.damageBonus + (offhandWeapon.isRanged ? rangedBonus : meleeBonus) : fist + meleeBonus;
+        if (mainWeapon?.handsRequired === 2) {
+            this.damage = mainWeapon.damageBonus + (mainWeapon.isRanged ? rangedBonus : meleeBonus) + mainWeapon.getPlasmaBonusDamage();
+            return;
+        }
+        const main = mainWeapon
+            ? mainWeapon.damageBonus + (mainWeapon.isRanged ? rangedBonus : meleeBonus) + mainWeapon.getPlasmaBonusDamage()
+            : fist + meleeBonus;
+        const off = offhandWeapon
+            ? offhandWeapon.damageBonus + (offhandWeapon.isRanged ? rangedBonus : meleeBonus) + offhandWeapon.getPlasmaBonusDamage()
+            : fist + meleeBonus;
         this.damage = main + off;
     }
 
@@ -138,6 +139,14 @@ export default class PlayerBase extends DamageableEntity {
     public getInventoryCapacity = (): number => this.getInventoryCapacityForStrength(this.strength);
     public restoreMana(amount: number): void { if (amount > 0) {this.mana = Math.min(this.maxMana, this.mana + amount);} }
     public canEquipItem = (item: Item): boolean => this.agility >= (item.requirements.agility ?? 0) && this.strength >= (item.requirements.strength ?? 0);
+
+    private createInventorySystem = (): PlayerInventory => new PlayerInventory({
+        getInventoryCapacity: () => this.getInventoryCapacity(),
+        onEquipmentChanged: () => this.updateStats(),
+        onHealingPotionUsed: () => this.heal(5),
+        onManaPotionUsed: () => this.restoreMana(balanceConfig.combat.manaPotionRestore),
+        canEquip: (item) => this.canEquipItem(item),
+    });
 
     private initializePrimaryStats(startingSkillAllocation: Partial<Record<PlayerStat, number>> | null): void {
         this.vitality = balanceConfig.player.initialVitality;

--- a/rgfn_game/js/entities/player/core/PlayerInventoryAndRender.ts
+++ b/rgfn_game/js/entities/player/core/PlayerInventoryAndRender.ts
@@ -43,11 +43,11 @@ export default class PlayerInventoryAndRender extends PlayerCombatState {
         if (!main && !off) {return `Unarmed: (${fist} + ${meleeBonus}) + (${fist} + ${meleeBonus}) = ${this.damage}`;}
         if (main?.handsRequired === 2) {
             const statBonus = main.isRanged ? calculateBowDamageBonus(this.strength, this.agility) : meleeBonus;
-            return `${main.isRanged ? 'Ranged' : 'Melee'} (2H): weapon ${main.damageBonus} + stat bonus ${statBonus} = ${this.damage}`;
+            return `${main.isRanged ? 'Ranged' : 'Melee'} (2H): weapon ${main.damageBonus + main.getPlasmaBonusDamage()} + stat bonus ${statBonus} = ${this.damage}`;
         }
         const rangedBonus = calculateBowDamageBonus(this.strength, this.agility);
-        const mainText = main ? `${main.name} (${main.damageBonus} + ${main.isRanged ? rangedBonus : meleeBonus})` : `Fist (${fist} + ${meleeBonus})`;
-        const offText = off ? `${off.name} (${off.damageBonus} + ${off.isRanged ? rangedBonus : meleeBonus})` : `Fist (${fist} + ${meleeBonus})`;
+        const mainText = main ? `${main.name} (${main.damageBonus + main.getPlasmaBonusDamage()} + ${main.isRanged ? rangedBonus : meleeBonus})` : `Fist (${fist} + ${meleeBonus})`;
+        const offText = off ? `${off.name} (${off.damageBonus + off.getPlasmaBonusDamage()} + ${off.isRanged ? rangedBonus : meleeBonus})` : `Fist (${fist} + ${meleeBonus})`;
         return `Dual hand: main ${mainText} + off ${offText} = ${this.damage}`;
     }
 

--- a/rgfn_game/js/entities/player/core/PlayerPersistence.ts
+++ b/rgfn_game/js/entities/player/core/PlayerPersistence.ts
@@ -1,40 +1,27 @@
 import { createItemById } from '../../Item.js';
+import { ItemData } from '../../ItemDeclarations.js';
 import PlayerInventoryAndRender from './PlayerInventoryAndRender.js';
 
+type LegacyInventoryState = {
+    itemIds: string[];
+    equippedWeaponId: string | null;
+    equippedArmorId: string | null;
+    equippedOffhandWeaponId: string | null;
+};
+
 export default class PlayerPersistence extends PlayerInventoryAndRender {
-    public getState(): Record<string, unknown> {
-        const inventoryState = this.inventorySystem.getState();
-        const combat = this.getCombatState();
-        return {
-            level: this.level,
-            name: this.name,
-            xp: this.xp,
-            xpToNextLevel: this.xpToNextLevel,
-            vitality: this.vitality,
-            toughness: this.toughness,
-            strength: this.strength,
-            agility: this.agility,
-            connection: this.connection,
-            intelligence: this.intelligence,
-            skillPoints: this.skillPoints,
-            magicPoints: this.magicPoints,
-            hp: this.hp,
-            mana: this.mana,
-            gold: this.gold,
-            fatigue: this.fatigue,
-            armorAbsorbedHp: this.armorAbsorbedHp,
-            rageTurns: combat.rageTurns,
-            rageMultiplier: combat.rageMultiplier,
-            blockAdvantage: combat.blockAdvantage,
-            successfulDodgeMultiplier: combat.successfulDodgeMultiplier,
-            inventoryItemIds: inventoryState.inventoryItemIds,
-            equippedWeaponId: inventoryState.equippedWeaponId,
-            equippedOffhandWeaponId: inventoryState.equippedOffhandWeaponId,
-            equippedArmorId: inventoryState.equippedArmorId,
-        };
-    }
+    public getState = (): Record<string, unknown> => ({ ...this.getCoreState(), ...this.inventorySystem.getState() });
 
     public restoreState(state: Record<string, unknown>): void {
+        this.restorePlayerStats(state);
+        this.restoreCombatState(state);
+        this.restoreInventoryState(state);
+        this.updateStats();
+        this.hp = Math.max(0, Math.min(this.maxHp, this.toNumber(state.hp, this.hp)));
+        this.mana = Math.max(0, Math.min(this.maxMana, this.toNumber(state.mana, this.mana)));
+    }
+
+    private restorePlayerStats(state: Record<string, unknown>): void {
         this.level = this.toNumber(state.level, this.level);
         this.name = typeof state.name === 'string' && state.name.trim().length > 0 ? state.name : this.name;
         this.xp = this.toNumber(state.xp, this.xp);
@@ -50,23 +37,94 @@ export default class PlayerPersistence extends PlayerInventoryAndRender {
         this.gold = this.toNumber(state.gold, this.gold);
         this.fatigue = Math.max(0, Math.min(this.getMaxFatigue(), this.toNumber(state.fatigue, this.fatigue)));
         this.armorAbsorbedHp = this.toNumber(state.armorAbsorbedHp, 0);
+    }
+
+    private restoreCombatState(state: Record<string, unknown>): void {
         this.setCombatState({
             rageTurns: this.toNumber(state.rageTurns, 0),
             rageMultiplier: this.toNumber(state.rageMultiplier, 1),
             blockAdvantage: Boolean(state.blockAdvantage),
             successfulDodgeMultiplier: typeof state.successfulDodgeMultiplier === 'number' ? state.successfulDodgeMultiplier : null,
         });
+    }
 
-        const inventoryItemIds = Array.isArray(state.inventoryItemIds) ? state.inventoryItemIds.filter((id): id is string => typeof id === 'string') : [];
+    private restoreInventoryState(state: Record<string, unknown>): void {
+        const legacyState = this.readLegacyInventoryState(state);
+        const inventorySnapshots = this.readInventorySnapshots(state.inventoryItems);
+        const restoredFromSnapshots = this.inventorySystem.restoreStateFromSnapshots(
+            inventorySnapshots,
+            this.toItemData(state.equippedWeapon),
+            this.toItemData(state.equippedOffhandWeapon),
+            this.toItemData(state.equippedArmor),
+        );
+        if (!restoredFromSnapshots) {
+            const legacyRestoreState = { ...legacyState, itemFactory: createItemById };
+            this.inventorySystem.restoreState(legacyRestoreState);
+        }
+    }
+
+    private getCoreState = (): Record<string, unknown> => ({ ...this.getPrimaryState(), ...this.getCombatSnapshot() });
+
+    private getPrimaryState = (): Record<string, unknown> => ({ ...this.getIdentityState(), ...this.getVitalsState() });
+
+    private getIdentityState = (): Record<string, unknown> => ({
+        level: this.level,
+        name: this.name,
+        xp: this.xp,
+        xpToNextLevel: this.xpToNextLevel,
+        vitality: this.vitality,
+        toughness: this.toughness,
+        strength: this.strength,
+        agility: this.agility,
+        connection: this.connection,
+        intelligence: this.intelligence,
+        skillPoints: this.skillPoints,
+        magicPoints: this.magicPoints,
+    });
+
+    private getVitalsState = (): Record<string, unknown> => ({
+        hp: this.hp,
+        mana: this.mana,
+        gold: this.gold,
+        fatigue: this.fatigue,
+        armorAbsorbedHp: this.armorAbsorbedHp,
+    });
+
+    private getCombatSnapshot(): Record<string, unknown> {
+        const combat = this.getCombatState();
+        return {
+            rageTurns: combat.rageTurns,
+            rageMultiplier: combat.rageMultiplier,
+            blockAdvantage: combat.blockAdvantage,
+            successfulDodgeMultiplier: combat.successfulDodgeMultiplier,
+        };
+    }
+
+    private readLegacyInventoryState(state: Record<string, unknown>): LegacyInventoryState {
+        const itemIds = Array.isArray(state.inventoryItemIds) ? state.inventoryItemIds.filter((id): id is string => typeof id === 'string') : [];
         const equippedWeaponId = typeof state.equippedWeaponId === 'string' ? state.equippedWeaponId : null;
         const equippedOffhandWeaponId = typeof state.equippedOffhandWeaponId === 'string' ? state.equippedOffhandWeaponId : null;
         const equippedArmorId = typeof state.equippedArmorId === 'string' ? state.equippedArmorId : null;
-        this.inventorySystem.restoreState({ itemIds: inventoryItemIds, equippedWeaponId, equippedArmorId, itemFactory: createItemById, equippedOffhandWeaponId });
+        return { itemIds, equippedWeaponId, equippedArmorId, equippedOffhandWeaponId };
+    }
 
-        this.updateStats();
-        this.hp = Math.max(0, Math.min(this.maxHp, this.toNumber(state.hp, this.hp)));
-        this.mana = Math.max(0, Math.min(this.maxMana, this.toNumber(state.mana, this.mana)));
+    private readInventorySnapshots(value: unknown): ItemData[] | undefined {
+        if (!Array.isArray(value)) {
+            return undefined;
+        }
+        return value.map((item) => this.toItemData(item)).filter((item): item is ItemData => item !== null);
     }
 
     private toNumber = (value: unknown, fallback: number): number => (typeof value === 'number' && Number.isFinite(value) ? value : fallback);
+
+    private toItemData(value: unknown): ItemData | null {
+        if (!value || typeof value !== 'object') {
+            return null;
+        }
+        const candidate = value as Record<string, unknown>;
+        if (typeof candidate.id !== 'string' || typeof candidate.name !== 'string' || typeof candidate.description !== 'string' || typeof candidate.type !== 'string') {
+            return null;
+        }
+        return candidate as unknown as ItemData;
+    }
 }

--- a/rgfn_game/js/entities/player/inventory/PlayerInventory.ts
+++ b/rgfn_game/js/entities/player/inventory/PlayerInventory.ts
@@ -1,4 +1,5 @@
 import Item from '../../Item.js';
+import { ItemData } from '../../ItemDeclarations.js';
 import PlayerInventoryEquipment from './PlayerInventoryEquipment.js';
 import type { InventoryState, PlayerInventoryHooks, PotionItemId, RestoreInventoryStateArgs } from './PlayerInventoryTypes.js';
 
@@ -10,7 +11,6 @@ export default class PlayerInventory {
     constructor(hooks: PlayerInventoryHooks) {
         this.hooks = hooks;
     }
-
     public addItem(item: Item): boolean {
         if (this.inventory.length >= this.hooks.getInventoryCapacity()) {
             return false;
@@ -18,7 +18,6 @@ export default class PlayerInventory {
         this.inventory.push(item);
         return true;
     }
-
     public useHealingPotion = (): boolean => this.usePotionById('healingPotion', this.hooks.onHealingPotionUsed);
 
     public useManaPotion = (): boolean => this.usePotionById('manaPotion', this.hooks.onManaPotionUsed);
@@ -46,7 +45,6 @@ export default class PlayerInventory {
         }
         return removedItem;
     }
-
     public unequipWeapon(): Item | null {
         const weapon = this.equipment.unequipWeapon(this.moveItemToInventory);
         if (!weapon) {
@@ -55,7 +53,6 @@ export default class PlayerInventory {
         this.hooks.onEquipmentChanged();
         return weapon;
     }
-
     public unequipOffhandWeapon(): Item | null {
         const weapon = this.equipment.unequipOffhandWeapon(this.moveItemToInventory);
         if (!weapon) {
@@ -64,7 +61,6 @@ export default class PlayerInventory {
         this.hooks.onEquipmentChanged();
         return weapon;
     }
-
     public unequipArmor(): Item | null {
         const armor = this.equipment.unequipArmor(this.moveItemToInventory);
         if (!armor) {
@@ -73,21 +69,18 @@ export default class PlayerInventory {
         this.hooks.onEquipmentChanged();
         return armor;
     }
-
     public setEquippedWeapon(weapon: Item | null): void {
         this.moveEquippedItemsToInventory([this.equipment.getEquippedMainWeapon(), this.equipment.getEquippedOffhandWeapon()], [weapon]);
         this.removeItemFromInventory(weapon);
         this.equipment.setEquippedWeapon(weapon);
         this.hooks.onEquipmentChanged();
     }
-
     public setEquippedOffhandWeapon(weapon: Item | null): void {
         this.moveEquippedItemsToInventory([this.equipment.getEquippedOffhandWeapon()], [this.equipment.getEquippedMainWeapon(), weapon]);
         this.removeItemFromInventory(weapon);
         this.equipment.setEquippedOffhandWeapon(weapon);
         this.hooks.onEquipmentChanged();
     }
-
     public equipWeaponToSlot(weapon: Item, slot: 'main' | 'offhand'): void {
         const previousMainWeapon = this.equipment.getEquippedMainWeapon();
         const previousOffhandWeapon = this.equipment.getEquippedOffhandWeapon();
@@ -100,21 +93,43 @@ export default class PlayerInventory {
         );
         this.hooks.onEquipmentChanged();
     }
-
     public setEquippedArmor(armor: Item | null): void {
         this.moveEquippedItemsToInventory([this.equipment.getEquippedArmor()], [armor]);
         this.removeItemFromInventory(armor);
         this.equipment.setEquippedArmor(armor);
         this.hooks.onEquipmentChanged();
     }
-
     public restoreState({ itemIds, equippedWeaponId, equippedArmorId, itemFactory, equippedOffhandWeaponId }: RestoreInventoryStateArgs): void {
         this.restoreInventoryItems(itemIds, itemFactory);
         this.equipment.restoreFromFactory(equippedWeaponId, equippedOffhandWeaponId, equippedArmorId, itemFactory);
         this.hooks.onEquipmentChanged();
     }
+    public getState = (): InventoryState => ({
+        inventoryItemIds: this.inventory.map((item) => item.id),
+        inventoryItems: this.inventory.map((item) => item.toItemData()),
+        equippedWeapon: this.equipment.getEquippedMainWeapon()?.toItemData() ?? null,
+        equippedOffhandWeapon: this.equipment.getEquippedOffhandWeapon()?.toItemData() ?? null,
+        equippedArmor: this.equipment.getEquippedArmor()?.toItemData() ?? null,
+        ...this.equipment.getEquippedItemIds(),
+    });
 
-    public getState = (): InventoryState => ({ inventoryItemIds: this.inventory.map((item) => item.id), ...this.equipment.getEquippedItemIds() });
+    public restoreStateFromSnapshots(
+        inventoryItems: ItemData[] | undefined,
+        equippedWeapon: ItemData | null | undefined,
+        equippedOffhandWeapon: ItemData | null | undefined,
+        equippedArmor: ItemData | null | undefined,
+    ): boolean {
+        if (!Array.isArray(inventoryItems)) {
+            return false;
+        }
+        this.inventory.length = 0;
+        inventoryItems.forEach((itemData) => this.inventory.push(new Item(itemData)));
+        this.equipment.setEquippedWeapon(equippedWeapon ? new Item(equippedWeapon) : null);
+        this.equipment.setEquippedOffhandWeapon(equippedOffhandWeapon ? new Item(equippedOffhandWeapon) : null);
+        this.equipment.setEquippedArmor(equippedArmor ? new Item(equippedArmor) : null);
+        this.hooks.onEquipmentChanged();
+        return true;
+    }
 
     private readonly moveItemToInventory = (item: Item): boolean => {
         if (this.inventory.includes(item)) {

--- a/rgfn_game/js/entities/player/inventory/PlayerInventoryTypes.ts
+++ b/rgfn_game/js/entities/player/inventory/PlayerInventoryTypes.ts
@@ -1,4 +1,5 @@
 import Item from '../../Item.js';
+import { ItemData } from '../../ItemDeclarations.js';
 
 export type PlayerInventoryHooks = {
     onEquipmentChanged: () => void;
@@ -13,6 +14,10 @@ export type InventoryState = {
     equippedWeaponId: string | null;
     equippedOffhandWeaponId: string | null;
     equippedArmorId: string | null;
+    inventoryItems?: ItemData[];
+    equippedWeapon?: ItemData | null;
+    equippedOffhandWeapon?: ItemData | null;
+    equippedArmor?: ItemData | null;
 };
 
 export type RestoreInventoryStateArgs = {

--- a/rgfn_game/js/systems/encounter/EncounterResolver.ts
+++ b/rgfn_game/js/systems/encounter/EncounterResolver.ts
@@ -2,6 +2,7 @@ import { randomInt } from '../../../../engine/utils/MathUtils.js';
 import Skeleton, { EnemyConfig } from '../../entities/Skeleton.js';
 import Item, { DISCOVERABLE_ITEM_LIBRARY, HEALING_POTION_ITEM, MANA_POTION_ITEM } from '../../entities/Item.js';
 import { balanceConfig } from '../../config/balance/balanceConfig.js';
+import { applyRandomEnchantmentsToGeneratedItem } from '../../entities/items/WeaponEnchantments.js';
 import { assignMonsterBehaviorPool } from '../combat/MonsterBehaviorDirector.js';
 import type { EncounterResult, ForcedEncounterType, RandomEncounterType } from './EncounterSystem.js';
 import Wanderer from '../../entities/Wanderer.js';
@@ -91,7 +92,7 @@ export default class EncounterResolver {
             if (roll <= 0) {
                 const itemData = DISCOVERABLE_ITEM_LIBRARY.find((item) => item.id === candidate.id);
                 if (itemData) {
-                    return { type: 'item', item: new Item(itemData) };
+                    return { type: 'item', item: applyRandomEnchantmentsToGeneratedItem(new Item(itemData)) };
                 }
             }
         }

--- a/rgfn_game/js/systems/game/BattleCommandController.ts
+++ b/rgfn_game/js/systems/game/BattleCommandController.ts
@@ -10,7 +10,7 @@ import { CombatMove, getMoveLabel } from '../combat/DirectionalCombat.js';
 import BattleTargetResolver from './BattleTargetResolver.js';
 import BattleLootManager from './BattleLootManager.js';
 import BattleDirectionalCombatResolver from './BattleDirectionalCombatResolver.js';
-
+import { resolveWeaponEnchantmentAttack } from './WeaponEnchantmentCombat.js';
 type BattleCommandCallbacks = {
     onUpdateHUD: () => void; onAddBattleLog: (message: string, type?: string) => void; onEnableBattleButtons: (enabled: boolean) => void;
     onProcessTurn: () => void; onEndBattle: (result: 'victory' | 'fled') => void; onPlayerTurnTransitionStart: () => void; onPlayerTurnReady: () => void;
@@ -21,7 +21,6 @@ export default class BattleCommandController {
     private stateMachine: StateMachine; private player: Player; private battleMap: BattleMap; private turnManager: TurnManager;
     private callbacks: BattleCommandCallbacks; private magicSystem: MagicSystem; private targetResolver: BattleTargetResolver;
     private lootManager: BattleLootManager; private directionalCombatResolver: BattleDirectionalCombatResolver;
-
     constructor(stateMachine: StateMachine, player: Player, battleMap: BattleMap, turnManager: TurnManager, magicSystem: MagicSystem, callbacks: BattleCommandCallbacks) {
         this.stateMachine = stateMachine;
         this.player = player;
@@ -37,7 +36,6 @@ export default class BattleCommandController {
             onTargetDefeated: this.handleTargetDefeated,
         });
     }
-
     public handleEquipmentAction(actionDescription: string): boolean {
         if (!this.stateMachine.isInState('BATTLE')) {return true;}
         if (!this.canUseBattleTurnInput()) {
@@ -50,7 +48,6 @@ export default class BattleCommandController {
         this.finishPlayerAction(timingConfig.battle.playerActionDelay);
         return true;
     }
-
     public handleAttack(): void {
         if (!this.canUseBattleTurnInput()) {return;}
         const enemies = this.turnManager.getActiveEnemies() as Skeleton[];
@@ -163,9 +160,11 @@ export default class BattleCommandController {
         attackBonusMessages.forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
         if (target.shouldAvoidHit()) {this.callbacks.onAddBattleLog(`${target.name} dodges the hit!`, 'enemy'); return;}
 
-        const damage = this.player.getPhysicalDamageWithBuff();
+        const enchantmentOutcome = resolveWeaponEnchantmentAttack(target, [this.player.equippedMainWeapon, this.player.equippedOffhandWeapon]);
+        const damage = Math.max(0, Math.round((this.player.getPhysicalDamageWithBuff() + enchantmentOutcome.flatDamageBonus) * enchantmentOutcome.damageMultiplier));
         target.takeDamage(damage);
         this.callbacks.onAddBattleLog(`${target.name} takes ${damage} damage!`, 'damage');
+        enchantmentOutcome.logs.forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
         this.applyRetaliationEffects(target, true);
         if (target.isDead()) {this.handleTargetDefeated(target);}
     }

--- a/rgfn_game/js/systems/game/BattleDirectionalCombatResolver.ts
+++ b/rgfn_game/js/systems/game/BattleDirectionalCombatResolver.ts
@@ -1,6 +1,7 @@
 import Player from '../../entities/player/Player.js';
 import Skeleton from '../../entities/Skeleton.js';
 import { CombatMove, getMoveLabel, isAttackMove, resolveDirectionalCombatExchange } from '../combat/DirectionalCombat.js';
+import { resolveWeaponEnchantmentAttack } from './WeaponEnchantmentCombat.js';
 
 type DirectionalCombatCallbacks = {
     onAddBattleLog: (message: string, type?: string) => void;
@@ -63,8 +64,11 @@ export default class BattleDirectionalCombatResolver {
 
     private applyDamage(actorDamage: number, enemyDamage: number, actorMove: CombatMove, enemyMove: CombatMove, target: Skeleton): void {
         if (actorDamage > 0) {
-            target.takeDamage(actorDamage);
-            this.callbacks.onAddBattleLog(`${target.name} takes ${actorDamage} damage from ${getMoveLabel(actorMove)}.`, 'damage');
+            const enchantmentOutcome = resolveWeaponEnchantmentAttack(target, [this.player.equippedMainWeapon, this.player.equippedOffhandWeapon]);
+            const totalDamage = Math.max(0, Math.round((actorDamage + enchantmentOutcome.flatDamageBonus) * enchantmentOutcome.damageMultiplier));
+            target.takeDamage(totalDamage);
+            this.callbacks.onAddBattleLog(`${target.name} takes ${totalDamage} damage from ${getMoveLabel(actorMove)}.`, 'damage');
+            enchantmentOutcome.logs.forEach((message) => this.callbacks.onAddBattleLog(message, 'system'));
             this.callbacks.onApplyRetaliation(target, true);
         } else if (isAttackMove(actorMove)) {
             this.callbacks.onAddBattleLog(`Your ${getMoveLabel(actorMove)} deals no damage this turn.`, 'system');

--- a/rgfn_game/js/systems/game/BattleLootManager.ts
+++ b/rgfn_game/js/systems/game/BattleLootManager.ts
@@ -3,6 +3,7 @@ import Skeleton from '../../entities/Skeleton.js';
 import Wanderer from '../../entities/Wanderer.js';
 import Player from '../../entities/player/Player.js';
 import { balanceConfig } from '../../config/balance/balanceConfig.js';
+import { applyRandomEnchantmentsToGeneratedItem } from '../../entities/items/WeaponEnchantments.js';
 
 type LootCallbacks = {
     onAddBattleLog: (message: string, type?: string) => void;
@@ -18,18 +19,7 @@ export default class BattleLootManager {
     public handleKillRewards(target: Skeleton, player: Player, callbacks: LootCallbacks, participantCount: number = 1): void {
         callbacks.onAddBattleLog(`${target.name} defeated!`, 'system');
         callbacks.onEnemyDefeated?.(target);
-
-        if (target.xpValue && target.xpValue > 0) {
-            const shareCount = Math.max(1, Math.floor(participantCount));
-            const playerShare = Math.max(1, Math.floor(target.xpValue / shareCount));
-            const leveledUp = player.addXp(playerShare);
-            callbacks.onAddBattleLog(`Gained ${playerShare} XP (${target.xpValue} total split across ${shareCount} allies).`, 'system');
-            if (leveledUp) {
-                callbacks.onAddBattleLog(`LEVEL UP! Now level ${player.level}!`, 'system');
-                callbacks.onAddBattleLog(`Gained ${balanceConfig.leveling.skillPointsPerLevel} skill points! HP and mana fully restored!`, 'system');
-            }
-        }
-
+        this.awardXp(target, player, callbacks, participantCount);
         this.collectLoot(target, callbacks, Math.max(1, Math.floor(participantCount)));
         if (callbacks.getSelectedEnemy() === target) {
             callbacks.setSelectedEnemy(null);
@@ -58,53 +48,73 @@ export default class BattleLootManager {
         this.pendingLoot = [];
     };
 
+    private awardXp(target: Skeleton, player: Player, callbacks: LootCallbacks, participantCount: number): void {
+        if (!target.xpValue || target.xpValue <= 0) {
+            return;
+        }
+        const shareCount = Math.max(1, Math.floor(participantCount));
+        const playerShare = Math.max(1, Math.floor(target.xpValue / shareCount));
+        const leveledUp = player.addXp(playerShare);
+        callbacks.onAddBattleLog(`Gained ${playerShare} XP (${target.xpValue} total split across ${shareCount} allies).`, 'system');
+        if (leveledUp) {
+            callbacks.onAddBattleLog(`LEVEL UP! Now level ${player.level}!`, 'system');
+            callbacks.onAddBattleLog(`Gained ${balanceConfig.leveling.skillPointsPerLevel} skill points! HP and mana fully restored!`, 'system');
+        }
+    }
+
     private collectLoot(target: Skeleton, callbacks: LootCallbacks, participantCount: number): void {
-        const loot: Item[] = [];
-        const lootable = target as Skeleton & { getLootItems?: () => Item[] };
-
-        if (lootable.getLootItems) {
-            loot.push(...lootable.getLootItems());
-        }
-
-        if (!(target instanceof Wanderer)) {
-            const randomDrop = this.rollMonsterDrop();
-            if (randomDrop) {
-                loot.push(randomDrop);
-            }
-        }
-
-        for (const item of loot) {
+        const loot = this.getLootDrops(target);
+        loot.forEach((item) => {
             if (participantCount > 1 && Math.random() > (1 / participantCount)) {
                 callbacks.onAddBattleLog(`${item.name} was claimed by allied defenders.`, 'system-message');
-                continue;
+                return;
             }
             this.pendingLoot.push(item);
             callbacks.onAddBattleLog(`${item.name} dropped. It will be collected after battle.`, 'system');
+        });
+    }
+
+    private getLootDrops(target: Skeleton): Item[] {
+        const loot: Item[] = [];
+        const lootable = target as Skeleton & { getLootItems?: () => Item[] };
+        if (lootable.getLootItems) {
+            loot.push(...lootable.getLootItems());
         }
+        if (target instanceof Wanderer) {
+            return loot;
+        }
+        const randomDrop = this.rollMonsterDrop();
+        if (randomDrop) {
+            loot.push(randomDrop);
+        }
+        return loot;
     }
 
     private rollMonsterDrop(): Item | null {
         if (Math.random() >= balanceConfig.items.monsterDropChance) {
             return null;
         }
+        const candidateId = this.rollFromWeightedPool();
+        if (!candidateId) {
+            return null;
+        }
+        const itemData = DISCOVERABLE_ITEM_LIBRARY.find((item) => item.id === candidateId);
+        return itemData ? applyRandomEnchantmentsToGeneratedItem(new Item(itemData)) : null;
+    }
 
+    private rollFromWeightedPool(): string | null {
         const weightedPool = balanceConfig.items.discoveryPool;
         const totalWeight = weightedPool.reduce((sum, entry) => sum + entry.weight, 0);
         if (totalWeight <= 0) {
             return null;
         }
-
         let roll = Math.random() * totalWeight;
         for (const candidate of weightedPool) {
             roll -= candidate.weight;
-            if (roll > 0) {
-                continue;
+            if (roll <= 0) {
+                return candidate.id;
             }
-
-            const itemData = DISCOVERABLE_ITEM_LIBRARY.find((item) => item.id === candidate.id);
-            return itemData ? new Item(itemData) : null;
         }
-
         return null;
     }
 }

--- a/rgfn_game/js/systems/game/BattleTurnController.ts
+++ b/rgfn_game/js/systems/game/BattleTurnController.ts
@@ -62,7 +62,7 @@ export default class BattleTurnController {
 
     private executeAiTurn(actor: Skeleton): void {
         setTimeout(() => {
-            if (actor.shouldSkipTurnFromSlow()) {
+            if (actor.shouldSkipTurn()) {
                 const effectMessages = actor.consumeTurnEffects();
                 this.completeAiTurn(effectMessages);
                 return;

--- a/rgfn_game/js/systems/game/WeaponEnchantmentCombat.ts
+++ b/rgfn_game/js/systems/game/WeaponEnchantmentCombat.ts
@@ -1,0 +1,82 @@
+import Skeleton from '../../entities/Skeleton.js';
+import Item from '../../entities/Item.js';
+import { WeaponEnchantment } from '../../entities/ItemDeclarations.js';
+
+type WeaponEnchantmentCombatResult = {
+    damageMultiplier: number;
+    flatDamageBonus: number;
+    logs: string[];
+};
+
+const formatPercent = (value: number): string => `${Math.max(0, Math.min(100, Math.round(value)))}%`;
+
+const rollChance = (chancePercent: number | undefined): boolean => {
+    const safe = Math.max(0, Math.min(100, Math.round(chancePercent ?? 0)));
+    return Math.random() < (safe / 100);
+};
+
+const getAllEnchantments = (weapons: Array<Item | null>): WeaponEnchantment[] =>
+    weapons
+        .filter((weapon): weapon is Item => weapon !== null)
+        .flatMap((weapon) => weapon.enchantments ?? []);
+
+const applyPlasma = (enchantment: WeaponEnchantment, target: Skeleton, state: WeaponEnchantmentCombatResult): void => {
+    const bonus = enchantment.plasmaBonusDamage ?? 0;
+    if (bonus <= 0) {
+        return;
+    }
+    const delayed = Math.max(1, Math.floor(bonus / 2));
+    target.applyDamageOverTime(delayed, 1, 'plasma burn');
+    state.logs.push(`Plasma enchantment triggers: +${bonus} hit damage and ${delayed} delayed damage.`);
+};
+
+const applyWormhole = (enchantment: WeaponEnchantment, state: WeaponEnchantmentCombatResult): void => {
+    if (!rollChance(enchantment.wormholeCritChance)) {
+        return;
+    }
+    state.damageMultiplier *= 2;
+    state.logs.push(`Wormhole enchantment triggers: critical hit (${formatPercent(enchantment.wormholeCritChance)} chance).`);
+};
+
+const applyConfusion = (enchantment: WeaponEnchantment, target: Skeleton, state: WeaponEnchantmentCombatResult): void => {
+    if (!rollChance(enchantment.confusionStunChance)) {
+        return;
+    }
+    target.applyStun(1);
+    state.logs.push(`Confusion enchantment triggers: ${target.name} is stunned for 1 turn (${formatPercent(enchantment.confusionStunChance)} chance).`);
+};
+
+const applyDoubt = (enchantment: WeaponEnchantment, target: Skeleton, state: WeaponEnchantmentCombatResult): void => {
+    const dps = enchantment.doubtDamagePerSecond ?? 0;
+    const duration = enchantment.doubtDurationSeconds ?? 0;
+    if (dps > 0 && duration > 0) {
+        target.applyDamageOverTime(dps, duration, 'doubt');
+        state.logs.push(`Doubt enchantment triggers: ${dps} damage/sec for ${duration}s.`);
+    }
+};
+
+const applySingleEnchantment = (enchantment: WeaponEnchantment, target: Skeleton, state: WeaponEnchantmentCombatResult): void => {
+    if (enchantment.type === 'plasma') {
+        applyPlasma(enchantment, target, state);
+        return;
+    }
+    if (enchantment.type === 'wormhole') {
+        applyWormhole(enchantment, state);
+        return;
+    }
+    if (enchantment.type === 'confusion') {
+        applyConfusion(enchantment, target, state);
+        return;
+    }
+    applyDoubt(enchantment, target, state);
+};
+
+export const resolveWeaponEnchantmentAttack = (target: Skeleton, weapons: Array<Item | null>): WeaponEnchantmentCombatResult => {
+    const logs: string[] = [];
+    let damageMultiplier = 1;
+    let flatDamageBonus = 0;
+    const enchantments = getAllEnchantments(weapons);
+    const state: WeaponEnchantmentCombatResult = { damageMultiplier, flatDamageBonus, logs };
+    enchantments.forEach((enchantment) => applySingleEnchantment(enchantment, target, state));
+    return state;
+};

--- a/rgfn_game/js/systems/hud/HudInventoryItemMetadata.ts
+++ b/rgfn_game/js/systems/hud/HudInventoryItemMetadata.ts
@@ -36,6 +36,9 @@ export default class HudInventoryItemMetadata {
         }
         if (item.type === 'weapon') {
             lines.push(`Damage if requirements met: ${this.calculateWeaponDamageAtRequirements(item)}`);
+            if (item.enchantments.length > 0) {
+                lines.push(`Enchantments: ${item.enchantments.map((enchantment) => enchantment.type).join(', ')}`);
+            }
         }
 
         return lines.join('\n');
@@ -50,7 +53,7 @@ export default class HudInventoryItemMetadata {
             ? calculateBowDamageBonus(effectiveStrength, effectiveAgility)
             : calculateMeleeDamageBonus(effectiveStrength, effectiveAgility);
         const offHandDamage = item.handsRequired === 1 ? balanceConfig.combat.fistDamagePerHand : 0;
-        return item.damageBonus + offHandDamage + statBonus;
+        return item.damageBonus + item.getPlasmaBonusDamage() + offHandDamage + statBonus;
     }
 
     private getRequirementEntries(item: Item): Array<{ label: 'AGI' | 'STR'; required: number; current: number }> {

--- a/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
+++ b/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
@@ -91,6 +91,7 @@ export type VillageOffer = {
     kindName: string;
     buyPrice: number;
     possibleItemIds: string[];
+    isEnchantedWeaponOffer?: boolean;
 };
 
 export type BarterItemCost = {

--- a/rgfn_game/js/systems/village/actions/VillageStockService.ts
+++ b/rgfn_game/js/systems/village/actions/VillageStockService.ts
@@ -1,4 +1,5 @@
 import Item from '../../../entities/Item.js';
+import { balanceConfig } from '../../../config/balance/balanceConfig.js';
 import { NON_POTION_KINDS, POTION_KINDS, VillageOffer } from './VillageActionsTypes.js';
 
 export default class VillageStockService {
@@ -12,6 +13,7 @@ export default class VillageStockService {
             buyPrice: offerKind.buyPrice,
             possibleItemIds: offerKind.itemIds,
         }));
+        this.tryInjectEnchantedWeaponOffer();
     }
 
     public getCurrentOffers = (): VillageOffer[] => this.currentOffers;
@@ -19,6 +21,24 @@ export default class VillageStockService {
     public getOffer = (index: number): VillageOffer | undefined => this.currentOffers[index];
 
     public getSellPrice = (item: Item): number => Math.max(1, Math.ceil(item.goldValue * 0.5));
+
+    private tryInjectEnchantedWeaponOffer(): void {
+        const chance = balanceConfig.items.enchantments.villageSpecialOfferChance;
+        if (Math.random() >= chance || this.currentOffers.length < 2) {
+            return;
+        }
+        const replaceIndex = 1 + Math.floor(Math.random() * (this.currentOffers.length - 1));
+        const replacedOffer = this.currentOffers[replaceIndex];
+        if (!replacedOffer) {
+            return;
+        }
+        this.currentOffers[replaceIndex] = {
+            kindName: 'Enchanted Weapon',
+            buyPrice: Math.max(1, Math.ceil(replacedOffer.buyPrice * 1.8)),
+            possibleItemIds: [],
+            isEnchantedWeaponOffer: true,
+        };
+    }
 
     private pickOne = <T>(array: T[]): T => array[Math.floor(Math.random() * array.length)];
 

--- a/rgfn_game/js/systems/village/actions/VillageTradeInteractionService.ts
+++ b/rgfn_game/js/systems/village/actions/VillageTradeInteractionService.ts
@@ -1,6 +1,7 @@
 import Player from '../../../entities/player/Player.js';
 import { createItemById } from '../../../entities/Item.js';
 import { balanceConfig } from '../../../config/balance/balanceConfig.js';
+import { applyRandomEnchantmentsToGeneratedItem, buildRandomDiscoverableWeapon } from '../../../entities/items/WeaponEnchantments.js';
 import VillageStockService from './VillageStockService.js';
 import { VillageActionsCallbacks } from './VillageActionsTypes.js';
 import { VillageNpcProfile } from '../VillageDialogueEngine.js';
@@ -111,8 +112,9 @@ export default class VillageTradeInteractionService {
             return;
         }
 
-        const itemId = offer.possibleItemIds[Math.floor(Math.random() * offer.possibleItemIds.length)];
-        const item = createItemById(itemId);
+        const item = offer.isEnchantedWeaponOffer
+            ? this.buildVillageEnchantedWeapon(offer.buyPrice)
+            : this.buildRegularOfferItem(offer.possibleItemIds);
         if (!item) {
             this.deps.addLog('The merchant cannot find that item right now.', 'system');
             return;
@@ -155,5 +157,20 @@ export default class VillageTradeInteractionService {
     private isInnkeeper(role: string): boolean {
         const normalized = role.trim().toLocaleLowerCase();
         return normalized.includes('innkeeper') || normalized.includes('tavern') || normalized.includes('host');
+    }
+
+    private buildRegularOfferItem(itemIds: string[]): ReturnType<typeof createItemById> {
+        const itemId = itemIds[Math.floor(Math.random() * itemIds.length)];
+        const item = itemId ? createItemById(itemId) : null;
+        return item ? applyRandomEnchantmentsToGeneratedItem(item) : null;
+    }
+
+    private buildVillageEnchantedWeapon(offerPrice: number): ReturnType<typeof createItemById> {
+        const item = buildRandomDiscoverableWeapon();
+        if (!item) {
+            return null;
+        }
+        item.goldValue = Math.max(item.goldValue, offerPrice);
+        return item;
     }
 }


### PR DESCRIPTION
## Summary
- Added a full weapon enchantment system for `rgfn_game` with configurable balance knobs.
- Implemented four enchantments with randomized rolled values and multi-enchant support:
  - Plasma (`+N` damage, delayed `N/2` damage)
  - Wormhole (`M%` crit chance for 2x damage)
  - Confusion (`P%` chance to stun for 1 turn)
  - Doubt (`Q` damage/sec for `R` seconds)
- Enchantment generation now applies across random weapon sources:
  - random ground item discoveries
  - random monster drops
  - village purchases
- Added village special-offer flow for enchanted weapons with configurable probability.
- Added enchantment-aware pricing so enchanted weapons are more expensive based on rolled effect strength.
- Extended monster status runtime to support stun + generic damage-over-time effect consumption.
- Integrated enchantment combat resolution into both normal and directional player attacks.
- Updated item persistence to serialize/restore concrete item snapshots so random enchantments survive save/load.
- Added implementation notes and tuning guidance in:
  - `rgfn_game/docs/enchantment-system-2026-04-15.md`

## Key Config Added
`balanceConfig.items.enchantments` in:
- `rgfn_game/js/config/balance/itemsEncountersBalance.ts`

Includes:
- chance on random weapons
- extra enchantment roll chance
- max enchantments per weapon
- village special offer chance
- economy multiplier for enchantment score
- per-enchantment value ranges

## Validation
- `npm run build:rgfn`
- `npx eslint` on all touched RGFN files
- `npm run test:rgfn` (157 passing)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff4f4b76883239b28fcdb689e1211)