### PR TITLE
Roll village side-quest offers on entry with configurable per-villager chance (default 0.2)

### DIFF
--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -132,3 +132,26 @@
   - Known-person dialogue options are filtered to current village + immediate nearby villages.
   - Accepted side quests can inject referenced NPCs only into local/nearby village rosters, never distant village rosters.
   - This keeps rumor, dialogue, and objective references spatially coherent for the active local play area.
+
+## 2026-04-15: Probabilistic side-quest offers per villager on village entry
+
+- Side-quest offer generation now runs **on village entry**, not on NPC selection.
+- New balance parameters were added under `balanceConfig.quest`:
+  - `sideQuestVillagerOfferChance` (default `0.2`) → base per-villager chance to have side quests for that entry.
+  - `sideQuestMaxOffersPerVillager` (default `2`, clamped to `1..3`) → max generated offers for a villager in one entry roll.
+- Roll behavior per villager:
+  1. First roll decides whether villager has at least one quest (`chance` check).
+  2. If first roll succeeds, at least one quest is guaranteed.
+  3. Additional offers up to max are rolled independently with the same chance.
+- Runtime integration details:
+  - `VillageActionsController` computes per-villager quest-count rolls on `enterVillage`.
+  - Callback contract now includes `initializeVillageSideQuestOffers(villageName, npcQuestOfferRolls)`.
+  - `GameFacade` clears existing **unaccepted** village offers for that village and asynchronously regenerates offers through `QuestGenerator.generateSideQuest`.
+  - `GameQuestRuntime` now provides `clearVillageSideQuestOffers(villageName)` to support per-entry re-roll behavior.
+- ID generation details:
+  - Side-quest IDs are generated as `side.<village>.<npc>.<timestamp>.<sequence>` to avoid collisions across entries and NPC batches.
+
+### Why this fixes "no villagers have quests"
+
+- Previously there was side-quest offer storage + UI, but no village-entry generation hook guaranteed that NPCs would receive new offers.
+- With entry-time probabilistic generation wired into the runtime callback chain, villagers now reliably have a configurable chance to spawn offers whenever the player enters a village.

--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -155,3 +155,14 @@
 
 - Previously there was side-quest offer storage + UI, but no village-entry generation hook guaranteed that NPCs would receive new offers.
 - With entry-time probabilistic generation wired into the runtime callback chain, villagers now reliably have a configurable chance to spawn offers whenever the player enters a village.
+
+## 2026-04-16: Clarification for "In progress" side quests shown before manual acceptance
+
+- Root cause observed: side quests could appear as **In progress** immediately for an NPC in some sessions because active side quests already existed in runtime state (from earlier acceptance/save), while UI also previously had a developer-mode auto-accept path.
+- UX/runtime adjustments made:
+  - Developer-mode auto-accept path was removed so side quests are always explicitly accepted by player action.
+  - Village dialogue now emits an explicit line when an NPC has no new offers but does have active quests:
+    - `No new side-quest offers from <NPC>. <N> quest(s) already in progress from earlier acceptance.`
+- Practical debugging tip:
+  - If a quest card is **In progress** with no Accept button, check the log for the line above; this indicates an already-active quest rather than a newly spawned unaccepted offer.
+  - Offer cards remain labeled **Offer available** and include an **Accept quest** button.

--- a/rgfn_game/js/config/balance/balanceConfig.ts
+++ b/rgfn_game/js/config/balance/balanceConfig.ts
@@ -11,7 +11,7 @@ import { itemBalance, encounterBalance } from './itemsEncountersBalance.js';
 
 export const balanceConfig = {
     worldMap: worldMapBalance,
-    quest: { sideQuestMaxVillageDistanceCells: 8, sideQuestNearbyRosterDistanceCells: 4 },
+    quest: { sideQuestMaxVillageDistanceCells: 8, sideQuestNearbyRosterDistanceCells: 4, sideQuestVillagerOfferChance: 0.2, sideQuestMaxOffersPerVillager: 2 },
     survival: {
         awakeHoursPerDay: 16,
         requiredSleepHours: 8,

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -86,6 +86,7 @@ export class GameFacade implements GameFacadeStateAccess {
     public gameTime!: GameTimeRuntime;
     private readonly lifecycle = new GameFacadeLifecycleCoordinator(this);
     private readonly worldInteractionCoordinator = new GameFacadeWorldInteractionCoordinator(this);
+    private questGenerator: QuestGenerator | null = null;
     private devController: DeveloperEventController | null = null;
 
     public constructor(canvas: HTMLCanvasElement) {
@@ -130,6 +131,7 @@ export class GameFacade implements GameFacadeStateAccess {
             },
             this.worldMap,
         );
+        this.questGenerator = runtime.questGenerator;
         this.questRuntime.activeSideQuests = Array.isArray(savedSideQuests)
             ? savedSideQuests.map((quest) => ({ ...quest, track: 'side' as const }))
             : [];
@@ -167,6 +169,16 @@ export class GameFacade implements GameFacadeStateAccess {
         villagerNames: string[],
     ): { status: 'started' | 'inactive' | 'not-target' | 'already-active'; objectiveTitle?: string; days?: number } =>
         this.lifecycle.onTryStartDefendObjective(npcName, villageName, villagerNames);
+    public initializeVillageSideQuestOffers = (
+        villageName: string,
+        npcQuestOfferRolls: Array<{ npcName: string; questCount: number }>,
+    ): void => {
+        if (!this.questGenerator) {
+            return;
+        }
+        this.questRuntime.clearVillageSideQuestOffers(villageName);
+        void this.generateVillageSideQuestOffers(villageName, npcQuestOfferRolls);
+    };
     public registerVillageSideQuestOffer = (quest: QuestNode): boolean => this.questRuntime.registerVillageSideQuestOffer(quest);
     public markSideQuestReadyToTurnIn = (questId: string): boolean => this.questRuntime.markSideQuestReadyToTurnIn(questId);
     public getVillageSideQuestOffers = (villageName: string, npcName: string): QuestNode[] =>
@@ -251,6 +263,30 @@ export class GameFacade implements GameFacadeStateAccess {
             hash = Math.imul(hash, 16777619);
         }
         return hash >>> 0;
+    }
+
+    private async generateVillageSideQuestOffers(
+        villageName: string,
+        npcQuestOfferRolls: Array<{ npcName: string; questCount: number }>,
+    ): Promise<void> {
+        if (!this.questGenerator) {
+            return;
+        }
+        const timestamp = Date.now();
+        let sequence = 0;
+        for (const roll of npcQuestOfferRolls) {
+            const npcName = roll.npcName.trim();
+            const questCount = Math.max(0, Math.floor(roll.questCount));
+            if (!npcName || questCount <= 0) {
+                continue;
+            }
+            for (let index = 0; index < questCount; index += 1) {
+                sequence += 1;
+                const sideQuestId = `side.${villageName.trim().toLocaleLowerCase()}.${npcName.toLocaleLowerCase().replace(/\s+/g, '_')}.${timestamp}.${sequence}`;
+                const quest = await this.questGenerator.generateSideQuest(sideQuestId, npcName, villageName);
+                this.registerVillageSideQuestOffer(quest);
+            }
+        }
     }
 }
 

--- a/rgfn_game/js/game/GameFactoryHelpers.ts
+++ b/rgfn_game/js/game/GameFactoryHelpers.ts
@@ -66,6 +66,7 @@ const createVillageActionsController = (
     onTryStartRecoverConfrontation: (personName, villageName) => game.onTryStartRecoverConfrontation(personName, villageName),
     onStartBattle: (enemies) => game.stateMachine.transition(MODES.BATTLE, { enemies, terrainType: 'grass' }),
     onTryStartDefend: (npcName, villageName, villagerNames) => game.onTryStartDefendObjective(npcName, villageName, villagerNames),
+    initializeVillageSideQuestOffers: (villageName, npcQuestOfferRolls) => game.initializeVillageSideQuestOffers(villageName, npcQuestOfferRolls),
     getVillageSideQuestOffers: (villageName, npcName) => game.getVillageSideQuestOffers(villageName, npcName),
     getVillageNpcActiveSideQuests: (villageName, npcName) => game.getVillageNpcActiveSideQuests(villageName, npcName),
     acceptSideQuest: (questId) => game.acceptSideQuest(questId),

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -110,6 +110,19 @@ export default class GameQuestRuntime {
             .map((quest) => ({ ...quest }));
     }
 
+    public clearVillageSideQuestOffers(villageName: string): void {
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        if (!normalizedVillage) {
+            return;
+        }
+        for (const npcKey of this.sideQuestOffersByNpc.keys()) {
+            if (!npcKey.startsWith(`${normalizedVillage}::`)) {
+                continue;
+            }
+            this.sideQuestOffersByNpc.delete(npcKey);
+        }
+    }
+
     public acceptSideQuest(questId: string): { accepted: boolean; reason?: 'inactive' | 'not-found' | 'already-active' } {
         const normalizedQuestId = questId.trim();
         if (!normalizedQuestId) {

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -43,6 +43,7 @@ export default class VillageActionsController {
         this.barterService.assignQuestBarterContractsIfNeeded(villageName);
         this.stockService.refreshVillageStock();
         this.npcRoster = this.getOrCreateVillageNpcRoster(villageName);
+        this.initializeVillageSideQuestOffers(villageName);
         this.selectedNpcId = null;
         this.prepareVillageUiForEntry(villageName);
         this.handleEnter(villageName);
@@ -271,6 +272,28 @@ export default class VillageActionsController {
         this.ensureQuestPeoplePresent(roster, villageName);
         this.villageNpcRosters.set(villageName, roster);
         return roster;
+    }
+
+    private initializeVillageSideQuestOffers(villageName: string): void {
+        const sideQuestOfferChance = Math.max(0, Math.min(1, Number(balanceConfig.quest?.sideQuestVillagerOfferChance ?? 0.2)));
+        const maxOffersPerVillager = Math.max(1, Math.min(3, Math.floor(balanceConfig.quest?.sideQuestMaxOffersPerVillager ?? 2)));
+        const npcQuestOfferRolls = this.npcRoster
+            .map((npc) => ({ npcName: npc.name, questCount: this.rollSideQuestOfferCount(sideQuestOfferChance, maxOffersPerVillager) }))
+            .filter((roll) => roll.questCount > 0);
+        this.callbacks.initializeVillageSideQuestOffers?.(villageName, npcQuestOfferRolls);
+    }
+
+    private rollSideQuestOfferCount(sideQuestOfferChance: number, maxOffersPerVillager: number): number {
+        if (maxOffersPerVillager <= 0 || Math.random() >= sideQuestOfferChance) {
+            return 0;
+        }
+        let offers = 1;
+        for (let index = 1; index < maxOffersPerVillager; index += 1) {
+            if (Math.random() < sideQuestOfferChance) {
+                offers += 1;
+            }
+        }
+        return offers;
     }
 
     private ensureQuestPeoplePresent(roster: VillageNpcProfile[], villageName: string): void {

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -483,6 +483,13 @@ export default class VillageActionsController {
             + `${activeQuests.length} active, ${readyToTurnInCount} ready to turn in.`,
             'system-message',
         );
+        if (offers.length === 0 && activeQuests.length > 0) {
+            this.addLog(
+                `No new side-quest offers from ${npc.name}. ${activeQuests.length} quest${activeQuests.length === 1 ? '' : 's'} `
+                + 'already in progress from earlier acceptance.',
+                'system-message',
+            );
+        }
         activeQuests.forEach((quest) => {
             this.activeNpcSideQuestIds.add(quest.id);
             this.injectSideQuestNpcReferencesIntoNearbyRosters(quest);
@@ -492,14 +499,7 @@ export default class VillageActionsController {
             this.readySideQuestLogIds.add(quest.id);
             this.addLog(`Side quest ready to turn in: ${quest.title}.`, 'system');
         });
-        if (!this.shouldAutoAcceptVillageSideQuests() || offers.length === 0) {
-            this.updateButtons();
-            return;
-        }
-        offers.forEach((offer) => this.handleAcceptSideQuest(offer.id));
-        if (offers.length > 0) {
-            this.addLog('[DEV] Auto-accepted side quests for selected NPC.', 'system-message');
-        }
+        this.updateButtons();
     }
 
     private renderSideQuestUiForNpc(npc: VillageNpcProfile, offers: QuestNode[], activeQuests: QuestNode[]): void {
@@ -609,8 +609,6 @@ export default class VillageActionsController {
         }
         return 'Available';
     }
-
-    private shouldAutoAcceptVillageSideQuests = (): boolean => isDeveloperModeEnabled();
 
     private getKnownSettlementNames(): string[] {
         const knownFromMap = this.callbacks.getKnownSettlementNames?.() ?? [];

--- a/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
+++ b/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
@@ -59,6 +59,7 @@ export type VillageActionsCallbacks = {
         villageName: string,
         villagerNames: string[],
     ) => { status: 'started' | 'inactive' | 'not-target' | 'already-active'; objectiveTitle?: string; days?: number };
+    initializeVillageSideQuestOffers?: (villageName: string, npcQuestOfferRolls: Array<{ npcName: string; questCount: number }>) => void;
     getVillageSideQuestOffers?: (villageName: string, npcName: string) => QuestNode[];
     getVillageNpcActiveSideQuests?: (villageName: string, npcName: string) => QuestNode[];
     acceptSideQuest?: (questId: string) => { accepted: boolean; reason?: 'inactive' | 'not-found' | 'already-active' };

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -731,6 +731,43 @@ test('VillageActionsController requires explicit side-quest acceptance and expos
   assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Side quest accepted')), true);
 }));
 
+test('VillageActionsController does not auto-accept side quests in developer mode', () => withDeveloperMode(true, () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  let acceptCalls = 0;
+  const offerQuest = {
+    id: 'side-quest-offer-dev',
+    title: 'Count Grain Sacks',
+    description: 'Inspect missing grain sacks in the barn.',
+    reward: '10g',
+    status: 'available',
+    children: [],
+  };
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onLeaveVillage: () => {},
+    onAdvanceTime: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+    getVillageSideQuestOffers: () => [offerQuest],
+    getVillageNpcActiveSideQuests: () => [],
+    acceptSideQuest: () => { acceptCalls += 1; return { accepted: true }; },
+  });
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'moss-0', name: 'Mara', role: 'Trader', look: 'cloak', speechStyle: 'calm', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Mossbrook');
+  controller.handleSelectNpc(0);
+
+  assert.equal(acceptCalls, 0);
+  const hasAcceptButton = villageUI.sideQuestList.children.some((child) => child.children?.some((entry) => entry.textContent === 'Accept quest'));
+  assert.equal(hasAcceptButton, true);
+  assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Auto-accepted side quests')), false);
+})));
+
 test('VillageActionsController shows turn-in action for ready side quests and turn-in is explicit', () => withDocumentStub(() => {
   const villageUI = createVillageUi();
   const gameLog = createElement();

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -210,6 +210,42 @@ test('VillageActionsController shows village actions + rumors on entry and hides
   assert.equal(villageUI.rumorsPanel.classList.contains('hidden'), true);
 }));
 
+test('VillageActionsController rolls side-quest offers per villager on village entry', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  const sideQuestOfferRolls = [];
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onAdvanceTime: () => {},
+    onLeaveVillage: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+    initializeVillageSideQuestOffers: (villageName, rolls) => sideQuestOfferRolls.push({ villageName, rolls }),
+  });
+
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [
+      { id: 'moss-0', name: 'Mara', role: 'Trader', look: 'satchel', speechStyle: 'calm', disposition: 'truthful' },
+      { id: 'moss-1', name: 'Tor', role: 'Hunter', look: 'boots', speechStyle: 'cold', disposition: 'liar' },
+    ],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  const originalMathRandom = Math.random;
+  const randomValues = [0.15, 0.11, 0.9];
+  Math.random = () => randomValues.shift() ?? 0.95;
+
+  try {
+    controller.enterVillage('Mossbrook');
+  } finally {
+    Math.random = originalMathRandom;
+  }
+
+  assert.equal(sideQuestOfferRolls.length, 1);
+  assert.equal(sideQuestOfferRolls[0].villageName, 'Mossbrook');
+  assert.deepEqual(sideQuestOfferRolls[0].rolls, [{ npcName: 'Mara', questCount: 2 }]);
+}));
+
 test('VillageActionsController stores separate rumor rosters for different villages', () => withDocumentStub(() => {
   const villageUI = createVillageUi();
   const gameLog = createElement();


### PR DESCRIPTION
### Motivation
- Villagers were never getting side-quest offers reliably because there was no guaranteed village-entry generation hook for offers.  The intent is to give each villager a configurable probability to have one or more side-quest offers when the player enters a village.  
- Make the probability and maximum per-villager offers configurable via the central balance config with a sensible default of `0.2`.

### Description
- Add balance knobs `balanceConfig.quest.sideQuestVillagerOfferChance` (default `0.2`) and `balanceConfig.quest.sideQuestMaxOffersPerVillager` (default `2`) and clamp usages to safe ranges. (edited `rgfn_game/js/config/balance/balanceConfig.ts`).
- Roll per-villager offer counts on village entry inside `VillageActionsController.enterVillage`, guaranteeing one quest on a successful first roll and allowing additional independent rolls up to the configured cap; results are emitted via a new callback `initializeVillageSideQuestOffers`. (edited `rgfn_game/js/systems/village/VillageActionsController.ts` and `rgfn_game/js/systems/village/actions/VillageActionsTypes.ts`).
- Wire the new callback through `GameFactoryHelpers` into `GameFacade`, where the facade clears unaccepted offers for the village and asynchronously generates side quests with `QuestGenerator.generateSideQuest`, using collision-resistant IDs per batch. (edited `rgfn_game/js/game/GameFactoryHelpers.ts` and `rgfn_game/js/game/GameFacade.ts`).
- Add runtime support `GameQuestRuntime.clearVillageSideQuestOffers(villageName)` and preserve existing offer/accept/turn-in semantics. (edited `rgfn_game/js/game/runtime/GameQuestRuntime.ts`).
- Add a deterministic test for per-villager entry rolls and update side-quest runtime documentation to explain the new entry-time probabilistic model and config knobs. (edited `rgfn_game/test/systems/scenarios/villageActionsController.test.js` and `rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md`).

### Testing
- Ran targeted ESLint on the touched TypeScript files with `npx eslint ...` and the checked files passed linting. (passed)
- Ran the full RGfN test suite with `npm run test:rgfn` and all tests passed (`158` tests, `0` failures). (passed)
- Repository-wide lint `npm run lint:ts:rgfn` was executed and reported a pre-existing unrelated lint error in `rgfn_game/js/systems/village/VillageDialogueEngine.ts` that existed before this change, so full repo lint is still failing for unrelated reasons. (known pre-existing failure)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0041954f48323950612064a80aa82)