### PR TITLE
RGFN: add explicit village side-quest accept/turn-in UX

### DIFF
--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -56,6 +56,38 @@
 - If explicit UI acceptance is needed later, wire a dedicated village action button and call the same callbacks.
 - Reward handling currently returns reward text; economic/item granting is expected to be layered by caller.
 
+## 2026-04-15: Player-facing side-quest UX in village dialogue
+
+- The village dialogue modal now includes a **Side quests** panel (`#village-side-quest-panel`) with a per-NPC list (`#village-side-quest-list`).
+- The panel renders quest cards with:
+  - quest title + status label,
+  - description,
+  - **reward preview text** (`Reward preview: ...`).
+- Action controls are now explicit:
+  - **Accept quest** button appears for each offer.
+  - **Turn in quest** button appears only when quest status is `readyToTurnIn`.
+- Auto-accept-on-select was removed from default player flow.
+  - Optional developer-only behavior now exists when developer mode is enabled.
+- Side-quest callback surface expanded:
+  - `getVillageNpcActiveSideQuests(villageName, npcName)` returns active/ready quests tied to quest giver.
+- Logging updates now make progression explicit:
+  - side-quest board updated snapshots per selected NPC,
+  - accepted quest logs,
+  - quest tracker updated logs,
+  - ready-to-turn-in logs (once per quest id),
+  - turn-in completion logs with reward text.
+
+### Verification checklist used for this change
+
+1. Enter village.
+2. Select NPC.
+3. Confirm side-quest cards are visible with reward previews.
+4. Click **Accept quest**.
+5. Confirm acceptance + tracker update logs.
+6. Return with a `readyToTurnIn` quest.
+7. Click **Turn in quest**.
+8. Confirm single completion + reward log, and that repeated turn-in does not grant duplicate completion.
+
 ## 2026-04-15: Side quest generation expansion
 
 - `QuestObjectiveType` now includes side-focused objective leaves:

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -318,6 +318,10 @@
                 </div>
                 <p id="village-dialogue-selected-npc" class="village-dialogue-selected-npc">Select an NPC in the village rumors panel first.</p>
                 <div id="village-dialogue-log" class="village-dialogue-log"></div>
+                <div id="village-side-quest-panel" class="village-side-quest-panel">
+                    <h3>Side quests</h3>
+                    <div id="village-side-quest-list" class="village-side-quest-list"></div>
+                </div>
                 <div class="village-dialogue-actions">
                     <select id="village-ask-settlement-input" class="village-ask-input"></select>
                     <button id="village-ask-settlement-btn" class="action-btn">Ask about location</button>

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -171,6 +171,8 @@ export class GameFacade implements GameFacadeStateAccess {
     public markSideQuestReadyToTurnIn = (questId: string): boolean => this.questRuntime.markSideQuestReadyToTurnIn(questId);
     public getVillageSideQuestOffers = (villageName: string, npcName: string): QuestNode[] =>
         this.questRuntime.getVillageSideQuestOffers(villageName, npcName);
+    public getVillageNpcActiveSideQuests = (villageName: string, npcName: string): QuestNode[] =>
+        this.questRuntime.getVillageNpcActiveSideQuests(villageName, npcName);
     public acceptSideQuest = (questId: string): { accepted: boolean; reason?: 'inactive' | 'not-found' | 'already-active' } =>
         this.questRuntime.acceptSideQuest(questId);
     public turnInSideQuest = (

--- a/rgfn_game/js/game/GameFactoryHelpers.ts
+++ b/rgfn_game/js/game/GameFactoryHelpers.ts
@@ -67,6 +67,7 @@ const createVillageActionsController = (
     onStartBattle: (enemies) => game.stateMachine.transition(MODES.BATTLE, { enemies, terrainType: 'grass' }),
     onTryStartDefend: (npcName, villageName, villagerNames) => game.onTryStartDefendObjective(npcName, villageName, villagerNames),
     getVillageSideQuestOffers: (villageName, npcName) => game.getVillageSideQuestOffers(villageName, npcName),
+    getVillageNpcActiveSideQuests: (villageName, npcName) => game.getVillageNpcActiveSideQuests(villageName, npcName),
     acceptSideQuest: (questId) => game.acceptSideQuest(questId),
     turnInSideQuest: (questId, npcName, villageName) => game.turnInSideQuest(questId, npcName, villageName),
 });

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -100,6 +100,16 @@ export default class GameQuestRuntime {
         return offers.map((quest) => ({ ...quest }));
     }
 
+    public getVillageNpcActiveSideQuests(villageName: string, npcName: string): QuestNode[] {
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        const normalizedNpc = npcName.trim().toLocaleLowerCase();
+        return this.activeSideQuests
+            .filter((quest) => quest.status !== 'completed')
+            .filter((quest) => quest.giverVillageName?.trim().toLocaleLowerCase() === normalizedVillage)
+            .filter((quest) => quest.giverNpcName?.trim().toLocaleLowerCase() === normalizedNpc)
+            .map((quest) => ({ ...quest }));
+    }
+
     public acceptSideQuest(questId: string): { accepted: boolean; reason?: 'inactive' | 'not-found' | 'already-active' } {
         const normalizedQuestId = questId.trim();
         if (!normalizedQuestId) {

--- a/rgfn_game/js/systems/game/ui/GameUiFactory.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiFactory.ts
@@ -81,6 +81,8 @@ export default class GameUiFactory {
         dialogueCloseBtn: document.getElementById('village-dialogue-close-btn')! as HTMLButtonElement,
         dialogueSelectedNpc: document.getElementById('village-dialogue-selected-npc')!,
         dialogueLog: document.getElementById('village-dialogue-log')!,
+        sideQuestPanel: document.getElementById('village-side-quest-panel')!,
+        sideQuestList: document.getElementById('village-side-quest-list')!,
         enterBtn: document.getElementById('village-enter-btn')! as HTMLButtonElement,
         skipBtn: document.getElementById('village-skip-btn')! as HTMLButtonElement,
         doctorHealBtn: document.getElementById('village-doctor-heal-btn')! as HTMLButtonElement,

--- a/rgfn_game/js/systems/game/ui/GameUiSceneModels.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiSceneModels.ts
@@ -53,6 +53,8 @@ export class VillageUiModel {
     public dialogueCloseBtn!: HTMLButtonElement;
     public dialogueSelectedNpc!: HTMLElement;
     public dialogueLog!: HTMLElement;
+    public sideQuestPanel!: HTMLElement;
+    public sideQuestList!: HTMLElement;
     public enterBtn!: HTMLButtonElement;
     public skipBtn!: HTMLButtonElement;
     public doctorHealBtn!: HTMLButtonElement;

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -26,6 +26,7 @@ export default class VillageActionsController {
     private escortContracts: QuestEscortContract[] = [];
     private defendContracts: QuestDefendContract[] = [];
     private activeNpcSideQuestIds: Set<string> = new Set();
+    private readySideQuestLogIds: Set<string> = new Set();
     private knownNpcNames: Set<string> = new Set();
     private joinedEscortNpcKeys: Set<string> = new Set();
 
@@ -108,8 +109,35 @@ export default class VillageActionsController {
         this.addLog(`You approach ${npc.name} the ${npc.role}.`, 'player');
         this.addLog(`${npc.name} looks ${npc.look} and speaks in a ${npc.speechStyle} manner.`, 'system-message');
         this.addRecoverLeadFromNpc(npc);
-        this.handleSelectedNpcSideQuests(npc);
+        this.refreshSelectedNpcSideQuestUi(npc);
         this.callbacks.onAdvanceTime(8, 0.12);
+    }
+
+    public handleAcceptSideQuest(questId: string): void {
+        const selectedNpc = this.getSelectedNpc();
+        if (!selectedNpc) {
+            this.addLog('Choose an NPC before accepting a side quest.', 'system');
+            return;
+        }
+        const result = this.callbacks.acceptSideQuest?.(questId) ?? { accepted: false, reason: 'inactive' as const };
+        if (!result.accepted && this.logSideQuestAcceptFailure(questId, result.reason)) {
+            return;
+        }
+        this.completeSideQuestAccept(selectedNpc, questId);
+    }
+
+    public handleTurnInSideQuest(questId: string): void {
+        const selectedNpc = this.getSelectedNpc();
+        if (!selectedNpc) {
+            this.addLog('Choose an NPC before turning in a side quest.', 'system');
+            return;
+        }
+        const result = this.callbacks.turnInSideQuest?.(questId, selectedNpc.name, this.currentVillageName)
+            ?? { turnedIn: false, reason: 'inactive' as const };
+        if (!result.turnedIn && this.logSideQuestTurnInFailure(questId, selectedNpc.name, result.reason)) {
+            return;
+        }
+        this.completeSideQuestTurnIn(selectedNpc, questId, result.reward);
     }
 
     public handleAskAboutSettlement(): void { this.dialogueInteraction.handleAskAboutSettlement(); this.callbacks.onAdvanceTime(14, 0.1); }
@@ -173,6 +201,7 @@ export default class VillageActionsController {
         this.villageUI.rumorsPanel.classList.remove('hidden');
         this.closeDialogueWindow();
         this.villageUI.dialogueLog.innerHTML = '';
+        this.villageUI.sideQuestList.innerHTML = '<p>Select an NPC to view side quests.</p>';
         this.addLog(`You arrive at ${villageName}.`, 'system');
     }
 
@@ -421,57 +450,144 @@ export default class VillageActionsController {
     }
 
     // eslint-disable-next-line style-guide/function-length-warning
-    private handleSelectedNpcSideQuests(npc: VillageNpcProfile): void {
+    private refreshSelectedNpcSideQuestUi(npc: VillageNpcProfile): void {
         const offers = this.callbacks.getVillageSideQuestOffers?.(this.currentVillageName, npc.name) ?? [];
-        if (offers.length === 0) {
-            if (this.tryTurnInNpcSideQuest(npc)) {
-                this.updateButtons();
-            }
-            return;
-        }
+        const activeQuests = this.callbacks.getVillageNpcActiveSideQuests?.(this.currentVillageName, npc.name) ?? [];
+        const readyToTurnInCount = activeQuests.filter((quest) => quest.status === 'readyToTurnIn').length;
+        this.renderSideQuestUiForNpc(npc, offers, activeQuests);
         this.addLog(
-            `${npc.name} can offer ${offers.length} side quest${offers.length === 1 ? '' : 's'}.`,
+            `Side-quest board updated for ${npc.name}: ${offers.length} offer${offers.length === 1 ? '' : 's'}, `
+            + `${activeQuests.length} active, ${readyToTurnInCount} ready to turn in.`,
             'system-message',
         );
-        offers.forEach((offer) => this.addLog(this.formatSideQuestOfferLine(offer), 'system-message'));
-        const acceptedOffers = offers
-            .map((offer) => ({ offer, result: this.callbacks.acceptSideQuest?.(offer.id) ?? { accepted: false, reason: 'inactive' as const } }))
-            .filter(({ result }) => result.accepted)
-            .map(({ offer }) => offer);
-        acceptedOffers.forEach((quest) => {
+        activeQuests.forEach((quest) => {
             this.activeNpcSideQuestIds.add(quest.id);
             this.injectSideQuestNpcReferencesIntoNearbyRosters(quest);
-            this.addLog(`New side quest accepted: ${quest.title}.`, 'system');
-        });
-        if (acceptedOffers.length > 0) {
-            this.updateButtons();
-        }
-    }
-
-    private formatSideQuestOfferLine(quest: QuestNode): string {
-        const rewardSegment = quest.reward?.trim() ? ` Reward: ${quest.reward}.` : '';
-        return `Offer — ${quest.title}: ${quest.description}.${rewardSegment}`;
-    }
-
-    private tryTurnInNpcSideQuest(npc: VillageNpcProfile): boolean {
-        if (!this.callbacks.turnInSideQuest || this.activeNpcSideQuestIds.size === 0) {
-            return false;
-        }
-        let turnedInAny = false;
-        Array.from(this.activeNpcSideQuestIds).forEach((questId) => {
-            const result = this.callbacks.turnInSideQuest?.(questId, npc.name, this.currentVillageName);
-            if (!result?.turnedIn) {
+            if (quest.status !== 'readyToTurnIn' || this.readySideQuestLogIds.has(quest.id)) {
                 return;
             }
-            turnedInAny = true;
-            this.activeNpcSideQuestIds.delete(questId);
-            this.addLog(
-                `${npc.name} accepts your side-quest handoff for ${questId}.${result.reward ? ` Reward received: ${result.reward}.` : ''}`,
-                'system',
-            );
+            this.readySideQuestLogIds.add(quest.id);
+            this.addLog(`Side quest ready to turn in: ${quest.title}.`, 'system');
         });
-        return turnedInAny;
+        if (!this.shouldAutoAcceptVillageSideQuests() || offers.length === 0) {
+            this.updateButtons();
+            return;
+        }
+        offers.forEach((offer) => this.handleAcceptSideQuest(offer.id));
+        if (offers.length > 0) {
+            this.addLog('[DEV] Auto-accepted side quests for selected NPC.', 'system-message');
+        }
     }
+
+    private renderSideQuestUiForNpc(npc: VillageNpcProfile, offers: QuestNode[], activeQuests: QuestNode[]): void {
+        this.villageUI.sideQuestList.innerHTML = '';
+        const entries = [...offers, ...activeQuests];
+        if (entries.length === 0) {
+            const empty = document.createElement('p');
+            empty.textContent = `No side quests from ${npc.name} right now.`;
+            this.villageUI.sideQuestList.appendChild(empty);
+            return;
+        }
+        entries.forEach((quest) => this.villageUI.sideQuestList.appendChild(this.createSideQuestCard(quest, offers.some((offer) => offer.id === quest.id))));
+    }
+
+    private createSideQuestCard(quest: QuestNode, isOffer: boolean): HTMLElement {
+        const card = document.createElement('div');
+        card.className = 'village-side-quest-card';
+        this.appendSideQuestCardText(card, quest, isOffer);
+        this.appendSideQuestCardAction(card, quest, isOffer);
+        return card;
+    }
+
+    private appendSideQuestCardText(card: HTMLElement, quest: QuestNode, isOffer: boolean): void {
+        const statusText = isOffer ? 'Offer available' : this.getSideQuestStatusText(quest.status);
+        [ `${quest.title} — ${statusText}`, quest.description, `Reward preview: ${quest.reward?.trim() ? quest.reward : 'Unknown reward'}` ]
+            .forEach((line) => {
+                const element = document.createElement('p');
+                element.textContent = line;
+                card.appendChild(element);
+            });
+    }
+
+    private appendSideQuestCardAction(card: HTMLElement, quest: QuestNode, isOffer: boolean): void {
+        if (isOffer) {
+            card.appendChild(this.createSideQuestActionButton('Accept quest', () => this.handleAcceptSideQuest(quest.id)));
+            return;
+        }
+        if (quest.status === 'readyToTurnIn') {
+            card.appendChild(this.createSideQuestActionButton('Turn in quest', () => this.handleTurnInSideQuest(quest.id)));
+        }
+    }
+
+    private createSideQuestActionButton(label: string, onClick: () => void): HTMLButtonElement {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'action-btn';
+        button.textContent = label;
+        button.addEventListener('click', onClick);
+        return button;
+    }
+
+    private completeSideQuestAccept(selectedNpc: VillageNpcProfile, questId: string): void {
+        this.activeNpcSideQuestIds.add(questId);
+        const quests = this.callbacks.getVillageNpcActiveSideQuests?.(this.currentVillageName, selectedNpc.name) ?? [];
+        const acceptedQuest = quests.find((quest) => quest.id === questId);
+        if (acceptedQuest) {
+            this.injectSideQuestNpcReferencesIntoNearbyRosters(acceptedQuest);
+            this.addLog(`Side quest accepted: ${acceptedQuest.title}.`, 'system');
+        } else {
+            this.addLog(`Side quest accepted: ${questId}.`, 'system');
+        }
+        this.addLog('Quest tracker updated with accepted side quest.', 'system-message');
+        this.refreshSelectedNpcSideQuestUi(selectedNpc);
+    }
+
+    private completeSideQuestTurnIn(selectedNpc: VillageNpcProfile, questId: string, reward?: string): void {
+        this.activeNpcSideQuestIds.delete(questId);
+        this.readySideQuestLogIds.delete(questId);
+        this.addLog(`${selectedNpc.name} accepts your side-quest turn-in for ${questId}.${reward ? ` Reward received: ${reward}.` : ''}`, 'system');
+        this.addLog('Quest tracker updated: side quest turned in.', 'system-message');
+        this.refreshSelectedNpcSideQuestUi(selectedNpc);
+    }
+
+    private logSideQuestAcceptFailure(questId: string, reason?: 'inactive' | 'not-found' | 'already-active'): boolean {
+        if (reason === 'already-active') {
+            this.addLog(`Side quest is already active: ${questId}.`, 'system-message');
+        } else if (reason === 'inactive') {
+            this.addLog('Side quest runtime is unavailable right now.', 'system-message');
+        } else {
+            this.addLog(`Side quest offer was not found: ${questId}.`, 'system-message');
+        }
+        return true;
+    }
+
+    private logSideQuestTurnInFailure(questId: string, npcName: string, reason?: 'inactive' | 'not-found' | 'wrong-giver' | 'not-ready' | 'already-completed'): boolean {
+        if (reason === 'not-ready') {
+            this.addLog(`Side quest is not ready to turn in yet: ${questId}.`, 'system-message');
+        } else if (reason === 'wrong-giver') {
+            this.addLog(`${npcName} cannot accept this side quest handoff.`, 'system-message');
+        } else if (reason === 'already-completed') {
+            this.addLog(`Side quest already completed: ${questId}.`, 'system-message');
+        } else {
+            this.addLog(`Unable to turn in side quest: ${questId}.`, 'system-message');
+        }
+        return true;
+    }
+
+    private getSideQuestStatusText(status: QuestNode['status']): string {
+        if (status === 'readyToTurnIn') {
+            return 'Ready to turn in';
+        }
+        if (status === 'completed') {
+            return 'Completed';
+        }
+        if (status === 'active') {
+            return 'In progress';
+        }
+        return 'Available';
+    }
+
+    private shouldAutoAcceptVillageSideQuests = (): boolean => isDeveloperModeEnabled();
 
     private getKnownSettlementNames(): string[] {
         const knownFromMap = this.callbacks.getKnownSettlementNames?.() ?? [];

--- a/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
+++ b/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
@@ -16,6 +16,8 @@ export type VillageUI = {
     dialogueCloseBtn: HTMLButtonElement;
     dialogueSelectedNpc: HTMLElement;
     dialogueLog: HTMLElement;
+    sideQuestPanel: HTMLElement;
+    sideQuestList: HTMLElement;
     buyOffer1Btn: HTMLButtonElement;
     buyOffer2Btn: HTMLButtonElement;
     buyOffer3Btn: HTMLButtonElement;
@@ -58,6 +60,7 @@ export type VillageActionsCallbacks = {
         villagerNames: string[],
     ) => { status: 'started' | 'inactive' | 'not-target' | 'already-active'; objectiveTitle?: string; days?: number };
     getVillageSideQuestOffers?: (villageName: string, npcName: string) => QuestNode[];
+    getVillageNpcActiveSideQuests?: (villageName: string, npcName: string) => QuestNode[];
     acceptSideQuest?: (questId: string) => { accepted: boolean; reason?: 'inactive' | 'not-found' | 'already-active' };
     turnInSideQuest?: (
         questId: string,

--- a/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
+++ b/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
@@ -101,6 +101,7 @@ export default class VillageUiPresenter {
         if (!npc) {
             this.deps.villageUI.npcTitle.textContent = 'Choose someone to talk to';
             this.deps.villageUI.dialogueSelectedNpc.textContent = 'Select an NPC in the village rumors panel first.';
+            this.deps.villageUI.sideQuestList.innerHTML = '<p>Select an NPC to view side quests.</p>';
             return;
         }
 

--- a/rgfn_game/style.css
+++ b/rgfn_game/style.css
@@ -1435,6 +1435,42 @@ button.quest-entity-name.location:hover {
     background-color: color-mix(in srgb, var(--color-panel-highlight) 74%, transparent);
 }
 
+.village-side-quest-panel {
+    border: 1px solid var(--color-secondary-accent);
+    border-radius: 6px;
+    padding: 8px;
+    background: color-mix(in srgb, var(--color-panel-highlight) 68%, transparent);
+}
+
+.village-side-quest-panel h3 {
+    margin: 0 0 8px;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: var(--color-item);
+}
+
+.village-side-quest-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.village-side-quest-card {
+    border: 1px solid color-mix(in srgb, var(--color-secondary-accent) 70%, transparent);
+    border-radius: 6px;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: color-mix(in srgb, var(--color-secondary-bg) 86%, transparent);
+}
+
+.village-side-quest-card p {
+    margin: 0;
+    font-size: 12px;
+}
+
 .village-dialogue-actions {
     display: flex;
     flex-direction: column;

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -80,6 +80,8 @@ function createVillageUi() {
     dialogueCloseBtn: createElement('button'),
     dialogueSelectedNpc: createElement(),
     dialogueLog: createElement(),
+    sideQuestPanel: createElement(),
+    sideQuestList: createElement(),
     buyOffer1Btn: createElement('button'),
     buyOffer2Btn: createElement('button'),
     buyOffer3Btn: createElement('button'),
@@ -652,4 +654,82 @@ test('VillageActionsController shows defend dialogue action only for NPCs with d
   const maraIndex = controller['npcRoster'].findIndex((npc) => npc.name === 'Mara');
   controller.handleSelectNpc(maraIndex);
   assert.equal(villageUI.defendVillageBtn.classList.contains('hidden'), true);
+}));
+
+test('VillageActionsController requires explicit side-quest acceptance and exposes accept action in dialogue UI', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  let acceptCalls = 0;
+  const offerQuest = {
+    id: 'side-quest-offer',
+    title: 'Patch the Mill Wheel',
+    description: 'Bring repair tools to the village mill.',
+    reward: '20g',
+    status: 'available',
+    children: [],
+  };
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onLeaveVillage: () => {},
+    onAdvanceTime: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+    getVillageSideQuestOffers: () => [offerQuest],
+    getVillageNpcActiveSideQuests: () => [],
+    acceptSideQuest: () => { acceptCalls += 1; return { accepted: true }; },
+  });
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'moss-0', name: 'Mara', role: 'Trader', look: 'cloak', speechStyle: 'calm', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Mossbrook');
+  controller.handleSelectNpc(0);
+
+  assert.equal(acceptCalls, 0);
+  const acceptButton = villageUI.sideQuestList.children.find((child) => child.children?.some((entry) => entry.textContent === 'Accept quest'));
+  assert.ok(acceptButton);
+  controller.handleAcceptSideQuest('side-quest-offer');
+  assert.equal(acceptCalls, 1);
+  assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Side quest accepted')), true);
+}));
+
+test('VillageActionsController shows turn-in action for ready side quests and turn-in is explicit', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  let turnInCalls = 0;
+  const readyQuest = {
+    id: 'side-quest-ready',
+    title: 'Deliver Herbs',
+    description: 'Hand over the herb crate.',
+    reward: 'Potion Bundle',
+    status: 'readyToTurnIn',
+    children: [],
+  };
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onLeaveVillage: () => {},
+    onAdvanceTime: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+    getVillageSideQuestOffers: () => [],
+    getVillageNpcActiveSideQuests: () => [readyQuest],
+    turnInSideQuest: () => { turnInCalls += 1; return { turnedIn: true, reward: 'Potion Bundle' }; },
+  });
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'moss-0', name: 'Mara', role: 'Trader', look: 'cloak', speechStyle: 'calm', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Mossbrook');
+  controller.handleSelectNpc(0);
+
+  assert.equal(turnInCalls, 0);
+  const hasTurnInButton = villageUI.sideQuestList.children.some((child) => child.children?.some((entry) => entry.textContent === 'Turn in quest'));
+  assert.equal(hasTurnInButton, true);
+  controller.handleTurnInSideQuest('side-quest-ready');
+  assert.equal(turnInCalls, 1);
+  assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('turn-in')), true);
 }));


### PR DESCRIPTION
### Motivation

- Make village side-quests visible and actionable to players by surfacing offers and active quests in the NPC dialogue modal instead of hiding acceptance behind selection side-effects.  
- Ensure players explicitly accept side-quests and must explicitly turn in `readyToTurnIn` quests to receive rewards to avoid hidden logic and duplicate grants.  
- Keep a developer-friendly fast path (auto-accept) behind dev-mode to preserve QA speed while defaulting to explicit player actions.

### Description

- Added a Side quests panel to the village dialogue modal (`#village-side-quest-panel` / `#village-side-quest-list`) and styles for quest cards and actions.  
- Added UI plumbing and presenter changes to render per-NPC offers and active quests with reward preview text and to show `Accept quest` and `Turn in quest` buttons where appropriate.  
- Reworked `VillageActionsController` to stop implicit auto-accept flows by default, add explicit handlers `handleAcceptSideQuest`/`handleTurnInSideQuest`, refresh side-quest UI on NPC selection, and add clearer logs for board updates, accepted, ready, and turned-in events.  
- Extended runtime/API surface: added `getVillageNpcActiveSideQuests` to `GameQuestRuntime` and exposed it via `GameFacade` and factory callbacks so UI can query giver-scoped active side quests.  
- Updated tests and docs: added regression tests for explicit accept/turn-in behavior in `villageActionsController.test.js` and extended `side-quest-village-runtime` docs with the new UI/verification checklist.

### Testing

- Ran targeted ESLint against the modified files with `npx eslint ... --ext .ts` and the touched-file checks passed (no new errors).  
- Ran the RGFN test suite with `npm run test:rgfn` (TypeScript build + node tests) and all tests passed (158 tests).  
- Note: running the full repository lint `npm run lint:ts:rgfn` still reports pre-existing unrelated style-guide warnings/errors elsewhere in the codebase and was not addressed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfff14fbf88323990eb75fac08b169)