### PR TITLE
RGFN: route villager naming through quest character generator

### DIFF
--- a/rgfn_game/docs/village/village-dialogue-directions.md
+++ b/rgfn_game/docs/village/village-dialogue-directions.md
@@ -163,3 +163,16 @@ Village dialogue now includes a dedicated button: **Ask about nearby settlements
   - if the reservoir has names, villagers consume those immediately;
   - if not (early startup or temporary fetch/init lag), generation falls back to legacy local names to avoid UI stalls.
 - Quest generator and village NPC naming now share one `QuestPackService` instance in runtime assembly.
+
+### 2026-04-16 incident + hardening follow-up
+- A regression was observed where browser console showed repeated CORS failures to `randomuser.me`, and in some runs quest panel bootstrap could fail (missing main quest tree).
+- Root cause: concurrent `generateName()` calls during startup (reservoir + quest generation) could race service initialization and over-probe remote sources.
+- Hardening applied:
+  - `QuestPackService.initialize()` is now guarded by a shared in-flight initialization promise.
+  - Source registry is rebuilt deterministically per initialization run (no duplicate source accumulation).
+  - Name selection has a local-pattern fallback if all probed sources are unavailable.
+  - Reservoir refill now generates sequentially and catches transient generation errors, avoiding cascading startup failures.
+- Expected runtime behavior after fix:
+  - transient remote CORS/network failures no longer break quest generation;
+  - main quest generation remains available from local/echo sources;
+  - villager naming still prefers quest-style person names when reservoir entries exist.

--- a/rgfn_game/docs/village/village-dialogue-directions.md
+++ b/rgfn_game/docs/village/village-dialogue-directions.md
@@ -145,3 +145,21 @@ Village dialogue now includes a dedicated button: **Ask about nearby settlements
 - Adds a richer semi-text investigation loop: one question can reveal several leads.
 - Makes NPC choice matter more (personality + knowledge radius).
 - Encourages cross-checking rumors before committing long travel.
+
+## 2026-04-16 update: village NPC names now follow quest character-name generation
+
+### What changed
+- Village rumor NPC names are no longer picked only from the old short hardcoded list.
+- `VillageActionsController` now accepts `nextCharacterName()` and applies generated names onto new village rumor rosters.
+- Runtime wires this callback from a shared quest-name reservoir that draws names via `QuestPackService.generateName('character', ...)`.
+
+### Why this was done
+- Quest-linked persons and regular villagers now look like they belong to the same naming universe.
+- This reduces immersion breaks where quest contacts had pack-generated names but local villagers looked repetitive.
+
+### Runtime design notes
+- A new `QuestCharacterNameReservoir` prefetches quest-style character names in background batches.
+- Villager generation is still synchronous at village-entry time:
+  - if the reservoir has names, villagers consume those immediately;
+  - if not (early startup or temporary fetch/init lag), generation falls back to legacy local names to avoid UI stalls.
+- Quest generator and village NPC naming now share one `QuestPackService` instance in runtime assembly.

--- a/rgfn_game/js/game/GameFactoryHelpers.ts
+++ b/rgfn_game/js/game/GameFactoryHelpers.ts
@@ -51,6 +51,7 @@ const createVillageActionsController = (
     player: Player,
     worldMap: WorldMap,
     hudCoordinator: GameHudCoordinator,
+    nextCharacterName: () => string,
 ): VillageActionsController => new VillageActionsController(player, ui.villageUI, ui.gameLogUI.log, {
     onUpdateHUD: () => hudCoordinator.updateHUD(),
     onAdvanceTime: (minutes, fatigueScale) => game.onVillageAdvanceTime(minutes, fatigueScale),
@@ -71,7 +72,7 @@ const createVillageActionsController = (
     getVillageNpcActiveSideQuests: (villageName, npcName) => game.getVillageNpcActiveSideQuests(villageName, npcName),
     acceptSideQuest: (questId) => game.acceptSideQuest(questId),
     turnInSideQuest: (questId, npcName, villageName) => game.turnInSideQuest(questId, npcName, villageName),
-});
+}, { nextCharacterName });
 
 // eslint-disable-next-line style-guide/function-length-warning
 export function createVillageRuntime(
@@ -81,8 +82,9 @@ export function createVillageRuntime(
     worldMap: WorldMap,
     villageLifeRenderer: VillageLifeRenderer,
     hudCoordinator: GameHudCoordinator,
+    nextCharacterName: () => string,
 ) {
-    const villageActionsController = createVillageActionsController(game, ui, player, worldMap, hudCoordinator);
+    const villageActionsController = createVillageActionsController(game, ui, player, worldMap, hudCoordinator, nextCharacterName);
     const villageCoordinator = new GameVillageCoordinator(
         ui.hudElements,
         ui.battleUI,

--- a/rgfn_game/js/game/GameRuntimeAssembly.ts
+++ b/rgfn_game/js/game/GameRuntimeAssembly.ts
@@ -10,6 +10,7 @@ import LoreBookController from '../systems/controllers/lore/LoreBookController.j
 import MagicSystem from '../systems/controllers/magic/MagicSystem.js';
 import QuestGenerator from '../systems/quest/QuestGenerator.js';
 import QuestPackService from '../systems/quest/generation/QuestPackService.js';
+import QuestCharacterNameReservoir from '../systems/quest/generation/QuestCharacterNameReservoir.js';
 import QuestUiController from '../systems/quest/ui/QuestUiController.js';
 import GameRenderRouter from '../systems/game/runtime/GameRenderRouter.js';
 import BattleCommandController from '../systems/game/BattleCommandController.js';
@@ -41,8 +42,8 @@ const createQuestUiController = (game: GameFacade, ui: RuntimeUi): QuestUiContro
     { onLocationClick: (locationName: string) => game.onQuestLocationClick(locationName) },
 );
 
-const createQuestGenerator = (worldMap: WorldMap): QuestGenerator => new QuestGenerator({
-    packService: new QuestPackService({ locationNamesProvider: () => worldMap.getAllVillageNames() }),
+const createQuestGenerator = (worldMap: WorldMap, packService: QuestPackService): QuestGenerator => new QuestGenerator({
+    packService,
     nearbyVillagesProvider: (villageName: string, maxDistanceCells: number) =>
         worldMap.getNearbyVillagesFromVillage(villageName, maxDistanceCells),
     villageDirectionHintProvider: (villageName: string) => worldMap.getVillageDirectionHintFromPlayer(villageName),
@@ -82,6 +83,7 @@ function createSharedRuntime(
     loreBookController: LoreBookController,
     magicSystem: MagicSystem,
     battleUiController: BattleUiController,
+    nextCharacterName: () => string,
 ) {
     const { player, ui, worldMap, villageLifeRenderer } = runtimeBase;
     let battleCommandControllerRef: BattleCommandController | null = null;
@@ -94,7 +96,7 @@ function createSharedRuntime(
         (action) => battleCommandControllerRef?.handleEquipmentAction(action) ?? true,
         () => game.getHudTimeSnapshot(),
     );
-    const villageRuntime = createVillageRuntime(game, ui, player, worldMap, villageLifeRenderer, hudCoordinator);
+    const villageRuntime = createVillageRuntime(game, ui, player, worldMap, villageLifeRenderer, hudCoordinator, nextCharacterName);
     return { hudCoordinator, battleCommandControllerRef, ...villageRuntime };
 }
 
@@ -140,14 +142,24 @@ const createWorldMode = (game: GameFacade, runtimeBase: RuntimeBase, shared: Sha
     return createWorldModeControllerRuntime(game, player, worldMap, encounterSystem, shared.stateMachine, ui, shared.hudCoordinator, loreBookController);
 };
 
+// eslint-disable-next-line style-guide/function-length-warning
 function createRuntimeControllers(game: GameFacade, runtimeBase: RuntimeBase) {
     const { player, worldMap, battleMap, turnManager, ui } = runtimeBase;
-    const questGenerator = createQuestGenerator(worldMap);
+    const packService = new QuestPackService({ locationNamesProvider: () => worldMap.getAllVillageNames() });
+    const questCharacterNameReservoir = new QuestCharacterNameReservoir(packService);
+    const questGenerator = createQuestGenerator(worldMap, packService);
     const questUiController = createQuestUiController(game, ui);
     const loreBookController = new LoreBookController({ loreBody: ui.hudElements.loreBody }, player, worldMap);
     const magicSystem = new MagicSystem(player);
     const battleUiController = new BattleUiController(ui.battleUI, battleMap, turnManager, player, ui.gameLogUI.log, magicSystem);
-    const shared = createSharedRuntime(game, runtimeBase, loreBookController, magicSystem, battleUiController);
+    const shared = createSharedRuntime(
+        game,
+        runtimeBase,
+        loreBookController,
+        magicSystem,
+        battleUiController,
+        () => questCharacterNameReservoir.nextName(),
+    );
     const combat = createBattleControllers(game, runtimeBase, shared, magicSystem, battleUiController);
     shared.battleCommandControllerRef = combat.battleCommandController;
     const worldModeController = createWorldMode(game, runtimeBase, shared, loreBookController);

--- a/rgfn_game/js/systems/quest/generation/QuestCharacterNameReservoir.ts
+++ b/rgfn_game/js/systems/quest/generation/QuestCharacterNameReservoir.ts
@@ -5,7 +5,7 @@ export default class QuestCharacterNameReservoir {
     private readonly names: string[] = [];
     private isRefilling = false;
 
-    constructor(private readonly packService: QuestPackService, private readonly refillSize: number = 16, private readonly refillThreshold: number = 8) {
+    constructor(private readonly packService: QuestPackService, private readonly refillSize: number = 10, private readonly refillThreshold: number = 5) {
         this.triggerRefill();
     }
 
@@ -22,16 +22,22 @@ export default class QuestCharacterNameReservoir {
             return;
         }
         this.isRefilling = true;
-        void this.refill().finally(() => {
-            this.isRefilling = false;
-        });
+        void this.refill();
     }
 
     private async refill(): Promise<void> {
-        const maxWords = Math.max(1, Math.floor(theme.quest.nameGeneration.maxWordsByDomain.character ?? 2));
-        const generatedNames = await Promise.all(
-            Array.from({ length: this.refillSize }, async () => (await this.packService.generateName('character', maxWords)).text.trim()),
-        );
-        generatedNames.filter((name) => name.length > 0).forEach((name) => this.names.push(name));
+        try {
+            const maxWords = Math.max(1, Math.floor(theme.quest.nameGeneration.maxWordsByDomain.character ?? 2));
+            for (let index = 0; index < this.refillSize; index += 1) {
+                const generatedName = (await this.packService.generateName('character', maxWords)).text.trim();
+                if (generatedName.length > 0) {
+                    this.names.push(generatedName);
+                }
+            }
+        } catch {
+            // Keep reservoir resilient: village naming can safely fall back when source generation is temporarily unavailable.
+        } finally {
+            this.isRefilling = false;
+        }
     }
 }

--- a/rgfn_game/js/systems/quest/generation/QuestCharacterNameReservoir.ts
+++ b/rgfn_game/js/systems/quest/generation/QuestCharacterNameReservoir.ts
@@ -1,0 +1,37 @@
+import { theme } from '../../../config/ThemeConfig.js';
+import QuestPackService from './QuestPackService.js';
+
+export default class QuestCharacterNameReservoir {
+    private readonly names: string[] = [];
+    private isRefilling = false;
+
+    constructor(private readonly packService: QuestPackService, private readonly refillSize: number = 16, private readonly refillThreshold: number = 8) {
+        this.triggerRefill();
+    }
+
+    public nextName = (): string => {
+        const selectedName = this.names.shift();
+        if (this.names.length < this.refillThreshold) {
+            this.triggerRefill();
+        }
+        return selectedName ?? '';
+    };
+
+    private triggerRefill(): void {
+        if (this.isRefilling) {
+            return;
+        }
+        this.isRefilling = true;
+        void this.refill().finally(() => {
+            this.isRefilling = false;
+        });
+    }
+
+    private async refill(): Promise<void> {
+        const maxWords = Math.max(1, Math.floor(theme.quest.nameGeneration.maxWordsByDomain.character ?? 2));
+        const generatedNames = await Promise.all(
+            Array.from({ length: this.refillSize }, async () => (await this.packService.generateName('character', maxWords)).text.trim()),
+        );
+        generatedNames.filter((name) => name.length > 0).forEach((name) => this.names.push(name));
+    }
+}

--- a/rgfn_game/js/systems/quest/generation/QuestPackService.ts
+++ b/rgfn_game/js/systems/quest/generation/QuestPackService.ts
@@ -20,6 +20,7 @@ export default class QuestPackService {
     private readonly sources: PackSource[] = [];
     private readonly targetSelector: QuestNameWordTargetSelector;
     private initialized = false;
+    private initializationPromise: Promise<void> | null = null;
 
     constructor(deps: QuestPackServiceDeps = {}) {
         this.fetchImpl = deps.fetchImpl ?? ((input: string) => globalThis.fetch(input));
@@ -33,10 +34,10 @@ export default class QuestPackService {
         if (this.initialized) {
             return;
         }
-        await this.loadAssets();
-        this.createSources();
-        await this.probeSources();
-        this.initialized = true;
+        if (!this.initializationPromise) {
+            this.initializationPromise = this.runInitialization();
+        }
+        await this.initializationPromise;
     }
 
     public async generateName(domain: QuestNameDomain, maxWords: number): Promise<GeneratedName> {
@@ -76,6 +77,17 @@ export default class QuestPackService {
         return { text: this.titleCase(words), domain, sourceTypes };
     }
 
+    private async runInitialization(): Promise<void> {
+        try {
+            await this.loadAssets();
+            this.createSources();
+            await this.probeSources();
+            this.initialized = true;
+        } finally {
+            this.initializationPromise = null;
+        }
+    }
+
     private async loadAssets(): Promise<void> {
         for (const [key, path] of Object.entries(ASSET_PATHS)) {
             const words = this.wordList(await this.fileReader(path));
@@ -87,6 +99,7 @@ export default class QuestPackService {
     }
 
     private createSources(): void {
+        this.sources.length = 0;
         const sourceFactory = new QuestPackSourceFactory({
             fetchImpl: this.fetchImpl,
             random: this.random,
@@ -121,9 +134,17 @@ export default class QuestPackService {
         }
     }
 
-    private pickSource = (domain: QuestNameDomain): PackSource => this.random.pick(
-        this.sources.filter((source) => source.domain === domain && source.available),
-    );
+    private pickSource = (domain: QuestNameDomain): PackSource => {
+        const availableSources = this.sources.filter((source) => source.domain === domain && source.available);
+        if (availableSources.length > 0) {
+            return this.random.pick(availableSources);
+        }
+        const localFallback = this.sources.find((source) => source.domain === domain && source.type === 'local-pattern');
+        if (!localFallback) {
+            throw new Error(`No available quest pack sources for domain "${domain}".`);
+        }
+        return localFallback;
+    };
 
     private titleCase = (words: string[]): string => words.map((word) => this.capitalizeWord(word)).join(' ');
 

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -13,7 +13,8 @@ import { balanceConfig } from '../../config/balance/balanceConfig.js';
 export default class VillageActionsController {
     private readonly villageUI: VillageUI;
     private readonly callbacks: VillageActionsCallbacks;
-    private readonly dialogueEngine = new VillageDialogueEngine();
+    private readonly dialogueEngine: VillageDialogueEngine;
+    private readonly nextCharacterName?: () => string;
     private readonly stockService = new VillageStockService();
     private readonly barterService = new VillageBarterService();
     private readonly uiPresenter: VillageUiPresenter;
@@ -30,9 +31,11 @@ export default class VillageActionsController {
     private knownNpcNames: Set<string> = new Set();
     private joinedEscortNpcKeys: Set<string> = new Set();
 
-    constructor(player: Player, villageUI: VillageUI, gameLog: HTMLElement, callbacks: VillageActionsCallbacks) {
+    constructor(player: Player, villageUI: VillageUI, gameLog: HTMLElement, callbacks: VillageActionsCallbacks, deps: { nextCharacterName?: () => string } = {}) {
         this.villageUI = villageUI;
         this.callbacks = callbacks;
+        this.dialogueEngine = new VillageDialogueEngine();
+        this.nextCharacterName = deps.nextCharacterName;
         this.uiPresenter = this.createVillageUiPresenter(player, villageUI, gameLog);
         this.tradeInteraction = this.createTradeInteraction(player, callbacks);
         this.dialogueInteraction = this.createDialogueInteraction(player, villageUI, callbacks);
@@ -268,10 +271,23 @@ export default class VillageActionsController {
             return cachedRoster;
         }
 
-        const roster = this.dialogueEngine.createNpcRoster(villageName);
+        const roster = this.applyQuestStyleNames(this.dialogueEngine.createNpcRoster(villageName));
         this.ensureQuestPeoplePresent(roster, villageName);
         this.villageNpcRosters.set(villageName, roster);
         return roster;
+    }
+
+    private applyQuestStyleNames(roster: VillageNpcProfile[]): VillageNpcProfile[] {
+        if (!this.nextCharacterName) {
+            return roster;
+        }
+        return roster.map((npc) => {
+            const generatedName = this.nextCharacterName?.().trim();
+            if (!generatedName?.length) {
+                return npc;
+            }
+            return { ...npc, name: generatedName };
+        });
     }
 
     private initializeVillageSideQuestOffers(villageName: string): void {

--- a/rgfn_game/test/systems/questPackService.test.js
+++ b/rgfn_game/test/systems/questPackService.test.js
@@ -142,3 +142,36 @@ test('QuestPackService ignores HTML/error payload tokens in local asset files', 
   assert.equal(result.text.includes('Cannot'), false);
   assert.equal(result.text.includes('rgfn_game'), false);
 });
+
+test('QuestPackService performs initialization once when multiple generateName calls start concurrently', async () => {
+  const random = new ScriptedQuestRandom({
+    ints: [95, 95, 95],
+    picks: [
+      'local-pattern',
+      ['GIVEN'],
+      'lena',
+      'local-pattern',
+      ['GIVEN'],
+      'orik',
+      'local-pattern',
+      ['GIVEN'],
+      'tala',
+    ],
+  });
+  const fetchCalls = [];
+  const fetchImpl = async (input) => {
+    fetchCalls.push(String(input));
+    throw new Error('offline');
+  };
+  const service = new QuestPackService({ fetchImpl, random, fileReader: createFileReader() });
+
+  const results = await Promise.all([
+    service.generateName('character', 2),
+    service.generateName('character', 2),
+    service.generateName('character', 2),
+  ]);
+
+  assert.equal(results.length, 3);
+  assert.equal(service['sources'].length, 14);
+  assert.equal(fetchCalls.length >= 3 && fetchCalls.length <= 4, true);
+});

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -806,3 +806,30 @@ test('VillageActionsController shows turn-in action for ready side quests and tu
   assert.equal(turnInCalls, 1);
   assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('turn-in')), true);
 }));
+
+test('VillageActionsController applies quest-style generated names to village NPC rosters when provided', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  const generatedNames = ['Ari Vale', 'Miller Forge', 'Nora Reed'];
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onAdvanceTime: () => {},
+    onLeaveVillage: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+  }, { nextCharacterName: () => generatedNames.shift() ?? '' });
+
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [
+      { id: 'moss-0', name: 'Mara', role: 'Trader', look: 'satchel', speechStyle: 'calm', disposition: 'truthful' },
+      { id: 'moss-1', name: 'Tor', role: 'Hunter', look: 'boots', speechStyle: 'cold', disposition: 'liar' },
+      { id: 'moss-2', name: 'Iven', role: 'Guard', look: 'hood', speechStyle: 'warm', disposition: 'imprecise' },
+    ],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Mossbrook');
+  const rosterNames = controller['npcRoster'].map((npc) => npc.name);
+  assert.deepEqual(rosterNames, ['Ari Vale', 'Miller Forge', 'Nora Reed']);
+}));


### PR DESCRIPTION
### Motivation
- Unify NPC naming so village rumor NPCs use the same quest-style name generator used for quest characters to avoid immersion breaks and duplicated hardcoded names. 
- Keep villager generation synchronous and robust so UI rendering never stalls while still preferring pack-generated names when available.

### Description
- Added `QuestCharacterNameReservoir` (`js/systems/quest/generation/QuestCharacterNameReservoir.ts`) which prefetches character names by calling `QuestPackService.generateName('character', ...)` and serves them synchronously via `nextName()`.
- Rewired runtime to share a single `QuestPackService` instance and to create the reservoir in `GameRuntimeAssembly` (`js/game/GameRuntimeAssembly.ts`), then pass a `nextCharacterName` callback into village runtime wiring.
- Plumbed `nextCharacterName` through `GameFactoryHelpers` into `VillageActionsController` and updated `VillageActionsController` (`js/systems/village/VillageActionsController.ts`) to apply quest-style generated names onto newly created village NPC rumor rosters while preserving fallback to legacy local names if the reservoir yields an empty name.
- Added a unit test asserting name application (`test/systems/scenarios/villageActionsController.test.js`) and updated documentation to describe the new naming flow (`docs/village/village-dialogue-directions.md`).

### Testing
- Ran project build with `npm run build:rgfn` which completed successfully. 
- Ran full RGFN unit tests with `npm run test:rgfn` and all tests passed (`158` tests passed, `0` failed). 
- Ran targeted ESLint on modified files (`npx eslint` against the touched sources and test) which completed cleanly, while a full-repo lint (`npm run lint:ts:rgfn`) still fails due to pre-existing repository-wide/style-rule definitions outside this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e126158ee48323ad08b05d3a915416)