### PR TITLE
RGFN: add enchantment inspection UX + change Doubt to damage-per-turn

### DIFF
--- a/rgfn_game/docs/enchantment-system-2026-04-15.md
+++ b/rgfn_game/docs/enchantment-system-2026-04-15.md
@@ -14,7 +14,7 @@ Implemented weapon enchantment effects:
 - **plasma**: `+N` direct damage and delayed `N/2` damage next turn,
 - **wormhole**: `M%` chance to crit for `2x` total attack damage,
 - **confusion**: `P%` chance to stun for 1 turn (target skips turn),
-- **doubt**: `+Q` damage per second for `R` seconds.
+- **doubt**: `+Q` damage per turn for `R` turns.
 
 Multiple enchantments can appear on the same weapon.
 
@@ -44,6 +44,13 @@ Added under `balanceConfig.items.enchantments` (`rgfn_game/js/config/balance/ite
   - turn-based stun support,
   - generalized damage-over-time support,
   - consumption of DoT/stun during turn processing.
+
+## UX: inspecting exact enchantment parameters
+- Inventory weapon tooltip now includes full per-enchantment parameter lines (not only enchantment names).
+- **Shift+click** on a weapon in the inventory logs an explicit enchantment breakdown into the game log.
+- **Shift+click** on equipped weapon slots (main hand/off hand) logs the same breakdown for currently held weapons.
+- Equipment hint text in the inventory panel now documents this interaction.
+- Doubt wording is now consistent with turn-based combat in both item descriptions and combat logs (`damage/turn`, `turns`).
 
 ## Persistence
 To preserve randomized enchantments through saves:

--- a/rgfn_game/docs/misc/verification-and-testing.md
+++ b/rgfn_game/docs/misc/verification-and-testing.md
@@ -1294,3 +1294,25 @@ This prints:
 3. Drag the other to offhand.
 4. Confirm offhand slot displays the weapon sprite/name and inventory count remains consistent.
 5. Unequip both and confirm both return to inventory.
+
+## 2026-04-15 — Weapon enchantment inspection UX (inventory + equipped)
+
+### What changed
+- Added explicit enchantment parameter inspection flow for weapons:
+  - Shift+click inventory weapon to print exact enchantment values to the game log.
+  - Shift+click equipped Main Hand/Off Hand weapon slot to print the same details.
+- Expanded tooltip content so enchantments show parameter lines (e.g., Doubt damage per turn + duration turns), not only enchantment type names.
+- Updated all user-facing Doubt text from "damage/sec" to "damage/turn" to match turn-based mechanics.
+
+### Manual verification checklist
+1. Open Inventory panel and ensure at least one enchanted weapon exists in inventory.
+2. Hover the weapon and verify tooltip includes detailed enchantment parameter lines.
+3. Shift+click that weapon in inventory and confirm game log prints the full enchantment breakdown.
+4. Equip the weapon, then Shift+click Main Hand slot and confirm the same breakdown appears.
+5. If weapon has Doubt enchantment, verify all text uses "damage/turn" and "turns".
+
+### Regression notes
+- Regular click behavior remains unchanged:
+  - inventory weapon click equips,
+  - equipped slot click unequips,
+  - right-click inventory still drops item.

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -141,7 +141,7 @@
                                 <button id="weapon-slot-off" class="equipment-slot" title="Off hand">Off Hand: Empty</button>
                                 <button id="armor-slot" class="equipment-slot" title="Armor">Armor: Empty</button>
                             </div>
-                            <div class="equipment-hint">Click inventory gear to equip. Click equipped slots to unequip. Right-click any inventory item to drop it. Use Recover Last Dropped Item to undo your latest drop.</div>
+                            <div class="equipment-hint">Click inventory gear to equip. Shift+click weapon entries (inventory or equipped slots) to inspect exact enchantment values. Click equipped slots to unequip. Right-click any inventory item to drop it. Use Recover Last Dropped Item to undo your latest drop.</div>
                         </div>
                     </div>
                     <div id="magic-panel" class="hud-section stats overlay-panel hidden">

--- a/rgfn_game/js/entities/items/WeaponEnchantments.ts
+++ b/rgfn_game/js/entities/items/WeaponEnchantments.ts
@@ -81,7 +81,22 @@ const buildEnchantmentDescriptionLine = (enchantment: WeaponEnchantment): string
     if (enchantment.type === 'confusion') {
         return `Confusion: ${formatPercent(enchantment.confusionStunChance ?? 0)} chance to stun target for 1 turn.`;
     }
-    return `Doubt: +${enchantment.doubtDamagePerSecond ?? 0} damage/sec for ${enchantment.doubtDurationSeconds ?? 0}s.`;
+    return `Doubt: +${enchantment.doubtDamagePerSecond ?? 0} damage/turn for ${enchantment.doubtDurationSeconds ?? 0} turns.`;
+};
+
+export const buildEnchantmentDetailLine = (enchantment: WeaponEnchantment): string => {
+    if (enchantment.type === 'plasma') {
+        const bonus = enchantment.plasmaBonusDamage ?? 0;
+        const delayed = Math.max(1, Math.floor(bonus / 2));
+        return `Plasma → +${bonus} hit damage, +${delayed} delayed damage on next turn.`;
+    }
+    if (enchantment.type === 'wormhole') {
+        return `Wormhole → ${formatPercent(enchantment.wormholeCritChance ?? 0)} crit chance, 2x damage on proc.`;
+    }
+    if (enchantment.type === 'confusion') {
+        return `Confusion → ${formatPercent(enchantment.confusionStunChance ?? 0)} chance to stun for 1 turn.`;
+    }
+    return `Doubt → ${enchantment.doubtDamagePerSecond ?? 0} damage per turn for ${enchantment.doubtDurationSeconds ?? 0} turns.`;
 };
 
 const buildEnchantedName = (baseName: string, enchantments: WeaponEnchantment[]): string => {

--- a/rgfn_game/js/systems/game/WeaponEnchantmentCombat.ts
+++ b/rgfn_game/js/systems/game/WeaponEnchantmentCombat.ts
@@ -47,11 +47,11 @@ const applyConfusion = (enchantment: WeaponEnchantment, target: Skeleton, state:
 };
 
 const applyDoubt = (enchantment: WeaponEnchantment, target: Skeleton, state: WeaponEnchantmentCombatResult): void => {
-    const dps = enchantment.doubtDamagePerSecond ?? 0;
+    const damagePerTurn = enchantment.doubtDamagePerSecond ?? 0;
     const duration = enchantment.doubtDurationSeconds ?? 0;
-    if (dps > 0 && duration > 0) {
-        target.applyDamageOverTime(dps, duration, 'doubt');
-        state.logs.push(`Doubt enchantment triggers: ${dps} damage/sec for ${duration}s.`);
+    if (damagePerTurn > 0 && duration > 0) {
+        target.applyDamageOverTime(damagePerTurn, duration, 'doubt');
+        state.logs.push(`Doubt enchantment triggers: ${damagePerTurn} damage/turn for ${duration} turns.`);
     }
 };
 

--- a/rgfn_game/js/systems/hud/HudEquipmentController.ts
+++ b/rgfn_game/js/systems/hud/HudEquipmentController.ts
@@ -1,9 +1,9 @@
 import Player from '../../entities/player/Player.js';
 import Item from '../../entities/Item.js';
+import HudInventoryItemMetadata from './HudInventoryItemMetadata.js';
 import { BattleEquipmentActionHandler, HudElements } from './HudTypes.js';
 
 type EquipmentSlot = 'main' | 'offhand' | 'armor';
-
 type InventoryItemProvider = () => { item: Item | null; index: number | null };
 type HudRefreshHandler = () => void;
 type LogHandler = (message: string) => void;
@@ -16,6 +16,7 @@ export default class HudEquipmentController {
     private readonly refreshHud: HudRefreshHandler;
     private readonly addLog: LogHandler;
     private readonly clearDraggedInventoryIndex: () => void;
+    private readonly itemMetadata: HudInventoryItemMetadata;
 
     constructor(
         player: Player,
@@ -33,6 +34,7 @@ export default class HudEquipmentController {
         this.clearDraggedInventoryIndex = clearDraggedInventoryIndex;
         this.refreshHud = refreshHud;
         this.addLog = addLog;
+        this.itemMetadata = new HudInventoryItemMetadata(this.player, this.addLog);
     }
 
     public bindEquipmentSlotEvents(): void {
@@ -45,116 +47,97 @@ export default class HudEquipmentController {
         const mainWeapon = this.player.equippedMainWeapon;
         const offhandWeapon = this.player.equippedOffhandWeapon;
         const armor = this.player.equippedArmor;
-
         this.hudElements.weaponSlotMain.classList.remove('equipment-slot-main-equipped', 'equipment-slot-off-equipped');
         this.hudElements.weaponSlotOff.classList.remove('equipment-slot-main-equipped', 'equipment-slot-off-equipped');
-
-        if (!mainWeapon && !offhandWeapon) {
-            this.renderEquipmentSlotContent(this.hudElements.weaponSlotMain, 'Main Hand', 'Fist');
-            this.renderEquipmentSlotContent(this.hudElements.weaponSlotOff, 'Off Hand', 'Fist');
-        } else if (mainWeapon?.handsRequired === 2) {
-            this.renderEquipmentSlotContent(this.hudElements.weaponSlotMain, 'Main Hand', mainWeapon.name, mainWeapon.spriteClass);
-            this.renderEquipmentSlotContent(this.hudElements.weaponSlotOff, 'Off Hand', mainWeapon.name, mainWeapon.spriteClass);
-            this.hudElements.weaponSlotMain.classList.add('equipment-slot-main-equipped');
-            this.hudElements.weaponSlotOff.classList.add('equipment-slot-main-equipped');
-        } else {
-            this.renderEquipmentSlotContent(this.hudElements.weaponSlotMain, 'Main Hand', mainWeapon ? mainWeapon.name : 'Fist', mainWeapon?.spriteClass);
-            this.renderEquipmentSlotContent(this.hudElements.weaponSlotOff, 'Off Hand', offhandWeapon ? offhandWeapon.name : 'Fist', offhandWeapon?.spriteClass);
-            if (mainWeapon) {
-                this.hudElements.weaponSlotMain.classList.add('equipment-slot-main-equipped');
-            }
-            if (offhandWeapon) {
-                this.hudElements.weaponSlotOff.classList.add('equipment-slot-off-equipped');
-            }
-        }
-
+        this.renderWeaponSlots(mainWeapon, offhandWeapon);
         this.renderEquipmentSlotContent(this.hudElements.armorSlot, 'Armor', armor ? armor.name : 'Empty', armor?.spriteClass);
+        this.applyEquipmentTooltips(mainWeapon, offhandWeapon, armor);
     }
 
     public handleEquipFromInventory(item: Item): void {
-        if (!this.player.canEquipItem(item)) {
-            return;
-        }
-
-        if (!this.requestBattleEquipmentAction(`You begin equipping ${item.name}.`)) {
-            return;
-        }
-
-        if (item.type === 'weapon') {
-            this.player.equippedWeapon = item;
-        } else if (item.type === 'armor') {
-            this.player.equippedArmor = item;
-        }
-
+        if (!this.player.canEquipItem(item) || !this.requestBattleEquipmentAction(`You begin equipping ${item.name}.`)) { return; }
+        if (item.type === 'weapon') { this.player.equippedWeapon = item; }
+        if (item.type === 'armor') { this.player.equippedArmor = item; }
         this.refreshHud();
     }
 
     private bindWeaponSlot(slot: 'main' | 'offhand', element: HTMLButtonElement): void {
-        element.addEventListener('click', () => this.handleWeaponSlotClick(slot));
+        element.addEventListener('click', (event) => this.handleWeaponSlotClick(slot, event));
         element.addEventListener('dragover', (event) => event.preventDefault());
-        element.addEventListener('drop', (event) => {
-            event.preventDefault();
-            this.handleDropOnEquipmentSlot(slot);
-        });
+        element.addEventListener('drop', (event) => { event.preventDefault(); this.handleDropOnEquipmentSlot(slot); });
     }
 
     private bindArmorSlot(): void {
         this.hudElements.armorSlot.addEventListener('click', () => {
-            if (!this.player.equippedArmor || !this.requestBattleEquipmentAction(`You start removing ${this.player.equippedArmor.name}.`)) {
-                return;
-            }
+            if (!this.player.equippedArmor || !this.requestBattleEquipmentAction(`You start removing ${this.player.equippedArmor.name}.`)) { return; }
             this.player.unequipArmor();
             this.refreshHud();
         });
         this.hudElements.armorSlot.addEventListener('dragover', (event) => event.preventDefault());
-        this.hudElements.armorSlot.addEventListener('drop', (event) => {
-            event.preventDefault();
-            this.handleDropOnEquipmentSlot('armor');
-        });
+        this.hudElements.armorSlot.addEventListener('drop', (event) => { event.preventDefault(); this.handleDropOnEquipmentSlot('armor'); });
     }
 
-    private handleWeaponSlotClick(slot: 'main' | 'offhand'): void {
+    private handleWeaponSlotClick(slot: 'main' | 'offhand', event: MouseEvent): void {
         const equipped = slot === 'main' ? this.player.equippedWeapon : this.player.equippedOffhandWeapon;
-        if (!equipped || !this.requestBattleEquipmentAction(`You start unequipping ${equipped.name}.`)) {
+        if (event.shiftKey && equipped?.type === 'weapon') {
+            this.itemMetadata.inspectWeaponEnchantments(equipped).forEach((line) => this.addLog(line));
             return;
         }
+        if (!equipped || !this.requestBattleEquipmentAction(`You start unequipping ${equipped.name}.`)) { return; }
         slot === 'main' ? this.player.unequipWeapon() : this.player.unequipOffhandWeapon();
         this.refreshHud();
     }
 
     private handleDropOnEquipmentSlot(slot: EquipmentSlot): void {
         const { item } = this.getDraggedInventoryItem();
-        if (!item) {
-            this.clearDraggedInventoryIndex();
-            return;
-        }
-
-        if (!this.player.canEquipItem(item)) {
-            this.addLog(`Cannot equip ${item.name}. Requirements are not met.`);
-            this.clearDraggedInventoryIndex();
-            return;
-        }
-
-        if (!this.requestBattleEquipmentAction(`You begin equipping ${item.name}.`)) {
-            this.clearDraggedInventoryIndex();
-            return;
-        }
-
-        if (slot === 'armor' && item.type === 'armor') {
-            this.player.equippedArmor = item;
-        } else if (slot !== 'armor' && item.type === 'weapon') {
-            this.player.equipWeaponToSlot(item, slot);
-        }
-
+        if (!this.canEquipDraggedItem(item) || !this.beginEquipDraggedItem(item)) { return; }
+        if (slot === 'armor' && item.type === 'armor') { this.player.equippedArmor = item; }
+        if (slot !== 'armor' && item.type === 'weapon') { this.player.equipWeaponToSlot(item, slot); }
         this.clearDraggedInventoryIndex();
         this.refreshHud();
     }
 
-    private requestBattleEquipmentAction(actionDescription: string): boolean {
-        if (!this.onBattleEquipmentAction) {
-            return true;
-        }
+    private beginEquipDraggedItem(item: Item): boolean {
+        if (this.requestBattleEquipmentAction(`You begin equipping ${item.name}.`)) { return true; }
+        this.clearDraggedInventoryIndex();
+        return false;
+    }
 
+    private renderWeaponSlots(mainWeapon: Item | null, offhandWeapon: Item | null): void {
+        if (!mainWeapon && !offhandWeapon) { this.renderEmptyWeaponSlots(); return; }
+        if (mainWeapon?.handsRequired === 2) { this.renderTwoHandedWeaponSlots(mainWeapon); return; }
+        this.renderDualWeaponSlots(mainWeapon, offhandWeapon);
+    }
+
+    private renderEmptyWeaponSlots(): void {
+        this.renderEquipmentSlotContent(this.hudElements.weaponSlotMain, 'Main Hand', 'Fist');
+        this.renderEquipmentSlotContent(this.hudElements.weaponSlotOff, 'Off Hand', 'Fist');
+    }
+
+    private renderTwoHandedWeaponSlots(mainWeapon: Item): void {
+        this.renderEquipmentSlotContent(this.hudElements.weaponSlotMain, 'Main Hand', mainWeapon.name, mainWeapon.spriteClass);
+        this.renderEquipmentSlotContent(this.hudElements.weaponSlotOff, 'Off Hand', mainWeapon.name, mainWeapon.spriteClass);
+        this.hudElements.weaponSlotMain.classList.add('equipment-slot-main-equipped');
+        this.hudElements.weaponSlotOff.classList.add('equipment-slot-main-equipped');
+    }
+
+    private renderDualWeaponSlots(mainWeapon: Item | null, offhandWeapon: Item | null): void {
+        this.renderEquipmentSlotContent(this.hudElements.weaponSlotMain, 'Main Hand', mainWeapon ? mainWeapon.name : 'Fist', mainWeapon?.spriteClass);
+        this.renderEquipmentSlotContent(this.hudElements.weaponSlotOff, 'Off Hand', offhandWeapon ? offhandWeapon.name : 'Fist', offhandWeapon?.spriteClass);
+        if (mainWeapon) { this.hudElements.weaponSlotMain.classList.add('equipment-slot-main-equipped'); }
+        if (offhandWeapon) { this.hudElements.weaponSlotOff.classList.add('equipment-slot-off-equipped'); }
+    }
+
+    private canEquipDraggedItem(item: Item | null): item is Item {
+        if (!item) { this.clearDraggedInventoryIndex(); return false; }
+        if (this.player.canEquipItem(item)) { return true; }
+        this.addLog(`Cannot equip ${item.name}. Requirements are not met.`);
+        this.clearDraggedInventoryIndex();
+        return false;
+    }
+
+    private requestBattleEquipmentAction(actionDescription: string): boolean {
+        if (!this.onBattleEquipmentAction) { return true; }
         return this.onBattleEquipmentAction(actionDescription);
     }
 
@@ -169,5 +152,18 @@ export default class HudEquipmentController {
         text.className = 'equipment-slot-label';
         text.textContent = `${label}: ${value}`;
         slot.appendChild(text);
+        slot.title = `${label}: ${value}`;
+    }
+
+    private applyEquipmentTooltips(mainWeapon: Item | null, offhandWeapon: Item | null, armor: Item | null): void {
+        this.hudElements.weaponSlotMain.title = this.buildEquipmentTooltip('Main Hand', mainWeapon);
+        this.hudElements.weaponSlotOff.title = this.buildEquipmentTooltip('Off Hand', offhandWeapon);
+        this.hudElements.armorSlot.title = this.buildEquipmentTooltip('Armor', armor);
+    }
+
+    private buildEquipmentTooltip(label: string, item: Item | null): string {
+        if (!item) { return `${label}: Empty`; }
+        if (item.type !== 'weapon') { return `${label}: ${item.name}`; }
+        return [`${label}: ${item.name} — click to unequip • shift+click to inspect enchantments`, ...this.itemMetadata.inspectWeaponEnchantments(item)].join('\n');
     }
 }

--- a/rgfn_game/js/systems/hud/HudInventoryController.ts
+++ b/rgfn_game/js/systems/hud/HudInventoryController.ts
@@ -128,7 +128,11 @@ export default class HudInventoryController {
 
     private bindEquipClickIfApplicable(slot: HTMLButtonElement, item: Item): void {
         if (item.type === 'weapon' || item.type === 'armor') {
-            slot.addEventListener('click', () => {
+            slot.addEventListener('click', (event) => {
+                if (item.type === 'weapon' && event.shiftKey) {
+                    this.itemMetadata.inspectWeaponEnchantments(item).forEach((line) => this.addLog(line));
+                    return;
+                }
                 if (this.tryEquipItem(item, slot)) {
                     this.onEquip(item, slot);
                 }

--- a/rgfn_game/js/systems/hud/HudInventoryItemMetadata.ts
+++ b/rgfn_game/js/systems/hud/HudInventoryItemMetadata.ts
@@ -2,6 +2,7 @@ import { balanceConfig } from '../../config/balance/balanceConfig.js';
 import { calculateBowDamageBonus, calculateMeleeDamageBonus } from '../../config/levelConfig.js';
 import Item from '../../entities/Item.js';
 import Player from '../../entities/player/Player.js';
+import { buildEnchantmentDetailLine } from '../../entities/items/WeaponEnchantments.js';
 
 type LogHandler = (message: string) => void;
 
@@ -27,7 +28,7 @@ export default class HudInventoryItemMetadata {
     public buildInventoryTooltip(item: Item): string {
         const lines = [`${item.name} — right-click to drop`];
         if (item.type === 'weapon' || item.type === 'armor') {
-            lines[0] = `${item.name} — click to equip • right-click to drop`;
+            lines[0] = `${item.name} — click to equip • shift+click to inspect • right-click to drop`;
         }
 
         const requirements = this.getRequirementEntries(item);
@@ -36,12 +37,28 @@ export default class HudInventoryItemMetadata {
         }
         if (item.type === 'weapon') {
             lines.push(`Damage if requirements met: ${this.calculateWeaponDamageAtRequirements(item)}`);
-            if (item.enchantments.length > 0) {
-                lines.push(`Enchantments: ${item.enchantments.map((enchantment) => enchantment.type).join(', ')}`);
-            }
+            this.appendWeaponEnchantmentDetails(lines, item);
         }
 
         return lines.join('\n');
+    }
+
+    public inspectWeaponEnchantments(item: Item): string[] {
+        if (item.type !== 'weapon') {
+            return [`${item.name} has no weapon enchantments.`];
+        }
+        if (item.enchantments.length === 0) {
+            return [`${item.name} has no enchantments.`];
+        }
+        return [`${item.name} enchantments:`, ...item.enchantments.map((enchantment) => buildEnchantmentDetailLine(enchantment))];
+    }
+
+    private appendWeaponEnchantmentDetails(lines: string[], item: Item): void {
+        if (item.enchantments.length === 0) {
+            return;
+        }
+        lines.push(`Enchantments: ${item.enchantments.map((enchantment) => enchantment.type).join(', ')}`);
+        lines.push(...item.enchantments.map((enchantment) => buildEnchantmentDetailLine(enchantment)));
     }
 
     private calculateWeaponDamageAtRequirements(item: Item): number {

--- a/rgfn_game/test/systems/scenarios/hudInventoryController.test.js
+++ b/rgfn_game/test/systems/scenarios/hudInventoryController.test.js
@@ -119,3 +119,52 @@ test('HudInventoryController fails fast when drag index exists without dragged i
     global.document = originalDocument;
   }
 });
+
+test('HudInventoryController shift+click on weapon logs enchantment parameters instead of equipping', () => {
+  const originalDocument = global.document;
+  global.document = { createElement: () => createElement() };
+
+  try {
+    const player = new Player(0, 0);
+    const enchantedKnife = new Item({
+      id: 'knife',
+      name: 'Doubt Knife +2',
+      description: 'Enchanted blade',
+      type: 'weapon',
+      handsRequired: 1,
+      damageBonus: 2,
+      requirements: { agility: 0, strength: 0 },
+      enchantments: [{ type: 'doubt', doubtDamagePerSecond: 3, doubtDurationSeconds: 2 }],
+    });
+    player.addItemToInventory(enchantedKnife);
+
+    const hudElements = {
+      inventoryCount: createElement(),
+      inventoryCapacity: createElement(),
+      inventoryCapacityHint: createElement(),
+      undoLastDropBtn: createElement(),
+      inventoryGrid: createElement(),
+    };
+    const logs = [];
+    let equipCount = 0;
+
+    const controller = new HudInventoryController(
+      player,
+      hudElements,
+      () => { equipCount += 1; },
+      () => {},
+      (message) => logs.push(message),
+      () => null,
+      () => {},
+    );
+
+    controller.renderInventoryAndMeta();
+    const slot = hudElements.inventoryGrid.children[0];
+    slot.dispatch('click', { shiftKey: true });
+
+    assert.equal(equipCount, 0);
+    assert.equal(logs.some((line) => line.includes('Doubt') && line.includes('damage per turn') && line.includes('2 turns')), true);
+  } finally {
+    global.document = originalDocument;
+  }
+});


### PR DESCRIPTION
### Motivation
- Make weapon enchantments discoverable so players can quickly inspect exact parameter values (e.g., Doubt amount and duration) without guessing from names. 
- Provide a quick, two-click-friendly inspection flow for both inventory entries and equipped weapon slots. 
- Align wording and logs with the turn-based design by replacing per-second phrasing with per-turn phrasing for the `doubt` enchantment.

### Description
- Added `buildEnchantmentDetailLine` and updated `buildEnchantmentDescriptionLine` in `rgfn_game/js/entities/items/WeaponEnchantments.ts` and changed Doubt description text to `damage/turn` and `turns`. 
- Updated combat handling in `rgfn_game/js/systems/game/WeaponEnchantmentCombat.ts` to use `damagePerTurn` and to log `damage/turn` and `turns` for Doubt procs. 
- Extended HUD metadata with `inspectWeaponEnchantments` and `appendWeaponEnchantmentDetails` in `rgfn_game/js/systems/hud/HudInventoryItemMetadata.ts` so tooltips include full per-enchantment parameter lines. 
- Implemented `Shift+click` inspection: inventory slot `Shift+click` now logs enchantment parameters in `rgfn_game/js/systems/hud/HudInventoryController.ts`, and equipped Main/Offhand `Shift+click` logs them in `rgfn_game/js/systems/hud/HudEquipmentController.ts`, without changing normal click behavior. 
- Added UI hint text to `rgfn_game/index.html` and documented the UX and verification steps in `rgfn_game/docs/*` files. 
- Added a regression test `rgfn_game/test/systems/scenarios/hudInventoryController.test.js` verifying `Shift+click` logs enchantment details and does not equip the item. 

### Testing
- Ran targeted ESLint on modified files with `npx eslint <touched files>` and fixed linter issues in the touched modules, producing no errors (only unrelated repo warnings remain). 
- Ran the RGFN test suite with `npm run test:rgfn` and all tests passed (`158` tests, `0` failures). 
- Noted that `npm run lint:ts:rgfn` still reports pre-existing repository-wide warnings/errors outside the changed files, so validation focused on the touched files and full RGFN tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dffab1be788323b0e5032ee4ca4cf2)