### PR TITLE
[RGFN] Close NPC dialogue modal on Escape

### DIFF
--- a/rgfn_game/docs/village/village-dialogue-modal.md
+++ b/rgfn_game/docs/village/village-dialogue-modal.md
@@ -63,7 +63,8 @@ This keeps one shared source of dialogue events while showing NPC conversation i
 
 - open dialogue button,
 - close dialogue button,
-- backdrop click-to-close for dialogue modal.
+- backdrop click-to-close for dialogue modal,
+- Escape key close for dialogue modal while it is open.
 
 ## Test coverage added
 
@@ -101,6 +102,18 @@ File: `rgfn_game/test/systems/villageActionsController.test.js`.
 - Root cause: `worldMap.getKnownSettlementNames()` merged in `namedLocations` without checking tile discovery state.
 - Fix: `WorldMapNamedLocationAndVillageOverlays.getKnownSettlementNames()` now includes named locations only when their anchor cell is discovered.
 - Regression guard: `worldMap.test.js` now verifies undiscovered named location entries are excluded until discovered.
+
+## Follow-up pitfall fixed (April 16, 2026)
+
+- Symptom: NPC dialogue popup had no keyboard close path, forcing mouse interaction with close button or backdrop.
+- Root cause: `GameUiPrimaryEventBinder` only wired click events for modal close and had no Escape handler.
+- Fix:
+  - Added a `keydown` listener in village UI binding flow.
+  - Added `handleDialogueCloseHotkeys(...)` that closes the dialogue modal when `event.key === 'Escape'` and the modal is currently visible.
+  - Added `preventDefault()` for that specific Escape close path to keep behavior deterministic while the popup is open.
+- Regression guard:
+  - Escape handling exits early when the modal is hidden, avoiding redundant close calls.
+  - Existing world map keyboard zoom handling remains isolated in its own keydown branch.
 
 ## Notes for future extension
 

--- a/rgfn_game/js/systems/game/ui/GameUiPrimaryEventBinder.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiPrimaryEventBinder.ts
@@ -119,6 +119,7 @@ export default class GameUiPrimaryEventBinder {
         this.villageUI.openDialogueBtn.addEventListener('click', () => this.villageActionsController.openDialogueWindow());
         this.villageUI.dialogueCloseBtn.addEventListener('click', () => this.villageActionsController.closeDialogueWindow());
         this.villageUI.dialogueModal.addEventListener('click', (event: MouseEvent) => this.closeDialogueFromOverlay(event));
+        document.addEventListener('keydown', (event: KeyboardEvent) => this.handleDialogueCloseHotkeys(event));
         this.villageUI.askVillageBtn.addEventListener('click', () => this.villageActionsController.handleAskAboutSettlement());
         this.villageUI.askNearbySettlementsBtn.addEventListener('click', () => this.villageActionsController.handleAskAboutNearbySettlements());
         this.villageUI.askPersonInput.addEventListener('change', () => this.villageActionsController.updateButtons());
@@ -136,5 +137,14 @@ export default class GameUiPrimaryEventBinder {
         if (event.target === this.villageUI.dialogueModal) {
             this.villageActionsController.closeDialogueWindow();
         }
+    }
+
+    private handleDialogueCloseHotkeys(event: KeyboardEvent): void {
+        if (event.key !== 'Escape' || this.villageUI.dialogueModal.classList.contains('hidden')) {
+            return;
+        }
+
+        event.preventDefault();
+        this.villageActionsController.closeDialogueWindow();
     }
 }


### PR DESCRIPTION
### Motivation
- Improve keyboard-first usability by allowing the NPC dialogue modal to be closed with the `Escape` key. 
- Keep modal close behavior consistent with existing close paths (close button and backdrop click) while avoiding interference with other global key handling. 

### Description
- Wire a `keydown` listener in `bindVillageEvents` of `GameUiPrimaryEventBinder` that delegates to a new `handleDialogueCloseHotkeys` method. 
- Implement `handleDialogueCloseHotkeys` to check `event.key === 'Escape'`, verify the dialogue modal is visible, call `event.preventDefault()`, and invoke `villageActionsController.closeDialogueWindow()`. 
- Update `docs/village/village-dialogue-modal.md` with an `April 16, 2026` entry documenting the Escape-key fix and regression notes. 

### Testing
- Ran `npm run test:rgfn` which compiled and executed the RGFN test suite and returned all tests passing (`158` tests passed). 
- Ran `npx eslint` against the modified file `rgfn_game/js/systems/game/ui/GameUiPrimaryEventBinder.ts` which passed for the touched file. 
- Ran the full `npm run lint:ts:rgfn` which surfaced pre-existing repository lint issues unrelated to this change (one existing `style-guide/function-length-error` in `rgfn_game/js/systems/village/VillageDialogueEngine.ts`), so full linting across the rgfn codebase did not pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e123c14b588323b44df9c83a2f8d4d)