### PR TITLE
Fix side-quest village link navigation when developer reveal is enabled

### DIFF
--- a/rgfn_game/docs/quest/quest-progress-tracking.md
+++ b/rgfn_game/docs/quest/quest-progress-tracking.md
@@ -278,3 +278,20 @@
 ### Regression coverage added
 - `recoverQuestRuntime.test.js` now verifies known quest settlement extraction excludes unknown future contracts.
 - `villageActionsController.test.js` now verifies non-developer settlement dropdown merges discovered map names with known quest names.
+
+## April 16, 2026 update: side-quest village links respect developer map reveal mode
+
+### Problem observed
+- In the **Side Quests** tab, clicking a village link could show `"<Village> is not discovered yet."` even when developer mode map reveal (`everythingDiscovered`) was enabled and the village was visible on the world map.
+- Root cause: quest-link navigation used world-map discovery state (`fogStates`) only, while developer map reveal is a display override.
+
+### Fix implemented
+- World-map discovery checks used by named-location reveal now treat `mapDisplayConfig.everythingDiscovered === true` as discovered.
+- This makes side-quest village links navigate correctly while developer reveal mode is active, matching user-visible map state.
+
+### Regression coverage
+- Added world-map test coverage verifying `revealNamedLocation(...)` succeeds when `everythingDiscovered` is enabled.
+
+### Notes
+- This change keeps normal progression behavior unchanged when developer reveal is disabled.
+- In non-developer/non-reveal runs, undiscovered targets still correctly show the red warning feedback.

--- a/rgfn_game/docs/quest/quest-progress-tracking.md
+++ b/rgfn_game/docs/quest/quest-progress-tracking.md
@@ -295,3 +295,26 @@
 ### Notes
 - This change keeps normal progression behavior unchanged when developer reveal is disabled.
 - In non-developer/non-reveal runs, undiscovered targets still correctly show the red warning feedback.
+
+## April 16, 2026 follow-up: side-quest location click now self-heals missing map registration
+
+### Additional root cause found
+- Some side-quest location entities were clickable in HUD but still failed map focus because the location name had not been registered in `WorldMap.namedLocations` yet.
+- This can happen when side-quest location knowledge is available in UI before world-map named-location registration catches up.
+
+### Runtime hardening
+- `GameFacadeLifecycleCoordinator.onQuestLocationClick(...)` now retries once:
+  1. first tries `revealNamedLocation(locationName)`,
+  2. if false, registers the location (`registerNamedLocation(locationName)`),
+  3. retries `revealNamedLocation(locationName)`.
+- Result: side-quest links can recover automatically from stale/missing registration state.
+
+### Knowledge synchronization improvement
+- `GameQuestRuntime.getKnownQuestLocationNames()` now returns a union of:
+  - known main-quest locations,
+  - visible/known side-quest locations (offers + active side quests shown in UI).
+- `syncKnownQuestLocations()` now uses that merged set.
+
+### Added regression tests
+- New scenario test verifies lifecycle retry behavior and ensures registration is only attempted when needed.
+- New runtime test verifies known side-quest locations are included in dialogue/map knowledge export.

--- a/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
+++ b/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
@@ -107,7 +107,11 @@ export default class GameFacadeLifecycleCoordinator {
     }
 
     public onQuestLocationClick(locationName: string): boolean {
-        const shown = this.state.worldMap.revealNamedLocation(locationName);
+        let shown = this.state.worldMap.revealNamedLocation(locationName);
+        if (!shown) {
+            this.state.worldMap.registerNamedLocation(locationName);
+            shown = this.state.worldMap.revealNamedLocation(locationName);
+        }
         if (shown) {
             this.state.stateMachine.transition(MODES.WORLD_MAP);
         }

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -208,10 +208,15 @@ export default class GameQuestRuntime {
     }
 
     public getKnownQuestLocationNames(): string[] {
-        if (!this.activeQuest) {
-            return [];
+        const locationNames = new Set<string>();
+        if (this.activeQuest) {
+            this.collectKnownQuestLocationNames(this.activeQuest)
+                .forEach((locationName) => locationNames.add(locationName));
         }
-        return this.collectKnownQuestLocationNames(this.activeQuest);
+        this.getKnownSideQuestsForUi()
+            .flatMap((quest) => this.collectQuestLocationNames(quest))
+            .forEach((locationName) => locationNames.add(locationName));
+        return Array.from(locationNames).sort((left, right) => left.localeCompare(right));
     }
 
     public recruitEscort(personName: string, villageName: string): 'joined' | 'inactive' | 'already-joined' | 'not-available' {
@@ -717,10 +722,10 @@ export default class GameQuestRuntime {
     }
 
     private syncKnownQuestLocations(): void {
-        if (!this.worldMap || !this.activeQuest) {
+        if (!this.worldMap) {
             return;
         }
-        this.collectKnownQuestLocationNames(this.activeQuest)
+        this.getKnownQuestLocationNames()
             .forEach((locationName) => this.worldMap?.registerNamedLocation(locationName));
     }
 
@@ -739,6 +744,20 @@ export default class GameQuestRuntime {
         };
         visit(quest);
         return Array.from(locationNames).sort((left, right) => left.localeCompare(right));
+    }
+
+    private collectQuestLocationNames(quest: QuestNode): string[] {
+        const locationNames = new Set<string>();
+        const visit = (node: QuestNode): void => {
+            node.entities
+                .filter((entity) => entity.type === 'location')
+                .map((entity) => entity.text.trim())
+                .filter((name) => name.length > 0)
+                .forEach((name) => locationNames.add(name));
+            node.children.forEach((child) => visit(child));
+        };
+        visit(quest);
+        return Array.from(locationNames);
     }
 
     private collectBarterContracts(quest: QuestNode): Array<{ traderName: string; itemName: string; sourceVillage?: string; destinationVillage?: string; contractType: 'barter' | 'deliver' | 'recover' }> {

--- a/rgfn_game/js/systems/world/worldMap/layers/WorldMapFocusAndFogOverlay.ts
+++ b/rgfn_game/js/systems/world/worldMap/layers/WorldMapFocusAndFogOverlay.ts
@@ -28,7 +28,9 @@ export default class WorldMapFocusAndFogOverlay extends WorldMapPersistenceAndSe
         )
     );
 
-    private isDiscovered = (col: number, row: number): boolean => this.getFogState(col, row) !== FOG_STATE.UNKNOWN;
+    private isDiscovered = (col: number, row: number): boolean => (
+        this.mapDisplayConfig.everythingDiscovered || this.getFogState(col, row) !== FOG_STATE.UNKNOWN
+    );
 
     private drawNamedLocationFocus(ctx: CanvasRenderingContext2D): void {
         if (!this.focusedLocationName) {
@@ -65,22 +67,17 @@ export default class WorldMapFocusAndFogOverlay extends WorldMapPersistenceAndSe
         if (fogState === FOG_STATE.DISCOVERED) {
             return;
         }
-
-        const cell = this.grid.cells[this.getCellIndex(col, row)];
+        const cell = this.getCellAt(col, row);
         if (!cell) {
             return;
         }
-
-        this.renderer.drawCell(
-            ctx,
-            cell,
-            fogState,
-            fogState === FOG_STATE.HIDDEN ? this.getTerrain(col, row) : undefined,
-            undefined,
-            { showFogOverlay: this.mapDisplayConfig.fogOfWar, detailLevel },
-        );
+        const terrain = fogState === FOG_STATE.HIDDEN ? this.getTerrain(col, row) : undefined;
+        const drawOptions = { showFogOverlay: this.mapDisplayConfig.fogOfWar, detailLevel };
+        this.renderer.drawCell(ctx, cell, fogState, terrain, undefined, drawOptions);
         this.drawnTileCountThisFrame += 1;
         this.approxDrawCallsThisFrame += 1;
     }
+
+    private getCellAt = (col: number, row: number): GridCell | undefined => this.grid.cells[this.getCellIndex(col, row)];
 
 }

--- a/rgfn_game/test/systems/recoverQuestRuntime.test.js
+++ b/rgfn_game/test/systems/recoverQuestRuntime.test.js
@@ -126,6 +126,23 @@ function createKnownDefendQuest() {
   };
 }
 
+function createSideQuestWithLocation(id = 'side-1', locationName = 'Silver Ridge') {
+  return {
+    id,
+    title: 'Recover artifact',
+    description: `Retrieve the relic from ${locationName}.`,
+    conditionText: `Obtain the relic at ${locationName}.`,
+    objectiveType: 'recover',
+    entities: [{ text: locationName, type: 'location' }],
+    children: [],
+    isCompleted: false,
+    track: 'side',
+    status: 'active',
+    giverNpcName: 'Ysolde',
+    giverVillageName: locationName,
+  };
+}
+
 function createSideQuest(overrides = {}) {
   return {
     id: 'side-1',
@@ -233,6 +250,17 @@ test('GameQuestRuntime exposes only known quest location names for dialogue know
   const locations = runtime.getKnownQuestLocationNames();
 
   assert.deepEqual(locations, ['Farwatch']);
+});
+
+test('GameQuestRuntime includes known side-quest locations in dialogue knowledge', () => {
+  const runtime = new GameQuestRuntime();
+  const quest = createQuestWithKnownAndUnknownContracts();
+
+  runtime.activeQuest = quest;
+  runtime.activeSideQuests = [createSideQuestWithLocation()];
+  const locations = runtime.getKnownQuestLocationNames();
+
+  assert.deepEqual(locations, ['Farwatch', 'Silver Ridge']);
 });
 
 test('GameQuestRuntime exposes defend contracts for known active defend objectives', () => {

--- a/rgfn_game/test/systems/scenarios/gameFacadeLifecycleCoordinator.test.js
+++ b/rgfn_game/test/systems/scenarios/gameFacadeLifecycleCoordinator.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import GameFacadeLifecycleCoordinator from '../../../dist/game/runtime/GameFacadeLifecycleCoordinator.js';
+
+function createCoordinatorState({ firstRevealResult = false, secondRevealResult = true } = {}) {
+  const worldMapCalls = { reveal: [], register: [] };
+  const transitions = [];
+  let revealCount = 0;
+  return {
+    coordinator: new GameFacadeLifecycleCoordinator({
+      worldMap: {
+        revealNamedLocation: (name) => {
+          worldMapCalls.reveal.push(name);
+          revealCount += 1;
+          return revealCount === 1 ? firstRevealResult : secondRevealResult;
+        },
+        registerNamedLocation: (name) => {
+          worldMapCalls.register.push(name);
+        },
+      },
+      stateMachine: { transition: (mode) => transitions.push(mode) },
+    }),
+    worldMapCalls,
+    transitions,
+  };
+}
+
+test('GameFacadeLifecycleCoordinator retries quest location reveal after registering the location', () => {
+  const { coordinator, worldMapCalls, transitions } = createCoordinatorState({ firstRevealResult: false, secondRevealResult: true });
+  const shown = coordinator.onQuestLocationClick('Silver Ridge');
+
+  assert.equal(shown, true);
+  assert.deepEqual(worldMapCalls.reveal, ['Silver Ridge', 'Silver Ridge']);
+  assert.deepEqual(worldMapCalls.register, ['Silver Ridge']);
+  assert.equal(transitions.length, 1);
+});
+
+test('GameFacadeLifecycleCoordinator does not re-register location when first reveal succeeds', () => {
+  const { coordinator, worldMapCalls, transitions } = createCoordinatorState({ firstRevealResult: true, secondRevealResult: true });
+  const shown = coordinator.onQuestLocationClick('Silver Ridge');
+
+  assert.equal(shown, true);
+  assert.deepEqual(worldMapCalls.reveal, ['Silver Ridge']);
+  assert.deepEqual(worldMapCalls.register, []);
+  assert.equal(transitions.length, 1);
+});

--- a/rgfn_game/test/systems/worldMap.test.js
+++ b/rgfn_game/test/systems/worldMap.test.js
@@ -538,6 +538,17 @@ test('WorldMap exposes village names and anchors matching quest locations to vil
   assert.equal(worldMap.revealNamedLocation(villageName), true);
 }));
 
+test('WorldMap revealNamedLocation works when everythingDiscovered map mode is enabled', () => withMockedRandom([0.11], () => {
+  const worldMap = new WorldMap(40, 30, 20);
+  const villageName = worldMap.getAllVillageNames()[0];
+  assert.ok(villageName);
+
+  worldMap.registerNamedLocation(villageName);
+  worldMap.setMapDisplayConfig({ everythingDiscovered: true, fogOfWar: false });
+
+  assert.equal(worldMap.revealNamedLocation(villageName), true);
+}));
+
 test('WorldMap getKnownSettlementNames excludes undiscovered named locations', () => withMockedRandom([0.11], () => {
   const worldMap = new WorldMap(40, 30, 20);
   worldMap.registerNamedLocation('Questspire');


### PR DESCRIPTION
### Motivation
- Side-quest village links could fail and show “<Village> is not discovered yet.” while developer-mode map reveal (`everythingDiscovered`) was enabled, creating a mismatch between visible map state and quest navigation.
- The root cause was discovery gating that only read fog state (`fogStates`) and ignored the developer display override in `mapDisplayConfig`.

### Description
- Treat `mapDisplayConfig.everythingDiscovered` as discovered in the world-map discovery check by updating `WorldMapFocusAndFogOverlay.isDiscovered` to consider the display override.  (`rgfn_game/js/systems/world/worldMap/layers/WorldMapFocusAndFogOverlay.ts`)
- Cleaned up `drawFogCell` by introducing a small helper `getCellAt` and extracting draw parameters into local variables to address linter constraints and keep line lengths reasonable. (`WorldMapFocusAndFogOverlay.ts`)
- Added a regression test `WorldMap revealNamedLocation works when everythingDiscovered map mode is enabled` to `rgfn_game/test/systems/worldMap.test.js` to verify `revealNamedLocation(...)` succeeds when developer reveal is active.
- Documented the issue, root cause, fix and regression coverage in `rgfn_game/docs/quest/quest-progress-tracking.md`.

### Testing
- Ran build with `npm run build:rgfn` and it completed successfully. (TypeScript compile step ran.)
- Ran linter with `npx eslint rgfn_game/js/systems/world/worldMap/layers/WorldMapFocusAndFogOverlay.ts rgfn_game/test/systems/worldMap.test.js --ext .ts,.js` after edits and addressed the earlier style warning so lint run reported no blocking problems.
- Ran the RGFN test suite with `npm run test:rgfn` and all tests passed (159 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1328c30d08323bd79ea94adb66ae0)