### PR TITLE
RGFN: auto-complete recover side quests on village-entry item discovery

### DIFF
--- a/rgfn_game/docs/quest/quest-progress-tracking.md
+++ b/rgfn_game/docs/quest/quest-progress-tracking.md
@@ -28,6 +28,23 @@
   - marks the side-quest root complete,
   - transitions side-quest status to `readyToTurnIn`.
 
+## April 16, 2026 update: recover side quests now complete through village-entry item discovery
+
+- Recover-type **side quests** now use one completion path: entering the objective village auto-discovers the recover item as a ground find.
+- Runtime now emits explicit village-entry logs for this path:
+  - item acquisition context (`Found <item> lying on the ground in <village>`),
+  - side-quest readiness (`Side quest ready to turn in: <title>`).
+- `GameQuestRuntime.recordLocationEntry(...)` now accepts an optional recovered-item callback so discovered recover items are immediately granted to player inventory.
+- Main quest recover confrontation flow remains unchanged in this update; this change targets side-quest recover playability/completion.
+
+### Regression coverage
+
+- Added automated runtime test:
+  - entering a recover side-quest village auto-completes the objective,
+  - grants the recover item through callback,
+  - emits acquisition log text,
+  - sets side-quest status to `readyToTurnIn`.
+
 ## April 8, 2026 update: village dialogue contract visibility now follows known quest frontier
 
 - Non-developer mode village dialogue dropdowns are now aligned with quest knowledge progression:

--- a/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
+++ b/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
@@ -203,11 +203,13 @@ export default class GameFacadeLifecycleCoordinator {
 
     public onVillageEntered(): void {
         const villageName = this.state.worldMap.getVillageNameAtPlayerPosition();
-        const questChanged = this.state.questRuntime.recordLocationEntry(
+        const questUpdate = this.state.questRuntime.recordLocationEntry(
             villageName,
             this.state.player.getInventory().map((item) => item.name),
+            (item) => this.state.player.addItemToInventory(item),
         );
-        if (questChanged) {
+        questUpdate.logs.forEach((line) => this.state.hudCoordinator.addBattleLog(line, 'system-message'));
+        if (questUpdate.changed) {
             this.state.hudCoordinator.addBattleLog(`Quest tracker: objectives updated at ${villageName}.`, 'system');
         }
         this.refreshGroupPanel();

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -193,19 +193,23 @@ export default class GameQuestRuntime {
         return true;
     }
 
-    public recordLocationEntry(locationName: string, carriedItemNames: string[]): boolean {
+    public recordLocationEntry(
+        locationName: string,
+        carriedItemNames: string[],
+        onRecoveredItemFound?: (item: Item) => boolean,
+    ): { changed: boolean; logs: string[] } {
         if (!this.questProgressTracker || !this.questUiController || !this.activeQuest) {
-            return false;
+            return { changed: false, logs: [] };
         }
         const locationChanged = this.questProgressTracker.recordLocationEntryWithInventory(locationName, carriedItemNames);
-        const sideQuestChanged = this.progressSideQuestsOnLocationEntry(locationName, carriedItemNames);
+        const sideQuestProgress = this.progressSideQuestsOnLocationEntry(locationName, carriedItemNames, onRecoveredItemFound);
         const escortChanged = this.resolveEscortArrival(locationName);
-        if (!locationChanged && !sideQuestChanged && !escortChanged) {
-            return false;
+        if (!locationChanged && !sideQuestProgress.changed && !escortChanged) {
+            return { changed: false, logs: sideQuestProgress.logs };
         }
         this.renderQuestUi();
         this.refreshContracts();
-        return true;
+        return { changed: true, logs: sideQuestProgress.logs };
     }
 
     public getKnownQuestLocationNames(): string[] {
@@ -1204,8 +1208,42 @@ export default class GameQuestRuntime {
         return known;
     }
 
-    private progressSideQuestsOnLocationEntry(locationName: string, carriedItemNames: string[]): boolean {
-        return this.progressActiveSideQuests((tracker) => tracker.recordLocationEntryWithInventory(locationName, carriedItemNames));
+    private progressSideQuestsOnLocationEntry(
+        locationName: string,
+        carriedItemNames: string[],
+        onRecoveredItemFound?: (item: Item) => boolean,
+    ): { changed: boolean; logs: string[] } {
+        const normalizedLocation = locationName.trim();
+        const lines: string[] = [];
+        let changed = false;
+
+        for (const sideQuest of this.activeSideQuests) {
+            if (sideQuest.status !== 'active') {
+                continue;
+            }
+
+            const tracker = new QuestProgressTracker(sideQuest);
+            let sideQuestChanged = false;
+            const recoverLogs = this.autoRecoverSideQuestItems(sideQuest, normalizedLocation, onRecoveredItemFound);
+            if (recoverLogs.length > 0) {
+                recoverLogs.forEach((line) => lines.push(line));
+                tracker.recomputeCompletion();
+                sideQuestChanged = true;
+            }
+            if (tracker.recordLocationEntryWithInventory(locationName, carriedItemNames)) {
+                sideQuestChanged = true;
+            }
+            if (!sideQuestChanged) {
+                continue;
+            }
+            changed = true;
+            if (sideQuest.isCompleted) {
+                sideQuest.status = 'readyToTurnIn';
+                lines.push(`Side quest ready to turn in: ${sideQuest.title}.`);
+            }
+        }
+
+        return { changed, logs: lines };
     }
 
     private progressSideQuestsOnBarterCompletion(traderName: string, itemName: string, villageName: string): boolean {
@@ -1214,6 +1252,37 @@ export default class GameQuestRuntime {
 
     private progressSideQuestsOnMonsterKill(monsterName: string): boolean {
         return this.progressActiveSideQuests((tracker) => tracker.recordMonsterKill(monsterName));
+    }
+
+    private autoRecoverSideQuestItems(
+        sideQuest: QuestNode,
+        locationName: string,
+        onRecoveredItemFound?: (item: Item) => boolean,
+    ): string[] {
+        const normalizedLocation = locationName.trim().toLocaleLowerCase();
+        if (!normalizedLocation) {
+            return [];
+        }
+        const logs: string[] = [];
+        this.visitQuestNodes(sideQuest, (node) => {
+            if (node.objectiveType !== 'recover' || node.children.length > 0 || node.isCompleted) {
+                return;
+            }
+            const recover = node.objectiveData?.recover;
+            if (!recover || recover.currentVillage.trim().toLocaleLowerCase() !== normalizedLocation) {
+                return;
+            }
+            node.isCompleted = true;
+            recover.isPersonKnown = true;
+            const recoverItem = this.createRecoverQuestItem(recover.itemName);
+            const wasAdded = onRecoveredItemFound ? onRecoveredItemFound(recoverItem) : true;
+            if (wasAdded) {
+                logs.push(`Quest tracker: Found ${recover.itemName} lying on the ground in ${recover.currentVillage}.`);
+                return;
+            }
+            logs.push(`Quest tracker: Found ${recover.itemName} in ${recover.currentVillage}, but your inventory is full.`);
+        });
+        return logs;
     }
 
     private progressActiveSideQuests(progressFn: (tracker: QuestProgressTracker) => boolean): boolean {

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -211,8 +211,8 @@ export default class GameQuestRuntime {
         const sideQuestProgress = this.progressSideQuestsOnLocationEntry(locationName, carriedItemNames, onRecoveredItemFound);
         const escortChanged = this.resolveEscortArrival(locationName);
         const sideQuestDeliveryChanged = this.updateSideQuestDeliveryProgress(locationName, carriedItemNames);
-        if (!locationChanged && !escortChanged && !sideQuestDeliveryChanged && !sideQuestChanged && !sideQuestProgress.changed) {
-            return false;
+        if (!locationChanged && !escortChanged && !sideQuestDeliveryChanged && !sideQuestProgress.changed) {
+            return { changed: false, logs: sideQuestProgress.logs };
         }
         this.renderQuestUi();
         this.refreshContracts();

--- a/rgfn_game/test/systems/recoverQuestRuntime.test.js
+++ b/rgfn_game/test/systems/recoverQuestRuntime.test.js
@@ -190,6 +190,34 @@ function createActiveScoutSideQuest(overrides = {}) {
   };
 }
 
+function createActiveRecoverSideQuest(overrides = {}) {
+  return {
+    id: 'side-recover',
+    title: 'Recover Torlys Eshlor',
+    description: 'Retrieve Torlys Eshlor from Golden Beacon.',
+    conditionText: 'Obtain Torlys Eshlor at Golden Beacon.',
+    objectiveType: 'recover',
+    entities: [{ text: 'Torlys Eshlor', type: 'item' }, { text: 'Golden Beacon', type: 'location' }],
+    objectiveData: {
+      recover: {
+        itemName: 'Torlys Eshlor',
+        personName: 'Unknown',
+        initialVillage: 'Golden Beacon',
+        currentVillage: 'Golden Beacon',
+        isPersonKnown: false,
+        hasFled: false,
+      },
+    },
+    children: [],
+    isCompleted: false,
+    track: 'side',
+    giverNpcName: 'Rica',
+    giverVillageName: 'Selzen',
+    status: 'active',
+    ...overrides,
+  };
+}
+
 test('GameQuestRuntime revealRecoverHolder confirms target person when speaking with another villager', () => {
   const runtime = new GameQuestRuntime();
   const quest = createRecoverQuest();
@@ -455,8 +483,31 @@ test('GameQuestRuntime marks active scout side quests ready to turn in after ent
 
   const updated = runtime.recordLocationEntry('Golden Beacon', []);
 
-  assert.equal(updated, true);
+  assert.equal(updated.changed, true);
   assert.equal(sideQuest.children[0].isCompleted, true);
+  assert.equal(sideQuest.isCompleted, true);
+  assert.equal(sideQuest.status, 'readyToTurnIn');
+});
+
+test('GameQuestRuntime auto-recovers side-quest recover items on village entry and marks quest ready to turn in', () => {
+  const runtime = new GameQuestRuntime();
+  const mainQuest = createQuestWithKnownAndUnknownContracts();
+  const sideQuest = createActiveRecoverSideQuest();
+  const foundItems = [];
+  runtime.activeQuest = mainQuest;
+  runtime.questProgressTracker = new QuestProgressTracker(mainQuest);
+  runtime.questUiController = { renderQuest: () => {} };
+  runtime.refreshContracts = () => {};
+  runtime.activeSideQuests = [sideQuest];
+
+  const updated = runtime.recordLocationEntry('Golden Beacon', [], (item) => {
+    foundItems.push(item.name);
+    return true;
+  });
+
+  assert.equal(updated.changed, true);
+  assert.equal(foundItems.includes('Torlys Eshlor'), true);
+  assert.equal(updated.logs.some((line) => line.includes('Found Torlys Eshlor lying on the ground in Golden Beacon')), true);
   assert.equal(sideQuest.isCompleted, true);
   assert.equal(sideQuest.status, 'readyToTurnIn');
 });


### PR DESCRIPTION
### Motivation
- Recover-type side quests were not reliably completable because the player had no deterministic way to acquire the quest item without running confrontation flows. 
- Provide a single, reliable completion path for side recover quests by treating the item as a world find on entering the objective village so side quests can be completed and turned in.

### Description
- `GameQuestRuntime.recordLocationEntry(...)` signature changed to return `{ changed, logs }` and accept an optional `onRecoveredItemFound` callback so discovered recover items can be granted to the player immediately.
- Added auto-recovery logic for active side quests: `progressSideQuestsOnLocationEntry(...)` now calls `autoRecoverSideQuestItems(...)` which marks recover leaves complete, builds the recover item, calls the provided inventory callback, and emits discovery logs.
- `GameFacadeLifecycleCoordinator.onVillageEntered()` now passes the player inventory callback into `recordLocationEntry(...)` and forwards any recover discovery logs to the HUD battle log while preserving the existing generic objective-update message.
- Added unit test coverage and fixtures in `recoverQuestRuntime.test.js` for the new behavior and updated docs in `docs/quest/quest-progress-tracking.md` describing the village-entry recover flow.

### Testing
- Built the rgfn project with `npm run build:rgfn` and the build completed successfully.
- Ran the full rgfn test suite with `npm run test:rgfn` and all tests passed (163 tests, 0 failures), including the new recover-side-quest test.
- Ran `npx eslint` against the two modified runtime files and it passed for those targets; a repo-wide lint run (`npm run lint:ts:rgfn`) still fails due to pre-existing style-guide rule resolution issues and unrelated lint errors in generated/other files outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14c6ef0848323bf387da9b47da795)