### PR TITLE
RGFN: add side-quest refusal UX and make NPC dialogue modal scrollable

### DIFF
--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -189,3 +189,18 @@
   - turn-in completion.
 - This prevents stale HUD state where village-side quest cards update but HUD Quests panel does not.
   - Offer cards remain labeled **Offer available** and include an **Accept quest** button.
+
+## 2026-04-16: Side-quest offer refusal (hide clutter without accepting)
+
+- Village NPC dialogue side-quest cards now expose a second explicit offer action:
+  - **Accept quest** (existing behavior),
+  - **Refuse** (new behavior).
+- Refuse behavior is intentionally non-destructive:
+  - the offer is **hidden from the selected NPC side-quest panel** to reduce clutter,
+  - no runtime acceptance occurs,
+  - no quest progress/status mutation occurs.
+- Scope/identity of hidden offers:
+  - hides a **specific offer ID** only,
+  - does **not** block future offers from that same NPC.
+- Practical UX effect:
+  - if multiple offers exist, player can decline noisy ones and keep only relevant cards visible in the dialogue panel.

--- a/rgfn_game/docs/village/village-dialogue-modal.md
+++ b/rgfn_game/docs/village/village-dialogue-modal.md
@@ -115,6 +115,17 @@ File: `rgfn_game/test/systems/villageActionsController.test.js`.
   - Escape handling exits early when the modal is hidden, avoiding redundant close calls.
   - Existing world map keyboard zoom handling remains isolated in its own keydown branch.
 
+## Follow-up pitfall fixed (April 16, 2026, layout/overflow)
+
+- Symptom: when side-quest cards grew in count/height, the dialogue popup content could overflow beyond viewport bounds with inaccessible controls.
+- Root cause: modal panel had fixed max-height but no own vertical scrolling, so inner sections could extend outside visible area.
+- Fix:
+  - `village-dialogue-panel` now uses `overflow-y: auto`, making the whole NPC dialogue panel scroll like other HUD/panel surfaces.
+  - Side-quest offer cards now use a compact two-button row (`Accept quest` + `Refuse`) to reduce vertical pressure per card.
+- Result:
+  - all dialogue sections remain reachable,
+  - modal behaves consistently with other scrollable panels under high-content scenarios.
+
 ## Notes for future extension
 
 - If needed, next step is to render only NPC conversation lines in modal (filter by tags), while keeping full system log in main log panel.

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -28,6 +28,7 @@ export default class VillageActionsController {
     private defendContracts: QuestDefendContract[] = [];
     private activeNpcSideQuestIds: Set<string> = new Set();
     private readySideQuestLogIds: Set<string> = new Set();
+    private dismissedSideQuestOfferIds: Set<string> = new Set();
     private knownNpcNames: Set<string> = new Set();
     private joinedEscortNpcKeys: Set<string> = new Set();
 
@@ -142,6 +143,22 @@ export default class VillageActionsController {
             return;
         }
         this.completeSideQuestTurnIn(selectedNpc, questId, result.reward);
+    }
+
+    public handleDismissSideQuestOffer(questId: string): void {
+        const selectedNpc = this.getSelectedNpc();
+        if (!selectedNpc) {
+            this.addLog('Choose an NPC before refusing a side quest offer.', 'system');
+            return;
+        }
+        if (this.dismissedSideQuestOfferIds.has(questId)) {
+            return;
+        }
+        const offers = this.callbacks.getVillageSideQuestOffers?.(this.currentVillageName, selectedNpc.name) ?? [];
+        const questTitle = offers.find((quest) => quest.id === questId)?.title ?? questId;
+        this.dismissedSideQuestOfferIds.add(questId);
+        this.addLog(`Side-quest offer hidden: ${questTitle}.`, 'system-message');
+        this.refreshSelectedNpcSideQuestUi(selectedNpc);
     }
 
     public handleAskAboutSettlement(): void { this.dialogueInteraction.handleAskAboutSettlement(); this.callbacks.onAdvanceTime(14, 0.1); }
@@ -491,15 +508,16 @@ export default class VillageActionsController {
     // eslint-disable-next-line style-guide/function-length-warning
     private refreshSelectedNpcSideQuestUi(npc: VillageNpcProfile): void {
         const offers = this.callbacks.getVillageSideQuestOffers?.(this.currentVillageName, npc.name) ?? [];
+        const visibleOffers = offers.filter((offer) => !this.dismissedSideQuestOfferIds.has(offer.id));
         const activeQuests = this.callbacks.getVillageNpcActiveSideQuests?.(this.currentVillageName, npc.name) ?? [];
         const readyToTurnInCount = activeQuests.filter((quest) => quest.status === 'readyToTurnIn').length;
-        this.renderSideQuestUiForNpc(npc, offers, activeQuests);
+        this.renderSideQuestUiForNpc(npc, visibleOffers, activeQuests);
         this.addLog(
-            `Side-quest board updated for ${npc.name}: ${offers.length} offer${offers.length === 1 ? '' : 's'}, `
+            `Side-quest board updated for ${npc.name}: ${visibleOffers.length} offer${visibleOffers.length === 1 ? '' : 's'}, `
             + `${activeQuests.length} active, ${readyToTurnInCount} ready to turn in.`,
             'system-message',
         );
-        if (offers.length === 0 && activeQuests.length > 0) {
+        if (visibleOffers.length === 0 && activeQuests.length > 0) {
             this.addLog(
                 `No new side-quest offers from ${npc.name}. ${activeQuests.length} quest${activeQuests.length === 1 ? '' : 's'} `
                 + 'already in progress from earlier acceptance.',
@@ -550,7 +568,11 @@ export default class VillageActionsController {
 
     private appendSideQuestCardAction(card: HTMLElement, quest: QuestNode, isOffer: boolean): void {
         if (isOffer) {
-            card.appendChild(this.createSideQuestActionButton('Accept quest', () => this.handleAcceptSideQuest(quest.id)));
+            const actionRow = document.createElement('div');
+            actionRow.className = 'village-side-quest-actions';
+            actionRow.appendChild(this.createSideQuestActionButton('Accept quest', () => this.handleAcceptSideQuest(quest.id)));
+            actionRow.appendChild(this.createSideQuestActionButton('Refuse', () => this.handleDismissSideQuestOffer(quest.id), 'Refuse and hide this offer'));
+            card.appendChild(actionRow);
             return;
         }
         if (quest.status === 'readyToTurnIn') {
@@ -558,16 +580,20 @@ export default class VillageActionsController {
         }
     }
 
-    private createSideQuestActionButton(label: string, onClick: () => void): HTMLButtonElement {
+    private createSideQuestActionButton(label: string, onClick: () => void, ariaLabel?: string): HTMLButtonElement {
         const button = document.createElement('button');
         button.type = 'button';
         button.className = 'action-btn';
         button.textContent = label;
+        if (ariaLabel) {
+            button.ariaLabel = ariaLabel;
+        }
         button.addEventListener('click', onClick);
         return button;
     }
 
     private completeSideQuestAccept(selectedNpc: VillageNpcProfile, questId: string): void {
+        this.dismissedSideQuestOfferIds.delete(questId);
         this.activeNpcSideQuestIds.add(questId);
         const quests = this.callbacks.getVillageNpcActiveSideQuests?.(this.currentVillageName, selectedNpc.name) ?? [];
         const acceptedQuest = quests.find((quest) => quest.id === questId);

--- a/rgfn_game/style.css
+++ b/rgfn_game/style.css
@@ -1464,6 +1464,7 @@ button.quest-entity-name.location:hover {
     max-height: min(82vh, 760px);
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
     gap: 10px;
     padding: 12px;
     border-radius: 8px;
@@ -1537,6 +1538,15 @@ button.quest-entity-name.location:hover {
 .village-side-quest-card p {
     margin: 0;
     font-size: 12px;
+}
+
+.village-side-quest-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.village-side-quest-actions .action-btn {
+    flex: 1;
 }
 
 .village-dialogue-actions {

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -104,6 +104,14 @@ function createVillageUi() {
   };
 }
 
+function containsTextInTree(element, text) {
+  if (element.textContent === text) {
+    return true;
+  }
+  const children = Array.isArray(element.children) ? element.children : [];
+  return children.some((child) => containsTextInTree(child, text));
+}
+
 function createPlayerStub() {
   const inventory = [];
   return {
@@ -724,11 +732,57 @@ test('VillageActionsController requires explicit side-quest acceptance and expos
   controller.handleSelectNpc(0);
 
   assert.equal(acceptCalls, 0);
-  const acceptButton = villageUI.sideQuestList.children.find((child) => child.children?.some((entry) => entry.textContent === 'Accept quest'));
+  const acceptButton = villageUI.sideQuestList.children.find((child) => containsTextInTree(child, 'Accept quest'));
   assert.ok(acceptButton);
+  const hasRefuseButton = villageUI.sideQuestList.children.some((child) => containsTextInTree(child, 'Refuse'));
+  assert.equal(hasRefuseButton, true);
   controller.handleAcceptSideQuest('side-quest-offer');
   assert.equal(acceptCalls, 1);
   assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Side quest accepted')), true);
+}));
+
+test('VillageActionsController allows refusing a side-quest offer and keeps other offers visible', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  const firstOffer = {
+    id: 'side-quest-offer-1',
+    title: 'Patch the Mill Wheel',
+    description: 'Bring repair tools to the village mill.',
+    reward: '20g',
+    status: 'available',
+    children: [],
+  };
+  const secondOffer = {
+    id: 'side-quest-offer-2',
+    title: 'Track Missing Cart',
+    description: 'Follow wheel marks east of the ford.',
+    reward: '18g',
+    status: 'available',
+    children: [],
+  };
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onLeaveVillage: () => {},
+    onAdvanceTime: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+    getVillageSideQuestOffers: () => [firstOffer, secondOffer],
+    getVillageNpcActiveSideQuests: () => [],
+  });
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'moss-0', name: 'Mara', role: 'Trader', look: 'cloak', speechStyle: 'calm', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Mossbrook');
+  controller.handleSelectNpc(0);
+  assert.equal(villageUI.sideQuestList.children.length, 2);
+
+  controller.handleDismissSideQuestOffer('side-quest-offer-1');
+  assert.equal(villageUI.sideQuestList.children.length, 1);
+  assert.equal(villageUI.sideQuestList.children[0].children.some((entry) => entry.textContent?.includes('Track Missing Cart')), true);
+  assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Side-quest offer hidden')), true);
 }));
 
 test('VillageActionsController does not auto-accept side quests in developer mode', () => withDeveloperMode(true, () => withDocumentStub(() => {
@@ -763,7 +817,7 @@ test('VillageActionsController does not auto-accept side quests in developer mod
   controller.handleSelectNpc(0);
 
   assert.equal(acceptCalls, 0);
-  const hasAcceptButton = villageUI.sideQuestList.children.some((child) => child.children?.some((entry) => entry.textContent === 'Accept quest'));
+  const hasAcceptButton = villageUI.sideQuestList.children.some((child) => containsTextInTree(child, 'Accept quest'));
   assert.equal(hasAcceptButton, true);
   assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Auto-accepted side quests')), false);
 })));


### PR DESCRIPTION
### Motivation
- Side-quest offers in the RGFN NPC dialogue were cluttering the modal and could overflow the viewport with no way to scroll, making some controls unreachable.
- Players need a quick way to hide unwanted offers per-NPC without accepting them so future offers can still appear normally.

### Description
- Added an in-controller refuse/ hide mechanism by introducing `dismissedSideQuestOfferIds` and a public `handleDismissSideQuestOffer(questId)` to hide specific offer IDs from the selected NPC panel without mutating quest runtime state (file: `rgfn_game/js/systems/village/VillageActionsController.ts`).
- Filtered visible offers in `refreshSelectedNpcSideQuestUi(...)` so dismissed offers are excluded and acceptance clears any previously dismissed ID for that quest (keeps future offers unaffected).
- Reworked offer card actions to a compact action row rendering both `Accept quest` and `Refuse` buttons, and extended `createSideQuestActionButton(...)` to accept an optional `ariaLabel` (CSS: `rgfn_game/style.css` adds `.village-side-quest-actions` and makes `.village-dialogue-panel` vertically scrollable via `overflow-y: auto`).
- Added/updated scenario tests to validate the new UI and behavior, and documented the UX/layout fixes in `rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md` and `rgfn_game/docs/village/village-dialogue-modal.md`.

### Testing
- Ran `npm run build:rgfn` and the TypeScript build completed successfully. ✅
- Linted the modified files with `npx eslint rgfn_game/js/systems/village/VillageActionsController.ts rgfn_game/test/systems/scenarios/villageActionsController.test.js` and the checks passed for those files. ✅
- Executed the RGFN test suite with `npm run test:rgfn` and all tests passed (162 tests, 0 failures). ✅
- Running the full repo lint `npm run lint:ts:rgfn` surfaced many pre-existing style-guide rules and unrelated warnings/errors outside the scope of these changes and therefore failed; this PR limits lint fixes to the touched files only. ❌

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14d9335948323b7c86069c40e1339)