### PR TITLE
Advance active side quests on runtime events (fix scout completion)

### DIFF
--- a/rgfn_game/docs/quest/quest-progress-tracking.md
+++ b/rgfn_game/docs/quest/quest-progress-tracking.md
@@ -1,5 +1,33 @@
 # Quest progress tracking notes
 
+## April 16, 2026 update: active side-quest objectives now progress from runtime events (including Scout village entry)
+
+- Side-quest progression is no longer passive/UI-only after acceptance.
+- `GameQuestRuntime` now applies runtime objective events to **active side quests** in the same event paths already used for the main quest:
+  - location entry,
+  - barter completion,
+  - monster kill.
+- When an active side quest becomes structurally completed (`isCompleted === true`) after one of these events, runtime now automatically flips side-quest status to:
+  - `readyToTurnIn`
+- This specifically fixes scout-type side quests where entering the target village did not previously advance the accepted quest.
+
+### Implementation details
+
+- Added side-quest progression helpers in `GameQuestRuntime`:
+  - `progressSideQuestsOnLocationEntry(...)`
+  - `progressSideQuestsOnBarterCompletion(...)`
+  - `progressSideQuestsOnMonsterKill(...)`
+  - shared `progressActiveSideQuests(...)` loop.
+- Each active side quest is evaluated with a dedicated `QuestProgressTracker` rooted at that side-quest tree, preserving existing objective-type logic and known-node gating behavior.
+- Existing render + contract refresh behavior remains centralized in the original event handlers (`recordLocationEntry`, `recordBarterCompletion`, `recordMonsterKill`).
+
+### Regression coverage
+
+- Added automated runtime test:
+  - entering the target village for an active scout side quest marks the scout leaf complete,
+  - marks the side-quest root complete,
+  - transitions side-quest status to `readyToTurnIn`.
+
 ## April 8, 2026 update: village dialogue contract visibility now follows known quest frontier
 
 - Non-developer mode village dialogue dropdowns are now aligned with quest knowledge progression:

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -198,8 +198,9 @@ export default class GameQuestRuntime {
             return false;
         }
         const locationChanged = this.questProgressTracker.recordLocationEntryWithInventory(locationName, carriedItemNames);
+        const sideQuestChanged = this.progressSideQuestsOnLocationEntry(locationName, carriedItemNames);
         const escortChanged = this.resolveEscortArrival(locationName);
-        if (!locationChanged && !escortChanged) {
+        if (!locationChanged && !sideQuestChanged && !escortChanged) {
             return false;
         }
         this.renderQuestUi();
@@ -432,7 +433,9 @@ export default class GameQuestRuntime {
         if (!this.questProgressTracker || !this.questUiController || !this.activeQuest) {
             return 'inactive';
         }
-        if (!this.questProgressTracker.recordBarterCompletion(traderName, itemName, villageName)) {
+        const mainQuestChanged = this.questProgressTracker.recordBarterCompletion(traderName, itemName, villageName);
+        const sideQuestChanged = this.progressSideQuestsOnBarterCompletion(traderName, itemName, villageName);
+        if (!mainQuestChanged && !sideQuestChanged) {
             return 'no-objective';
         }
         this.renderQuestUi();
@@ -444,7 +447,9 @@ export default class GameQuestRuntime {
         if (!this.questProgressTracker || !this.questUiController || !this.activeQuest) {
             return false;
         }
-        if (!this.questProgressTracker.recordMonsterKill(monsterName)) {
+        const mainQuestChanged = this.questProgressTracker.recordMonsterKill(monsterName);
+        const sideQuestChanged = this.progressSideQuestsOnMonsterKill(monsterName);
+        if (!mainQuestChanged && !sideQuestChanged) {
             return false;
         }
         this.renderQuestUi();
@@ -1197,6 +1202,37 @@ export default class GameQuestRuntime {
             known.push(sideQuest);
         }
         return known;
+    }
+
+    private progressSideQuestsOnLocationEntry(locationName: string, carriedItemNames: string[]): boolean {
+        return this.progressActiveSideQuests((tracker) => tracker.recordLocationEntryWithInventory(locationName, carriedItemNames));
+    }
+
+    private progressSideQuestsOnBarterCompletion(traderName: string, itemName: string, villageName: string): boolean {
+        return this.progressActiveSideQuests((tracker) => tracker.recordBarterCompletion(traderName, itemName, villageName));
+    }
+
+    private progressSideQuestsOnMonsterKill(monsterName: string): boolean {
+        return this.progressActiveSideQuests((tracker) => tracker.recordMonsterKill(monsterName));
+    }
+
+    private progressActiveSideQuests(progressFn: (tracker: QuestProgressTracker) => boolean): boolean {
+        let changed = false;
+        for (const sideQuest of this.activeSideQuests) {
+            if (sideQuest.status !== 'active') {
+                continue;
+            }
+            const tracker = new QuestProgressTracker(sideQuest);
+            const questChanged = progressFn(tracker);
+            if (!questChanged) {
+                continue;
+            }
+            changed = true;
+            if (sideQuest.isCompleted) {
+                sideQuest.status = 'readyToTurnIn';
+            }
+        }
+        return changed;
     }
 
     private randomInt(min: number, max: number): number {

--- a/rgfn_game/test/systems/recoverQuestRuntime.test.js
+++ b/rgfn_game/test/systems/recoverQuestRuntime.test.js
@@ -161,6 +161,35 @@ function createSideQuest(overrides = {}) {
   };
 }
 
+function createActiveScoutSideQuest(overrides = {}) {
+  return {
+    id: 'side-scout',
+    title: 'Scout Golden Beacon',
+    description: 'Travel to Golden Beacon and secure the path.',
+    conditionText: 'Complete the listed task and return to the quest giver.',
+    objectiveType: 'scout',
+    entities: [],
+    children: [
+      {
+        id: 'side-scout.1',
+        title: 'Scout Golden Beacon',
+        description: 'Travel to Golden Beacon and secure the path.',
+        conditionText: 'Enter Golden Beacon.',
+        objectiveType: 'scout',
+        entities: [{ text: 'Golden Beacon', type: 'location' }],
+        children: [],
+        isCompleted: false,
+      },
+    ],
+    isCompleted: false,
+    track: 'side',
+    giverNpcName: 'Rica',
+    giverVillageName: 'Selzen',
+    status: 'active',
+    ...overrides,
+  };
+}
+
 test('GameQuestRuntime revealRecoverHolder confirms target person when speaking with another villager', () => {
   const runtime = new GameQuestRuntime();
   const quest = createRecoverQuest();
@@ -412,4 +441,22 @@ test('GameQuestRuntime side-quest turn-in requires the original quest giver and 
   const success = runtime.turnInSideQuest('side-turnin', 'Mira', 'Ashford');
   assert.equal(success.turnedIn, true);
   assert.equal(runtime.activeSideQuests[0].status, 'completed');
+});
+
+test('GameQuestRuntime marks active scout side quests ready to turn in after entering objective village', () => {
+  const runtime = new GameQuestRuntime();
+  const mainQuest = createQuestWithKnownAndUnknownContracts();
+  const sideQuest = createActiveScoutSideQuest();
+  runtime.activeQuest = mainQuest;
+  runtime.questProgressTracker = new QuestProgressTracker(mainQuest);
+  runtime.questUiController = { renderQuest: () => {} };
+  runtime.refreshContracts = () => {};
+  runtime.activeSideQuests = [sideQuest];
+
+  const updated = runtime.recordLocationEntry('Golden Beacon', []);
+
+  assert.equal(updated, true);
+  assert.equal(sideQuest.children[0].isCompleted, true);
+  assert.equal(sideQuest.isCompleted, true);
+  assert.equal(sideQuest.status, 'readyToTurnIn');
 });


### PR DESCRIPTION
### Motivation
- Scout-type side quests did not progress when the player entered the target village because side-quest progression was only driven by UI/main-quest trackers. 
- Make accepted side quests fully playable by applying the same runtime events used for main-quest progression to active side quests.

### Description
- Update `GameQuestRuntime` to invoke side-quest progression from runtime event handlers by enhancing `recordLocationEntry`, `recordBarterCompletion`, and `recordMonsterKill` to also consider side-quest changes. 
- Add helper methods `progressSideQuestsOnLocationEntry`, `progressSideQuestsOnBarterCompletion`, `progressSideQuestsOnMonsterKill`, and a shared `progressActiveSideQuests` loop that evaluates each active side quest with a fresh `QuestProgressTracker` and flips completed side quests to `readyToTurnIn`. 
- Add a unit test (`recoverQuestRuntime.test.js`) that creates an active scout side quest and verifies entering the objective village marks the scout leaf complete, marks the side-quest root complete, and transitions the side quest to `readyToTurnIn`. 
- Update documentation (`rgfn_game/docs/quest/quest-progress-tracking.md`) with an April 16, 2026 note describing the change, helper APIs, and regression coverage.

### Testing
- Ran `npm run build:rgfn` which completed successfully. 
- Ran `npm run test:rgfn` which completed successfully (all tests passed, including the new side-quest regression). 
- Ran targeted ESLint on the modified files with `npx eslint rgfn_game/js/game/runtime/GameQuestRuntime.ts rgfn_game/test/systems/recoverQuestRuntime.test.js` which passed for the touched files. 
- Running the full lint pipeline `npm run lint:ts:rgfn` still reports pre-existing, repository-wide lint/config issues unrelated to these changes (including `dist/` rule-definition noise), but the change itself and added test pass the targeted checks and automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e148036c748323957c6536576bd58b)