### PR TITLE
RGFN: add active-only filter toggle for Side Quests tab (tab-aware quest-mode checkbox)

### DIFF
--- a/rgfn_game/docs/quest/quest-progress-tracking.md
+++ b/rgfn_game/docs/quest/quest-progress-tracking.md
@@ -131,18 +131,23 @@
   - verifies known-only defaults to checked when there is no saved preference,
   - verifies stored `'0'`/`'1'` values are restored and updated as user toggles the checkbox.
 
-## April 16, 2026 update: side-quest tab "active only" filter toggle
+## April 17, 2026 update: side-quest status filter popup with Apply flow
 
-- The quest-mode checkbox is now tab-aware instead of being effectively main-only:
-  - **Main Quests** tab label remains `Show only known/current quests`.
-  - **Side Quests** tab label switches to `Show only active side quests`.
-- Side-tab behavior:
-  - checkbox is ON by default,
-  - when ON, side-quest cards with status `available` are hidden,
-  - accepted/known side quests remain visible.
+- Side Quests tab no longer uses the quest-mode checkbox.
+- New side-tab control is a **Filter statuses** button with popup checklist + **Apply** button.
+- Available statuses:
+  - `Active`
+  - `Available`
+  - `Ready to turn in`
+  - `Completed`
+- Apply behavior:
+  - checkbox changes in popup are staged until **Apply** is clicked,
+  - at least one status must remain selected; applying zero statuses is blocked with an error message.
+- Default visible set:
+  - `Active`, `Ready to turn in`, `Completed` (with `Available` hidden by default).
 - Persistence:
-  - main-tab state still uses `rgfn_quests_known_only_toggle_v1`,
-  - side-tab state now uses `rgfn_side_quests_active_only_toggle_v1`.
+  - main-tab known-only checkbox continues to use `rgfn_quests_known_only_toggle_v1`,
+  - side-tab status selection is stored in `rgfn_side_quests_status_filter_v1` as CSV (e.g. `active,readyToTurnIn,completed`).
 
 ## March 28, 2026 update: "is not discovered yet" quest-panel warning now auto-hides
 

--- a/rgfn_game/docs/quest/quest-progress-tracking.md
+++ b/rgfn_game/docs/quest/quest-progress-tracking.md
@@ -131,6 +131,19 @@
   - verifies known-only defaults to checked when there is no saved preference,
   - verifies stored `'0'`/`'1'` values are restored and updated as user toggles the checkbox.
 
+## April 16, 2026 update: side-quest tab "active only" filter toggle
+
+- The quest-mode checkbox is now tab-aware instead of being effectively main-only:
+  - **Main Quests** tab label remains `Show only known/current quests`.
+  - **Side Quests** tab label switches to `Show only active side quests`.
+- Side-tab behavior:
+  - checkbox is ON by default,
+  - when ON, side-quest cards with status `available` are hidden,
+  - accepted/known side quests remain visible.
+- Persistence:
+  - main-tab state still uses `rgfn_quests_known_only_toggle_v1`,
+  - side-tab state now uses `rgfn_side_quests_active_only_toggle_v1`.
+
 ## March 28, 2026 update: "is not discovered yet" quest-panel warning now auto-hides
 
 ### What changed

--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -176,13 +176,23 @@
   - each card contains the full nested quest objective tree under that side-quest root.
 - Status chips are shown in the Side Quests tab:
   - `Available`, `Active`, `Ready to turn in`, `Completed`.
-- Tab-aware checkbox UX:
-  - **Main Quests** tab keeps the existing checkbox label: `Show only known/current quests`.
-  - **Side Quests** tab now reuses the same checkbox control but changes label to: `Show only active side quests`.
-  - Side-tab checkbox defaults to checked and filters out `available` side-quest offers in the HUD list.
-  - Side-tab checkbox state is persisted separately from main-tab known/current state:
-    - `rgfn_quests_known_only_toggle_v1` for main quests
-    - `rgfn_side_quests_active_only_toggle_v1` for side quests
+- Side-tab status filter UX:
+  - **Main Quests** tab keeps the existing checkbox `Show only known/current quests`.
+  - **Side Quests** tab now shows a dedicated **Filter statuses** button.
+  - Clicking **Filter statuses** opens a popup list with checkboxes for:
+    - `Active`
+    - `Available`
+    - `Ready to turn in`
+    - `Completed`
+  - Popup applies changes only after clicking **Apply**.
+  - Default side-tab filter set is:
+    - `Active` ✅
+    - `Ready to turn in` ✅
+    - `Completed` ✅
+    - `Available` ❌
+  - Side-tab filter is persisted in local storage as comma-separated statuses:
+    - key: `rgfn_side_quests_status_filter_v1`
+    - example: `active,readyToTurnIn,completed`
 
 ### Runtime/UI synchronization notes
 

--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -193,6 +193,9 @@
   - Side-tab filter is persisted in local storage as comma-separated statuses:
     - key: `rgfn_side_quests_status_filter_v1`
     - example: `active,readyToTurnIn,completed`
+  - UI wiring note:
+    - `#quests-side-filter-controls` must not keep the global `hidden` utility class in markup.
+    - Visibility is controlled by `QuestUiController` via tab-aware `style.display`; leaving `hidden` on the container will keep the button invisible even on Side Quests tab.
 
 ### Runtime/UI synchronization notes
 

--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -176,9 +176,13 @@
   - each card contains the full nested quest objective tree under that side-quest root.
 - Status chips are shown in the Side Quests tab:
   - `Available`, `Active`, `Ready to turn in`, `Completed`.
-- Main-tab-only UX:
-  - `Show only known/current quests` checkbox remains visible and active only on **Main Quests** tab,
-  - checkbox is hidden on **Side Quests** tab to avoid implying unknown-side-quest filtering.
+- Tab-aware checkbox UX:
+  - **Main Quests** tab keeps the existing checkbox label: `Show only known/current quests`.
+  - **Side Quests** tab now reuses the same checkbox control but changes label to: `Show only active side quests`.
+  - Side-tab checkbox defaults to checked and filters out `available` side-quest offers in the HUD list.
+  - Side-tab checkbox state is persisted separately from main-tab known/current state:
+    - `rgfn_quests_known_only_toggle_v1` for main quests
+    - `rgfn_side_quests_active_only_toggle_v1` for side quests
 
 ### Runtime/UI synchronization notes
 

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -178,6 +178,29 @@
                             <input id="quests-known-only-toggle" type="checkbox" checked>
                             <span id="quests-mode-toggle-label">Show only known/current quests</span>
                         </label>
+                        <div id="quests-side-filter-controls" class="quest-side-filter-controls hidden">
+                            <button id="quests-side-filter-btn" class="quest-side-filter-btn" type="button">Filter statuses</button>
+                            <div id="quests-side-filter-popup" class="quest-side-filter-popup hidden">
+                                <div class="quest-side-filter-title">Show statuses</div>
+                                <label class="quest-side-filter-option">
+                                    <input id="quests-side-filter-status-active" type="checkbox" checked>
+                                    Active
+                                </label>
+                                <label class="quest-side-filter-option">
+                                    <input id="quests-side-filter-status-available" type="checkbox">
+                                    Available
+                                </label>
+                                <label class="quest-side-filter-option">
+                                    <input id="quests-side-filter-status-ready" type="checkbox" checked>
+                                    Ready to turn in
+                                </label>
+                                <label class="quest-side-filter-option">
+                                    <input id="quests-side-filter-status-completed" type="checkbox" checked>
+                                    Completed
+                                </label>
+                                <button id="quests-side-filter-apply-btn" class="quest-side-filter-apply-btn" type="button">Apply</button>
+                            </div>
+                        </div>
                         <div id="quests-body" class="quests-body"></div>
                     </div>
                     <div id="group-panel" class="hud-section stats overlay-panel hidden">

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -174,9 +174,9 @@
                             <button id="quests-tab-main-btn" class="quest-tab is-active" type="button" role="tab" aria-selected="true">Main Quests</button>
                             <button id="quests-tab-side-btn" class="quest-tab" type="button" role="tab" aria-selected="false">Side Quests</button>
                         </div>
-                        <label class="quest-mode-toggle" for="quests-known-only-toggle">
+                        <label id="quests-mode-toggle" class="quest-mode-toggle" for="quests-known-only-toggle">
                             <input id="quests-known-only-toggle" type="checkbox" checked>
-                            Show only known/current quests
+                            <span id="quests-mode-toggle-label">Show only known/current quests</span>
                         </label>
                         <div id="quests-body" class="quests-body"></div>
                     </div>

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -178,9 +178,9 @@
                             <input id="quests-known-only-toggle" type="checkbox" checked>
                             <span id="quests-mode-toggle-label">Show only known/current quests</span>
                         </label>
-                        <div id="quests-side-filter-controls" class="quest-side-filter-controls hidden">
+                        <div id="quests-side-filter-controls" class="quest-side-filter-controls">
                             <button id="quests-side-filter-btn" class="quest-side-filter-btn" type="button">Filter statuses</button>
-                            <div id="quests-side-filter-popup" class="quest-side-filter-popup hidden">
+                            <div id="quests-side-filter-popup" class="quest-side-filter-popup">
                                 <div class="quest-side-filter-title">Show statuses</div>
                                 <label class="quest-side-filter-option">
                                     <input id="quests-side-filter-status-active" type="checkbox" checked>

--- a/rgfn_game/js/game/GameRuntimeAssembly.ts
+++ b/rgfn_game/js/game/GameRuntimeAssembly.ts
@@ -37,6 +37,8 @@ const createQuestUiController = (game: GameFacade, ui: RuntimeUi): QuestUiContro
     document.getElementById('quests-tab-main-btn')! as HTMLButtonElement,
     document.getElementById('quests-tab-side-btn')! as HTMLButtonElement,
     ui.hudElements.questsKnownOnlyToggle,
+    document.getElementById('quests-mode-toggle')! as HTMLElement,
+    document.getElementById('quests-mode-toggle-label')! as HTMLElement,
     ui.hudElements.questsBody,
     ui.hudElements.questIntroModal,
     ui.hudElements.questIntroBody,

--- a/rgfn_game/js/game/GameRuntimeAssembly.ts
+++ b/rgfn_game/js/game/GameRuntimeAssembly.ts
@@ -32,19 +32,53 @@ type RuntimeBase = {
 type SharedRuntime = ReturnType<typeof createSharedRuntime>;
 type RuntimeControllers = ReturnType<typeof createRuntimeControllers>;
 
-const createQuestUiController = (game: GameFacade, ui: RuntimeUi): QuestUiController => new QuestUiController(
-    ui.hudElements.questsTitle,
-    document.getElementById('quests-tab-main-btn')! as HTMLButtonElement,
-    document.getElementById('quests-tab-side-btn')! as HTMLButtonElement,
-    ui.hudElements.questsKnownOnlyToggle,
-    document.getElementById('quests-mode-toggle')! as HTMLElement,
-    document.getElementById('quests-mode-toggle-label')! as HTMLElement,
-    ui.hudElements.questsBody,
-    ui.hudElements.questIntroModal,
-    ui.hudElements.questIntroBody,
-    ui.hudElements.questIntroCloseBtn,
-    { onLocationClick: (locationName: string) => game.onQuestLocationClick(locationName) },
-);
+// eslint-disable-next-line style-guide/function-length-warning
+const getSideQuestFilterElements = (): {
+    sideFilterContainer: HTMLElement;
+    sideFilterButton: HTMLButtonElement;
+    sideFilterPopup: HTMLElement;
+    sideFilterApplyButton: HTMLButtonElement;
+    sideStatusFilterCheckboxes: {
+        active: HTMLInputElement;
+        available: HTMLInputElement;
+        readyToTurnIn: HTMLInputElement;
+        completed: HTMLInputElement;
+    };
+} => ({
+    sideFilterContainer: document.getElementById('quests-side-filter-controls')! as HTMLElement,
+    sideFilterButton: document.getElementById('quests-side-filter-btn')! as HTMLButtonElement,
+    sideFilterPopup: document.getElementById('quests-side-filter-popup')! as HTMLElement,
+    sideFilterApplyButton: document.getElementById('quests-side-filter-apply-btn')! as HTMLButtonElement,
+    sideStatusFilterCheckboxes: {
+        active: document.getElementById('quests-side-filter-status-active')! as HTMLInputElement,
+        available: document.getElementById('quests-side-filter-status-available')! as HTMLInputElement,
+        readyToTurnIn: document.getElementById('quests-side-filter-status-ready')! as HTMLInputElement,
+        completed: document.getElementById('quests-side-filter-status-completed')! as HTMLInputElement,
+    },
+});
+
+// eslint-disable-next-line style-guide/function-length-warning
+const createQuestUiController = (game: GameFacade, ui: RuntimeUi): QuestUiController => {
+    const sideFilterElements = getSideQuestFilterElements();
+    return new QuestUiController(
+        ui.hudElements.questsTitle,
+        document.getElementById('quests-tab-main-btn')! as HTMLButtonElement,
+        document.getElementById('quests-tab-side-btn')! as HTMLButtonElement,
+        ui.hudElements.questsKnownOnlyToggle,
+        document.getElementById('quests-mode-toggle')! as HTMLElement,
+        document.getElementById('quests-mode-toggle-label')! as HTMLElement,
+        sideFilterElements.sideFilterContainer,
+        sideFilterElements.sideFilterButton,
+        sideFilterElements.sideFilterPopup,
+        sideFilterElements.sideFilterApplyButton,
+        sideFilterElements.sideStatusFilterCheckboxes,
+        ui.hudElements.questsBody,
+        ui.hudElements.questIntroModal,
+        ui.hudElements.questIntroBody,
+        ui.hudElements.questIntroCloseBtn,
+        { onLocationClick: (locationName: string) => game.onQuestLocationClick(locationName) },
+    );
+};
 
 const createQuestGenerator = (worldMap: WorldMap, packService: QuestPackService): QuestGenerator => new QuestGenerator({
     packService,

--- a/rgfn_game/js/systems/quest/ui/QuestUiController.ts
+++ b/rgfn_game/js/systems/quest/ui/QuestUiController.ts
@@ -5,11 +5,14 @@ import QuestUiFeedbackPresenter from './QuestUiFeedbackPresenter.js';
 
 const KNOWN_ONLY_TOGGLE_STORAGE_KEY = 'rgfn_quests_known_only_toggle_v1';
 const KNOWN_ONLY_TOGGLE_DEFAULT = true;
-const SIDE_ACTIVE_ONLY_TOGGLE_STORAGE_KEY = 'rgfn_side_quests_active_only_toggle_v1';
-const SIDE_ACTIVE_ONLY_TOGGLE_DEFAULT = true;
+const SIDE_STATUS_FILTER_STORAGE_KEY = 'rgfn_side_quests_status_filter_v1';
 const MAIN_TOGGLE_LABEL = 'Show only known/current quests';
-const SIDE_TOGGLE_LABEL = 'Show only active side quests';
+const SIDE_FILTER_BUTTON_LABEL_PREFIX = 'Filter statuses';
+const SIDE_STATUS_ORDER = ['active', 'available', 'readyToTurnIn', 'completed'] as const;
+const SIDE_STATUS_DEFAULT_FILTER = new Set<SideQuestStatus>(['active', 'readyToTurnIn', 'completed']);
 type QuestTab = 'main' | 'side';
+type SideQuestStatus = typeof SIDE_STATUS_ORDER[number];
+type SideStatusFilterCheckboxes = Record<SideQuestStatus, HTMLInputElement>;
 
 type QuestUiCallbacks = {
     onLocationClick: (locationName: string) => boolean;
@@ -22,6 +25,11 @@ export default class QuestUiController {
     private readonly knownOnlyToggle: HTMLInputElement;
     private readonly modeToggleContainer: HTMLElement;
     private readonly modeToggleLabel: HTMLElement;
+    private sideFilterContainer: HTMLElement;
+    private sideFilterButton: HTMLButtonElement;
+    private sideFilterPopup: HTMLElement;
+    private sideFilterApplyButton: HTMLButtonElement;
+    private sideStatusFilterCheckboxes: SideStatusFilterCheckboxes;
     private readonly questBody: HTMLElement;
     private readonly introModal: HTMLElement;
     private readonly introBody: HTMLElement;
@@ -34,7 +42,7 @@ export default class QuestUiController {
     private lastRenderedSideQuests: QuestNode[] = [];
     private activeTab: QuestTab = 'main';
     private mainKnownOnlyEnabled = KNOWN_ONLY_TOGGLE_DEFAULT;
-    private sideActiveOnlyEnabled = SIDE_ACTIVE_ONLY_TOGGLE_DEFAULT;
+    private sideStatusFilter: Set<SideQuestStatus> = new Set(SIDE_STATUS_DEFAULT_FILTER);
 
     constructor(
         questTitle: HTMLElement,
@@ -43,6 +51,11 @@ export default class QuestUiController {
         knownOnlyToggle: HTMLInputElement,
         modeToggleContainer: HTMLElement,
         modeToggleLabel: HTMLElement,
+        sideFilterContainer: HTMLElement,
+        sideFilterButton: HTMLButtonElement,
+        sideFilterPopup: HTMLElement,
+        sideFilterApplyButton: HTMLButtonElement,
+        sideStatusFilterCheckboxes: SideStatusFilterCheckboxes,
         questBody: HTMLElement,
         introModal: HTMLElement,
         introBody: HTMLElement,
@@ -55,6 +68,7 @@ export default class QuestUiController {
         this.knownOnlyToggle = knownOnlyToggle;
         this.modeToggleContainer = modeToggleContainer;
         this.modeToggleLabel = modeToggleLabel;
+        this.assignSideFilterElements(sideFilterContainer, sideFilterButton, sideFilterPopup, sideFilterApplyButton, sideStatusFilterCheckboxes);
         this.questBody = questBody;
         this.introModal = introModal;
         this.introBody = introBody;
@@ -64,6 +78,7 @@ export default class QuestUiController {
         this.feedbackPresenter = new QuestUiFeedbackPresenter({ containers: [this.questBody, this.introBody] });
         this.feedbackElements = this.feedbackPresenter.feedbackElements;
         this.introModal.classList.add('hidden');
+        this.hideSideFilterPopup();
         this.switchTab('main');
         this.applyPersistedKnownOnlyState();
         this.bindEvents();
@@ -88,6 +103,8 @@ export default class QuestUiController {
     private bindEvents(): void {
         this.introCloseBtn.addEventListener('click', () => this.introModal.classList.add('hidden'));
         this.knownOnlyToggle.addEventListener('change', () => this.handleKnownOnlyToggleChange());
+        this.sideFilterButton.addEventListener('click', () => this.handleSideFilterButtonClick());
+        this.sideFilterApplyButton.addEventListener('click', () => this.handleSideFilterApplyClick());
         this.mainTabBtn.addEventListener('click', () => this.switchTab('main'));
         this.sideTabBtn.addEventListener('click', () => this.switchTab('side'));
         this.introModal.addEventListener('click', (event: MouseEvent) => this.handleIntroModalClick(event));
@@ -95,14 +112,27 @@ export default class QuestUiController {
         this.bindLocationClicks(this.introBody);
     }
 
+    private assignSideFilterElements(
+        sideFilterContainer: HTMLElement,
+        sideFilterButton: HTMLButtonElement,
+        sideFilterPopup: HTMLElement,
+        sideFilterApplyButton: HTMLButtonElement,
+        sideStatusFilterCheckboxes: SideStatusFilterCheckboxes,
+    ): void {
+        this.sideFilterContainer = sideFilterContainer;
+        this.sideFilterButton = sideFilterButton;
+        this.sideFilterPopup = sideFilterPopup;
+        this.sideFilterApplyButton = sideFilterApplyButton;
+        this.sideStatusFilterCheckboxes = sideStatusFilterCheckboxes;
+    }
+
     private handleKnownOnlyToggleChange(): void {
-        if (this.activeTab === 'main') {
-            this.mainKnownOnlyEnabled = this.knownOnlyToggle.checked;
-            this.persistKnownOnlyState();
-        } else {
-            this.sideActiveOnlyEnabled = this.knownOnlyToggle.checked;
-            this.persistSideActiveOnlyState();
+        if (this.activeTab !== 'main') {
+            return;
         }
+
+        this.mainKnownOnlyEnabled = this.knownOnlyToggle.checked;
+        this.persistKnownOnlyState();
         if (this.lastRenderedQuest) {
             this.renderCurrentTab();
         }
@@ -116,7 +146,7 @@ export default class QuestUiController {
 
     private applyPersistedKnownOnlyState(): void {
         this.mainKnownOnlyEnabled = this.readKnownOnlyState() ?? KNOWN_ONLY_TOGGLE_DEFAULT;
-        this.sideActiveOnlyEnabled = this.readSideActiveOnlyState() ?? SIDE_ACTIVE_ONLY_TOGGLE_DEFAULT;
+        this.sideStatusFilter = this.readSideStatusFilter();
         this.updateModeToggleUi();
     }
 
@@ -145,29 +175,38 @@ export default class QuestUiController {
         return null;
     }
 
-    private persistSideActiveOnlyState(): void {
+    private persistSideStatusFilter(): void {
         const storage = this.getLocalStorage();
         if (!storage) {
             return;
         }
 
-        storage.setItem(SIDE_ACTIVE_ONLY_TOGGLE_STORAGE_KEY, this.sideActiveOnlyEnabled ? '1' : '0');
+        const serializedFilter = SIDE_STATUS_ORDER
+            .filter((status) => this.sideStatusFilter.has(status))
+            .join(',');
+        storage.setItem(SIDE_STATUS_FILTER_STORAGE_KEY, serializedFilter);
     }
 
-    private readSideActiveOnlyState(): boolean | null {
+    private readSideStatusFilter(): Set<SideQuestStatus> {
         const storage = this.getLocalStorage();
         if (!storage) {
-            return null;
+            return new Set(SIDE_STATUS_DEFAULT_FILTER);
         }
 
-        const rawValue = storage.getItem(SIDE_ACTIVE_ONLY_TOGGLE_STORAGE_KEY);
-        if (rawValue === '1') {
-            return true;
+        const rawValue = storage.getItem(SIDE_STATUS_FILTER_STORAGE_KEY);
+        if (!rawValue) {
+            return new Set(SIDE_STATUS_DEFAULT_FILTER);
         }
-        if (rawValue === '0') {
-            return false;
+
+        const statuses = rawValue
+            .split(',')
+            .map((value) => value.trim())
+            .filter((value): value is SideQuestStatus => SIDE_STATUS_ORDER.includes(value as SideQuestStatus));
+        if (statuses.length === 0) {
+            return new Set(SIDE_STATUS_DEFAULT_FILTER);
         }
-        return null;
+
+        return new Set(statuses);
     }
 
     private getLocalStorage(): Storage | null {
@@ -192,19 +231,24 @@ export default class QuestUiController {
         this.sideTabBtn.classList.toggle('is-active', tab === 'side');
         this.mainTabBtn.setAttribute('aria-selected', String(tab === 'main'));
         this.sideTabBtn.setAttribute('aria-selected', String(tab === 'side'));
+        if (tab === 'main') {
+            this.hideSideFilterPopup();
+        }
         this.updateModeToggleUi();
         this.renderCurrentTab();
     }
 
     private updateModeToggleUi(): void {
-        this.modeToggleContainer.style.display = '';
+        this.modeToggleContainer.style.display = this.activeTab === 'main' ? '' : 'none';
+        this.sideFilterContainer.style.display = this.activeTab === 'side' ? '' : 'none';
         if (this.activeTab === 'main') {
             this.modeToggleLabel.textContent = MAIN_TOGGLE_LABEL;
             this.knownOnlyToggle.checked = this.mainKnownOnlyEnabled;
+            this.sideFilterButton.textContent = SIDE_FILTER_BUTTON_LABEL_PREFIX;
             return;
         }
-        this.modeToggleLabel.textContent = SIDE_TOGGLE_LABEL;
-        this.knownOnlyToggle.checked = this.sideActiveOnlyEnabled;
+        this.syncSideFilterCheckboxesFromState();
+        this.sideFilterButton.textContent = this.buildSideFilterButtonLabel();
     }
 
     private renderCurrentTab(): void {
@@ -226,9 +270,7 @@ export default class QuestUiController {
 
     private renderSideQuestTab(sideQuests: QuestNode[]): void {
         this.questTitle.textContent = 'Side Quests';
-        const filteredQuests = this.sideActiveOnlyEnabled
-            ? sideQuests.filter((quest) => (quest.status ?? 'active') !== 'available')
-            : sideQuests;
+        const filteredQuests = sideQuests.filter((quest) => this.sideStatusFilter.has(this.toSideQuestStatus(quest.status)));
         if (filteredQuests.length === 0) {
             this.questBody.innerHTML = '<p>No known side quests yet.</p>';
             return;
@@ -258,6 +300,57 @@ export default class QuestUiController {
     }
 
     private formatStatus = (status: string): string => status === 'readyToTurnIn' ? 'Ready to turn in' : status.charAt(0).toUpperCase() + status.slice(1);
+
+    private handleSideFilterButtonClick(): void {
+        if (this.activeTab !== 'side') {
+            return;
+        }
+        if (this.sideFilterPopup.style.display === 'none') {
+            this.showSideFilterPopup();
+            return;
+        }
+        this.hideSideFilterPopup();
+    }
+
+    private handleSideFilterApplyClick(): void {
+        const selectedStatuses = SIDE_STATUS_ORDER.filter((status) => this.sideStatusFilterCheckboxes[status].checked);
+        if (selectedStatuses.length === 0) {
+            this.syncSideFilterCheckboxesFromState();
+            this.setFeedback('Select at least one side-quest status before applying filter.', true);
+            return;
+        }
+
+        this.sideStatusFilter = new Set(selectedStatuses);
+        this.persistSideStatusFilter();
+        this.sideFilterButton.textContent = this.buildSideFilterButtonLabel();
+        this.hideSideFilterPopup();
+        this.renderSideQuestTab(this.lastRenderedSideQuests);
+    }
+
+    private syncSideFilterCheckboxesFromState(): void {
+        SIDE_STATUS_ORDER.forEach((status) => {
+            this.sideStatusFilterCheckboxes[status].checked = this.sideStatusFilter.has(status);
+        });
+    }
+
+    private buildSideFilterButtonLabel(): string {
+        const visibleCount = SIDE_STATUS_ORDER.filter((status) => this.sideStatusFilter.has(status)).length;
+        return `${SIDE_FILTER_BUTTON_LABEL_PREFIX} (${visibleCount}/${SIDE_STATUS_ORDER.length})`;
+    }
+
+    private showSideFilterPopup(): void {
+        this.syncSideFilterCheckboxesFromState();
+        this.sideFilterPopup.style.display = '';
+    }
+
+    private hideSideFilterPopup = (): void => { this.sideFilterPopup.style.display = 'none'; };
+
+    private toSideQuestStatus(status: string | undefined): SideQuestStatus {
+        if (status === 'available' || status === 'readyToTurnIn' || status === 'completed') {
+            return status;
+        }
+        return 'active';
+    }
 
     private escapeHtml = (text: string): string => text
         .split('&').join('&amp;')

--- a/rgfn_game/js/systems/quest/ui/QuestUiController.ts
+++ b/rgfn_game/js/systems/quest/ui/QuestUiController.ts
@@ -5,6 +5,10 @@ import QuestUiFeedbackPresenter from './QuestUiFeedbackPresenter.js';
 
 const KNOWN_ONLY_TOGGLE_STORAGE_KEY = 'rgfn_quests_known_only_toggle_v1';
 const KNOWN_ONLY_TOGGLE_DEFAULT = true;
+const SIDE_ACTIVE_ONLY_TOGGLE_STORAGE_KEY = 'rgfn_side_quests_active_only_toggle_v1';
+const SIDE_ACTIVE_ONLY_TOGGLE_DEFAULT = true;
+const MAIN_TOGGLE_LABEL = 'Show only known/current quests';
+const SIDE_TOGGLE_LABEL = 'Show only active side quests';
 type QuestTab = 'main' | 'side';
 
 type QuestUiCallbacks = {
@@ -16,6 +20,8 @@ export default class QuestUiController {
     private readonly mainTabBtn: HTMLButtonElement;
     private readonly sideTabBtn: HTMLButtonElement;
     private readonly knownOnlyToggle: HTMLInputElement;
+    private readonly modeToggleContainer: HTMLElement;
+    private readonly modeToggleLabel: HTMLElement;
     private readonly questBody: HTMLElement;
     private readonly introModal: HTMLElement;
     private readonly introBody: HTMLElement;
@@ -27,12 +33,16 @@ export default class QuestUiController {
     private lastRenderedQuest: QuestNode | null = null;
     private lastRenderedSideQuests: QuestNode[] = [];
     private activeTab: QuestTab = 'main';
+    private mainKnownOnlyEnabled = KNOWN_ONLY_TOGGLE_DEFAULT;
+    private sideActiveOnlyEnabled = SIDE_ACTIVE_ONLY_TOGGLE_DEFAULT;
 
     constructor(
         questTitle: HTMLElement,
         mainTabBtn: HTMLButtonElement,
         sideTabBtn: HTMLButtonElement,
         knownOnlyToggle: HTMLInputElement,
+        modeToggleContainer: HTMLElement,
+        modeToggleLabel: HTMLElement,
         questBody: HTMLElement,
         introModal: HTMLElement,
         introBody: HTMLElement,
@@ -43,12 +53,14 @@ export default class QuestUiController {
         this.mainTabBtn = mainTabBtn;
         this.sideTabBtn = sideTabBtn;
         this.knownOnlyToggle = knownOnlyToggle;
+        this.modeToggleContainer = modeToggleContainer;
+        this.modeToggleLabel = modeToggleLabel;
         this.questBody = questBody;
         this.introModal = introModal;
         this.introBody = introBody;
         this.introCloseBtn = introCloseBtn;
         this.callbacks = callbacks;
-        this.markupBuilder = new QuestUiMarkupBuilder({ isKnownOnlyEnabled: () => this.knownOnlyToggle.checked });
+        this.markupBuilder = new QuestUiMarkupBuilder({ isKnownOnlyEnabled: () => this.mainKnownOnlyEnabled });
         this.feedbackPresenter = new QuestUiFeedbackPresenter({ containers: [this.questBody, this.introBody] });
         this.feedbackElements = this.feedbackPresenter.feedbackElements;
         this.introModal.classList.add('hidden');
@@ -84,7 +96,13 @@ export default class QuestUiController {
     }
 
     private handleKnownOnlyToggleChange(): void {
-        this.persistKnownOnlyState();
+        if (this.activeTab === 'main') {
+            this.mainKnownOnlyEnabled = this.knownOnlyToggle.checked;
+            this.persistKnownOnlyState();
+        } else {
+            this.sideActiveOnlyEnabled = this.knownOnlyToggle.checked;
+            this.persistSideActiveOnlyState();
+        }
         if (this.lastRenderedQuest) {
             this.renderCurrentTab();
         }
@@ -97,8 +115,9 @@ export default class QuestUiController {
     }
 
     private applyPersistedKnownOnlyState(): void {
-        const savedState = this.readKnownOnlyState();
-        this.knownOnlyToggle.checked = savedState ?? KNOWN_ONLY_TOGGLE_DEFAULT;
+        this.mainKnownOnlyEnabled = this.readKnownOnlyState() ?? KNOWN_ONLY_TOGGLE_DEFAULT;
+        this.sideActiveOnlyEnabled = this.readSideActiveOnlyState() ?? SIDE_ACTIVE_ONLY_TOGGLE_DEFAULT;
+        this.updateModeToggleUi();
     }
 
     private persistKnownOnlyState(): void {
@@ -117,6 +136,31 @@ export default class QuestUiController {
         }
 
         const rawValue = storage.getItem(KNOWN_ONLY_TOGGLE_STORAGE_KEY);
+        if (rawValue === '1') {
+            return true;
+        }
+        if (rawValue === '0') {
+            return false;
+        }
+        return null;
+    }
+
+    private persistSideActiveOnlyState(): void {
+        const storage = this.getLocalStorage();
+        if (!storage) {
+            return;
+        }
+
+        storage.setItem(SIDE_ACTIVE_ONLY_TOGGLE_STORAGE_KEY, this.sideActiveOnlyEnabled ? '1' : '0');
+    }
+
+    private readSideActiveOnlyState(): boolean | null {
+        const storage = this.getLocalStorage();
+        if (!storage) {
+            return null;
+        }
+
+        const rawValue = storage.getItem(SIDE_ACTIVE_ONLY_TOGGLE_STORAGE_KEY);
         if (rawValue === '1') {
             return true;
         }
@@ -148,8 +192,19 @@ export default class QuestUiController {
         this.sideTabBtn.classList.toggle('is-active', tab === 'side');
         this.mainTabBtn.setAttribute('aria-selected', String(tab === 'main'));
         this.sideTabBtn.setAttribute('aria-selected', String(tab === 'side'));
-        this.knownOnlyToggle.style.display = tab === 'main' ? '' : 'none';
+        this.updateModeToggleUi();
         this.renderCurrentTab();
+    }
+
+    private updateModeToggleUi(): void {
+        this.modeToggleContainer.style.display = '';
+        if (this.activeTab === 'main') {
+            this.modeToggleLabel.textContent = MAIN_TOGGLE_LABEL;
+            this.knownOnlyToggle.checked = this.mainKnownOnlyEnabled;
+            return;
+        }
+        this.modeToggleLabel.textContent = SIDE_TOGGLE_LABEL;
+        this.knownOnlyToggle.checked = this.sideActiveOnlyEnabled;
     }
 
     private renderCurrentTab(): void {
@@ -171,12 +226,15 @@ export default class QuestUiController {
 
     private renderSideQuestTab(sideQuests: QuestNode[]): void {
         this.questTitle.textContent = 'Side Quests';
-        if (sideQuests.length === 0) {
+        const filteredQuests = this.sideActiveOnlyEnabled
+            ? sideQuests.filter((quest) => (quest.status ?? 'active') !== 'available')
+            : sideQuests;
+        if (filteredQuests.length === 0) {
             this.questBody.innerHTML = '<p>No known side quests yet.</p>';
             return;
         }
 
-        const cards = sideQuests
+        const cards = filteredQuests
             .map((quest) => this.buildSideQuestCardMarkup(quest))
             .join('');
         this.questBody.innerHTML = `<div class="side-quest-list">${cards}</div>`;

--- a/rgfn_game/style.css
+++ b/rgfn_game/style.css
@@ -1136,6 +1136,55 @@ h1 {
     accent-color: var(--color-primary-accent);
 }
 
+.quest-side-filter-controls {
+    position: relative;
+    margin: 6px 0 8px;
+}
+
+.quest-side-filter-btn,
+.quest-side-filter-apply-btn {
+    border: 1px solid var(--color-secondary-accent);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--color-primary-bg) 80%, transparent);
+    color: var(--color-text-primary);
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 4px 10px;
+    cursor: pointer;
+}
+
+.quest-side-filter-popup {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 180px;
+    padding: 8px;
+    border: 1px solid var(--color-secondary-accent);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--color-panel-highlight) 80%, var(--color-primary-bg));
+    z-index: 4;
+}
+
+.quest-side-filter-title {
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.quest-side-filter-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+}
+
+.quest-side-filter-option input[type='checkbox'] {
+    accent-color: var(--color-primary-accent);
+}
+
 .quest-tabs {
     display: flex;
     gap: 6px;

--- a/rgfn_game/test/systems/scenarios/questUiController.test.js
+++ b/rgfn_game/test/systems/scenarios/questUiController.test.js
@@ -35,15 +35,24 @@ function createCheckbox(checked = false) {
   return checkbox;
 }
 
+function createSideStatusFilterCheckboxes() {
+  return {
+    active: createCheckbox(true),
+    available: createCheckbox(false),
+    readyToTurnIn: createCheckbox(true),
+    completed: createCheckbox(true),
+  };
+}
+
 function createStorageMock(initial = null) {
-  const state = { known: initial, side: initial };
+  const state = { known: initial, sideFilter: initial };
   return {
     getItem(key) {
       if (key === 'rgfn_quests_known_only_toggle_v1') {
         return state.known;
       }
-      if (key === 'rgfn_side_quests_active_only_toggle_v1') {
-        return state.side;
+      if (key === 'rgfn_side_quests_status_filter_v1') {
+        return state.sideFilter;
       }
       return null;
     },
@@ -51,8 +60,8 @@ function createStorageMock(initial = null) {
       if (key === 'rgfn_quests_known_only_toggle_v1') {
         state.known = value;
       }
-      if (key === 'rgfn_side_quests_active_only_toggle_v1') {
-        state.side = value;
+      if (key === 'rgfn_side_quests_status_filter_v1') {
+        state.sideFilter = value;
       }
     },
     state,
@@ -66,7 +75,7 @@ test('QuestUiController hides the default boilerplate on the root quest but keep
   const modal = createElement();
   const intro = createElement();
   const closeBtn = createElement();
-  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), body, modal, intro, closeBtn, { onLocationClick: () => false });
+  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), body, modal, intro, closeBtn, { onLocationClick: () => false });
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -105,7 +114,7 @@ test('QuestUiController hides the default boilerplate on the root quest but keep
 });
 
 test('QuestUiController opens and closes the intro modal through bound events', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
   const modal = controller['introModal'];
   const closeBtn = controller['introCloseBtn'];
 
@@ -118,7 +127,7 @@ test('QuestUiController opens and closes the intro modal through bound events', 
 });
 
 test('QuestUiController keeps intro modal hidden by default until explicitly opened', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
   const modal = controller['introModal'];
 
   assert.deepEqual(modal.classList.added, ['hidden']);
@@ -126,7 +135,7 @@ test('QuestUiController keeps intro modal hidden by default until explicitly ope
 });
 
 test('QuestUiController renders completion styling and checkmark for completed quest nodes', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -162,7 +171,7 @@ test('QuestUiController clears quest feedback after configured timeout', () => {
   };
 
   try {
-    const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
 
     controller['setFeedback']('Oakcross is not discovered yet.', true);
     assert.equal(scheduledDelay, 5000);
@@ -184,7 +193,7 @@ test('QuestUiController known-only mode hides quests below the first incomplete 
   const title = createElement();
   const knownOnlyToggle = createCheckbox(true);
   const body = createElement();
-  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), body, createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), body, createElement(), createElement(), createElement(), { onLocationClick: () => false });
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -241,7 +250,7 @@ test('QuestUiController defaults known-only toggle to checked when no saved pref
 
   try {
     const knownOnlyToggle = createCheckbox(false);
-    new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
     assert.equal(knownOnlyToggle.checked, true);
   } finally {
     global.window = originalWindow;
@@ -255,7 +264,7 @@ test('QuestUiController persists and restores known-only toggle state via localS
 
   try {
     const knownOnlyToggle = createCheckbox(true);
-    const controller = new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    const controller = new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
     assert.equal(knownOnlyToggle.checked, false);
 
     knownOnlyToggle.checked = true;
@@ -285,6 +294,11 @@ test('QuestUiController renders known side quests in side tab with nested object
     knownOnlyToggle,
     createElement(),
     createElement(),
+    createElement(),
+    createElement(),
+    createElement(),
+    createElement(),
+    createSideStatusFilterCheckboxes(),
     body,
     createElement(),
     createElement(),
@@ -331,23 +345,30 @@ test('QuestUiController renders known side quests in side tab with nested object
   assert.equal(body.innerHTML.includes('side-quest-status'), true);
 });
 
-test('QuestUiController filters available side quests by default and persists side-tab preference', () => {
+test('QuestUiController applies side quest status filter popup selections and persists status list', () => {
   const originalWindow = global.window;
   const storage = createStorageMock(null);
   global.window = { localStorage: storage };
 
   try {
     const sideTabBtn = createElement();
-    const knownOnlyToggle = createCheckbox(false);
-    const modeToggleLabel = createElement();
+    const sideFilterButton = createElement();
+    const sideFilterPopup = createElement();
+    const sideFilterApplyButton = createElement();
+    const sideStatusCheckboxes = createSideStatusFilterCheckboxes();
     const body = createElement();
     const controller = new QuestUiController(
       createElement(),
       createElement(),
       sideTabBtn,
-      knownOnlyToggle,
+      createCheckbox(true),
       createElement(),
-      modeToggleLabel,
+      createElement(),
+      createElement(),
+      sideFilterButton,
+      sideFilterPopup,
+      sideFilterApplyButton,
+      sideStatusCheckboxes,
       body,
       createElement(),
       createElement(),
@@ -361,14 +382,15 @@ test('QuestUiController filters available side quests by default and persists si
     controller.renderQuest(mainQuest, [activeQuest, availableQuest]);
     sideTabBtn.listeners.click();
 
-    assert.equal(modeToggleLabel.textContent, 'Show only active side quests');
-    assert.equal(knownOnlyToggle.checked, true);
+    assert.equal(sideFilterButton.textContent, 'Filter statuses (3/4)');
     assert.equal(body.innerHTML.includes('Active Quest'), true);
     assert.equal(body.innerHTML.includes('Available Quest'), false);
 
-    knownOnlyToggle.checked = false;
-    knownOnlyToggle.listeners.change();
-    assert.equal(storage.state.side, '0');
+    sideFilterButton.listeners.click();
+    sideStatusCheckboxes.available.checked = true;
+    sideFilterApplyButton.listeners.click();
+
+    assert.equal(storage.state.sideFilter, 'active,available,readyToTurnIn,completed');
     assert.equal(body.innerHTML.includes('Available Quest'), true);
   } finally {
     global.window = originalWindow;

--- a/rgfn_game/test/systems/scenarios/questUiController.test.js
+++ b/rgfn_game/test/systems/scenarios/questUiController.test.js
@@ -36,17 +36,23 @@ function createCheckbox(checked = false) {
 }
 
 function createStorageMock(initial = null) {
-  const state = { value: initial };
+  const state = { known: initial, side: initial };
   return {
     getItem(key) {
-      if (key !== 'rgfn_quests_known_only_toggle_v1') {
-        return null;
+      if (key === 'rgfn_quests_known_only_toggle_v1') {
+        return state.known;
       }
-      return state.value;
+      if (key === 'rgfn_side_quests_active_only_toggle_v1') {
+        return state.side;
+      }
+      return null;
     },
     setItem(key, value) {
       if (key === 'rgfn_quests_known_only_toggle_v1') {
-        state.value = value;
+        state.known = value;
+      }
+      if (key === 'rgfn_side_quests_active_only_toggle_v1') {
+        state.side = value;
       }
     },
     state,
@@ -60,7 +66,7 @@ test('QuestUiController hides the default boilerplate on the root quest but keep
   const modal = createElement();
   const intro = createElement();
   const closeBtn = createElement();
-  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, body, modal, intro, closeBtn, { onLocationClick: () => false });
+  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), body, modal, intro, closeBtn, { onLocationClick: () => false });
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -99,7 +105,7 @@ test('QuestUiController hides the default boilerplate on the root quest but keep
 });
 
 test('QuestUiController opens and closes the intro modal through bound events', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
   const modal = controller['introModal'];
   const closeBtn = controller['introCloseBtn'];
 
@@ -112,7 +118,7 @@ test('QuestUiController opens and closes the intro modal through bound events', 
 });
 
 test('QuestUiController keeps intro modal hidden by default until explicitly opened', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
   const modal = controller['introModal'];
 
   assert.deepEqual(modal.classList.added, ['hidden']);
@@ -120,7 +126,7 @@ test('QuestUiController keeps intro modal hidden by default until explicitly ope
 });
 
 test('QuestUiController renders completion styling and checkmark for completed quest nodes', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -156,7 +162,7 @@ test('QuestUiController clears quest feedback after configured timeout', () => {
   };
 
   try {
-    const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
 
     controller['setFeedback']('Oakcross is not discovered yet.', true);
     assert.equal(scheduledDelay, 5000);
@@ -178,7 +184,7 @@ test('QuestUiController known-only mode hides quests below the first incomplete 
   const title = createElement();
   const knownOnlyToggle = createCheckbox(true);
   const body = createElement();
-  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, body, createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), body, createElement(), createElement(), createElement(), { onLocationClick: () => false });
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -235,7 +241,7 @@ test('QuestUiController defaults known-only toggle to checked when no saved pref
 
   try {
     const knownOnlyToggle = createCheckbox(false);
-    new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
     assert.equal(knownOnlyToggle.checked, true);
   } finally {
     global.window = originalWindow;
@@ -249,16 +255,16 @@ test('QuestUiController persists and restores known-only toggle state via localS
 
   try {
     const knownOnlyToggle = createCheckbox(true);
-    const controller = new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    const controller = new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
     assert.equal(knownOnlyToggle.checked, false);
 
     knownOnlyToggle.checked = true;
     knownOnlyToggle.listeners.change();
-    assert.equal(storage.state.value, '1');
+    assert.equal(storage.state.known, '1');
 
     knownOnlyToggle.checked = false;
     knownOnlyToggle.listeners.change();
-    assert.equal(storage.state.value, '0');
+    assert.equal(storage.state.known, '0');
 
     assert.ok(controller);
   } finally {
@@ -277,6 +283,8 @@ test('QuestUiController renders known side quests in side tab with nested object
     mainTabBtn,
     sideTabBtn,
     knownOnlyToggle,
+    createElement(),
+    createElement(),
     body,
     createElement(),
     createElement(),
@@ -317,8 +325,52 @@ test('QuestUiController renders known side quests in side tab with nested object
   sideTabBtn.listeners.click();
 
   assert.equal(title.textContent, 'Side Quests');
-  assert.equal(knownOnlyToggle.style.display, 'none');
+  assert.equal(knownOnlyToggle.checked, true);
   assert.equal(body.innerHTML.includes('Village Supplies'), true);
   assert.equal(body.innerHTML.includes('Gather Resin Bundles'), true);
   assert.equal(body.innerHTML.includes('side-quest-status'), true);
+});
+
+test('QuestUiController filters available side quests by default and persists side-tab preference', () => {
+  const originalWindow = global.window;
+  const storage = createStorageMock(null);
+  global.window = { localStorage: storage };
+
+  try {
+    const sideTabBtn = createElement();
+    const knownOnlyToggle = createCheckbox(false);
+    const modeToggleLabel = createElement();
+    const body = createElement();
+    const controller = new QuestUiController(
+      createElement(),
+      createElement(),
+      sideTabBtn,
+      knownOnlyToggle,
+      createElement(),
+      modeToggleLabel,
+      body,
+      createElement(),
+      createElement(),
+      createElement(),
+      { onLocationClick: () => false },
+    );
+    const mainQuest = { id: 'main', title: 'Signal Dawn', description: '', conditionText: '', objectiveType: 'scout', entities: [], children: [] };
+    const activeQuest = { id: 'side.1', title: 'Active Quest', description: '', conditionText: '', objectiveType: 'gather', entities: [], status: 'active', children: [] };
+    const availableQuest = { id: 'side.2', title: 'Available Quest', description: '', conditionText: '', objectiveType: 'gather', entities: [], status: 'available', children: [] };
+
+    controller.renderQuest(mainQuest, [activeQuest, availableQuest]);
+    sideTabBtn.listeners.click();
+
+    assert.equal(modeToggleLabel.textContent, 'Show only active side quests');
+    assert.equal(knownOnlyToggle.checked, true);
+    assert.equal(body.innerHTML.includes('Active Quest'), true);
+    assert.equal(body.innerHTML.includes('Available Quest'), false);
+
+    knownOnlyToggle.checked = false;
+    knownOnlyToggle.listeners.change();
+    assert.equal(storage.state.side, '0');
+    assert.equal(body.innerHTML.includes('Available Quest'), true);
+  } finally {
+    global.window = originalWindow;
+  }
 });


### PR DESCRIPTION
### Motivation
- Make the Quests HUD checkbox usable for both tabs so players can hide spoilers on Main Quests and optionally hide `available` offers on Side Quests by default. 
- Persist separate preferences for main known-only behavior and side-tab active-only behavior so the two modes do not interfere.

### Description
- Made the quest-mode control a labeled container (`#quests-mode-toggle`, `#quests-mode-toggle-label`) in `rgfn_game/index.html` so the label can change per-tab. 
- Extended `QuestUiController` to be tab-aware and support two independent modes: main known-only mode (storage key `rgfn_quests_known_only_toggle_v1`) and side active-only mode (storage key `rgfn_side_quests_active_only_toggle_v1`), with both defaulting to checked. 
- Side-tab behavior now filters out side quests with `status === 'available'` when the side active-only toggle is ON and re-renders correctly; the toggle label switches to `Show only active side quests` on the Side Quests tab. 
- Wired new DOM elements into the runtime by passing the toggle container and label into the `QuestUiController` constructor in `GameRuntimeAssembly.ts`. 
- Added/updated unit tests in `rgfn_game/test/systems/scenarios/questUiController.test.js` and updated documentation in `rgfn_game/docs/*` to cover the tab-aware checkbox behavior and storage keys.

### Testing
- Ran `npm run build:rgfn` and the TypeScript build completed successfully. 
- Ran `npm run test:rgfn` and all tests passed (`162` tests passing). 
- Ran `npx eslint` on the modified files and the changed files show no new lint errors. 
- Running the full lint pipeline `npm run lint:ts:rgfn` still fails due to a pre-existing `style-guide` error in `rgfn_game/js/systems/village/VillageDialogueEngine.ts` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14ea34c8c8323b55ef06ff088a67c)