### PR TITLE
Show side quest task details in village dialogue offers

### DIFF
--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -77,6 +77,21 @@
   - ready-to-turn-in logs (once per quest id),
   - turn-in completion logs with reward text.
 
+## 2026-04-16: Side-quest offer cards now show concrete task details before acceptance
+
+- The side-quest card renderer now includes a **Task details** line when the quest has child objective descriptions.
+- This line is sourced from the first non-empty child objective description that is different from the root quest description.
+- Result: players can inspect the actual objective scope directly in the NPC dialogue side-quest block before clicking **Accept quest**, instead of needing to open the quest panel after accepting.
+- Existing card fields remain unchanged:
+  - title + status,
+  - root quest description,
+  - reward preview,
+  - accept/turn-in action button depending on status.
+
+### Regression guard added
+
+- `villageActionsController` scenario tests now assert that offer cards surface the new `Task details: ...` line when objective child text exists.
+
 ### Verification checklist used for this change
 
 1. Enter village.

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -540,12 +540,25 @@ export default class VillageActionsController {
 
     private appendSideQuestCardText(card: HTMLElement, quest: QuestNode, isOffer: boolean): void {
         const statusText = isOffer ? 'Offer available' : this.getSideQuestStatusText(quest.status);
-        [ `${quest.title} — ${statusText}`, quest.description, `Reward preview: ${quest.reward?.trim() ? quest.reward : 'Unknown reward'}` ]
+        const lines = [`${quest.title} — ${statusText}`, quest.description];
+        const taskDetails = this.getSideQuestTaskDetails(quest);
+        if (taskDetails) {
+            lines.push(`Task details: ${taskDetails}`);
+        }
+        lines.push(`Reward preview: ${quest.reward?.trim() ? quest.reward : 'Unknown reward'}`);
+        lines
             .forEach((line) => {
                 const element = document.createElement('p');
                 element.textContent = line;
                 card.appendChild(element);
             });
+    }
+
+    private getSideQuestTaskDetails(quest: QuestNode): string {
+        const detail = quest.children
+            .map((child) => child.description.trim())
+            .find((description) => description.length > 0 && description !== quest.description.trim());
+        return detail ?? '';
     }
 
     private appendSideQuestCardAction(card: HTMLElement, quest: QuestNode, isOffer: boolean): void {

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -699,10 +699,10 @@ test('VillageActionsController requires explicit side-quest acceptance and expos
   const offerQuest = {
     id: 'side-quest-offer',
     title: 'Patch the Mill Wheel',
-    description: 'Bring repair tools to the village mill.',
+    description: 'Assist Mara with a local task in Mossbrook.',
     reward: '20g',
     status: 'available',
-    children: [],
+    children: [{ description: 'Carry repair tools from the smithy to the mill wheel before sunset.' }],
   };
   const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
     onUpdateHUD: () => {},
@@ -726,6 +726,10 @@ test('VillageActionsController requires explicit side-quest acceptance and expos
   assert.equal(acceptCalls, 0);
   const acceptButton = villageUI.sideQuestList.children.find((child) => child.children?.some((entry) => entry.textContent === 'Accept quest'));
   assert.ok(acceptButton);
+  assert.equal(
+    acceptButton.children.some((entry) => String(entry.textContent ?? '').includes('Task details: Carry repair tools from the smithy to the mill wheel before sunset.')),
+    true,
+  );
   controller.handleAcceptSideQuest('side-quest-offer');
   assert.equal(acceptCalls, 1);
   assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Side quest accepted')), true);


### PR DESCRIPTION
### Motivation

- Players could only see a generic "local task" description in NPC dialogue offers and had to accept quests blindly to learn the actual objective, which is a poor UX for side quests.

### Description

- Update `VillageActionsController.appendSideQuestCardText` to include a `Task details: ...` line sourced from the first non-empty child objective description that differs from the root description.
- Add `getSideQuestTaskDetails(quest: QuestNode)` helper to extract a concrete child objective description.
- Update the village dialogue scenario test `rgfn_game/test/systems/scenarios/villageActionsController.test.js` to include a child objective description and assert the new `Task details` line is rendered before acceptance.
- Document the UX change in `rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md` under a new `2026-04-16` section and note the regression guard.

### Testing

- Ran `npm run test:rgfn` and all tests passed (`162` tests, `0` failures). 
- Ran `npx eslint rgfn_game/js/systems/village/VillageActionsController.ts` which completed successfully for the modified file. 
- Ran `npm run lint:ts:rgfn` which reports pre-existing project-wide lint/config issues unrelated to these changes, so lint was scoped to the touched file for this PR and the scoped lint passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14fbb7db08323bf73018e60ad1dd3)