### PR TITLE
Auto-award and verify recover items for side quests on village entry; HUD refresh and retry on inventory inconsistency

### DIFF
--- a/rgfn_game/docs/quest/quest-progress-tracking.md
+++ b/rgfn_game/docs/quest/quest-progress-tracking.md
@@ -28,6 +28,54 @@
   - marks the side-quest root complete,
   - transitions side-quest status to `readyToTurnIn`.
 
+## April 16, 2026 update: recover side quests now complete through village-entry item discovery
+
+- Recover-type **side quests** now use one completion path: entering the objective village auto-discovers the recover item as a ground find.
+- Runtime now emits explicit village-entry logs for this path:
+  - item acquisition context (`Found <item> lying on the ground in <village>`),
+  - side-quest readiness (`Side quest ready to turn in: <title>`).
+- `GameQuestRuntime.recordLocationEntry(...)` now accepts an optional recovered-item callback so discovered recover items are immediately granted to player inventory.
+- Main quest recover confrontation flow remains unchanged in this update; this change targets side-quest recover playability/completion.
+
+### Regression coverage
+
+- Added automated runtime test:
+  - entering a recover side-quest village auto-completes the objective,
+  - grants the recover item through callback,
+  - emits acquisition log text,
+  - sets side-quest status to `readyToTurnIn`.
+
+## April 17, 2026 hotfix: recover side quest completion now strictly requires successful inventory award
+
+- Fixed a completion-order issue: recover side-quest objectives are now marked complete **only after** item award callback confirms the item was added to inventory.
+- If inventory award fails (e.g., capacity constraints), quest completion is blocked and runtime logs the failure (`inventory is full`).
+- If inventory award callback is unavailable, runtime logs a callback-unavailable error and does not complete the recover objective.
+- Village-entry flow now refreshes HUD immediately when quest state changes so inventory panel reflects newly awarded recover items without waiting for later UI refresh triggers.
+
+### Regression coverage
+
+- Added runtime test to verify recover side quests remain active when item award callback returns `false`.
+- Added lifecycle-coordinator scenario test to verify:
+  - village-entry recover callback is invoked,
+  - recovered item is handed to player inventory callback,
+  - HUD refresh is triggered after changed quest state,
+  - village-entry logs remain visible.
+
+## April 17, 2026 follow-up: inventory-visible recover-item guarantee on village entry
+
+- Additional hardening was added for side-quest recover item awards because log-confirmed pickup could still be perceived as missing in inventory in live gameplay.
+- Village-entry item award now uses a verification+retry contract in lifecycle runtime:
+  1. attempt to add recover item to player inventory,
+  2. verify the recover item is visible in current inventory snapshot by name,
+  3. if add reported success but inventory does not reflect item, retry one additional add,
+  4. if still not visible, fail objective award and emit a persistence-failure log line.
+- This establishes a stronger invariant: recover-side-quest completion should only proceed when inventory actually reflects the recovered item.
+
+### Regression coverage
+
+- Added a lifecycle test that simulates an inconsistent inventory update path where first add returns success but does not materialize in inventory.
+- Test verifies second-chance retry is executed and item becomes visible in inventory state.
+
 ## April 8, 2026 update: village dialogue contract visibility now follows known quest frontier
 
 - Non-developer mode village dialogue dropdowns are now aligned with quest knowledge progression:

--- a/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
+++ b/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
@@ -2,6 +2,7 @@
 import { MODES } from '../../systems/game/runtime/GameModeStateMachine.js';
 import type { GameFacadeStateAccess } from './GameFacadeSharedTypes.js';
 import { getDeveloperModeConfig } from '../../utils/DeveloperModeConfig.js';
+import Item from '../../entities/Item.js';
 
 export default class GameFacadeLifecycleCoordinator {
     private readonly state: GameFacadeStateAccess;
@@ -203,12 +204,15 @@ export default class GameFacadeLifecycleCoordinator {
 
     public onVillageEntered(): void {
         const villageName = this.state.worldMap.getVillageNameAtPlayerPosition();
-        const questChanged = this.state.questRuntime.recordLocationEntry(
+        const questUpdate = this.state.questRuntime.recordLocationEntry(
             villageName,
             this.state.player.getInventory().map((item) => item.name),
+            (item) => this.awardRecoveredQuestItem(item, villageName),
         );
-        if (questChanged) {
+        questUpdate.logs.forEach((line) => this.state.hudCoordinator.addBattleLog(line, 'system-message'));
+        if (questUpdate.changed) {
             this.state.hudCoordinator.addBattleLog(`Quest tracker: objectives updated at ${villageName}.`, 'system');
+            this.refreshHud();
         }
         this.refreshGroupPanel();
         this.state.villageCoordinator.enterVillageMode(
@@ -240,6 +244,23 @@ export default class GameFacadeLifecycleCoordinator {
         const members = this.state.questRuntime.getGroupMembers();
         const lines = members.map((member) => `${member.name} — HP ${member.hp}/${member.maxHp} (${member.status})`);
         this.state.hudCoordinator.updateGroupPanel(lines);
+    }
+
+    private awardRecoveredQuestItem(item: Item, villageName: string): boolean {
+        const beforeInventory = this.state.player.getInventory();
+        const hadItemBefore = beforeInventory.some((entry) => entry.name === item.name);
+        const wasAdded = this.state.player.addItemToInventory(item);
+        const hasItemAfterFirstAttempt = this.state.player.getInventory().some((entry) => entry.name === item.name);
+        if (!hadItemBefore && wasAdded && !hasItemAfterFirstAttempt) {
+            const fallbackAdded = this.state.player.addItemToInventory(item);
+            const hasItemAfterFallback = this.state.player.getInventory().some((entry) => entry.name === item.name);
+            if (!fallbackAdded || !hasItemAfterFallback) {
+                this.state.hudCoordinator.addBattleLog(`Quest tracker: failed to persist recovered item ${item.name} at ${villageName}.`, 'system-message');
+                return false;
+            }
+            return true;
+        }
+        return wasAdded && hasItemAfterFirstAttempt;
     }
 
     private refreshHud(): void {

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -193,19 +193,23 @@ export default class GameQuestRuntime {
         return true;
     }
 
-    public recordLocationEntry(locationName: string, carriedItemNames: string[]): boolean {
+    public recordLocationEntry(
+        locationName: string,
+        carriedItemNames: string[],
+        onRecoveredItemFound?: (item: Item) => boolean,
+    ): { changed: boolean; logs: string[] } {
         if (!this.questProgressTracker || !this.questUiController || !this.activeQuest) {
-            return false;
+            return { changed: false, logs: [] };
         }
         const locationChanged = this.questProgressTracker.recordLocationEntryWithInventory(locationName, carriedItemNames);
-        const sideQuestChanged = this.progressSideQuestsOnLocationEntry(locationName, carriedItemNames);
+        const sideQuestProgress = this.progressSideQuestsOnLocationEntry(locationName, carriedItemNames, onRecoveredItemFound);
         const escortChanged = this.resolveEscortArrival(locationName);
-        if (!locationChanged && !sideQuestChanged && !escortChanged) {
-            return false;
+        if (!locationChanged && !sideQuestProgress.changed && !escortChanged) {
+            return { changed: false, logs: sideQuestProgress.logs };
         }
         this.renderQuestUi();
         this.refreshContracts();
-        return true;
+        return { changed: true, logs: sideQuestProgress.logs };
     }
 
     public getKnownQuestLocationNames(): string[] {
@@ -1204,8 +1208,42 @@ export default class GameQuestRuntime {
         return known;
     }
 
-    private progressSideQuestsOnLocationEntry(locationName: string, carriedItemNames: string[]): boolean {
-        return this.progressActiveSideQuests((tracker) => tracker.recordLocationEntryWithInventory(locationName, carriedItemNames));
+    private progressSideQuestsOnLocationEntry(
+        locationName: string,
+        carriedItemNames: string[],
+        onRecoveredItemFound?: (item: Item) => boolean,
+    ): { changed: boolean; logs: string[] } {
+        const normalizedLocation = locationName.trim();
+        const lines: string[] = [];
+        let changed = false;
+
+        for (const sideQuest of this.activeSideQuests) {
+            if (sideQuest.status !== 'active') {
+                continue;
+            }
+
+            const tracker = new QuestProgressTracker(sideQuest);
+            let sideQuestChanged = false;
+            const recoverLogs = this.autoRecoverSideQuestItems(sideQuest, normalizedLocation, onRecoveredItemFound);
+            if (recoverLogs.length > 0) {
+                recoverLogs.forEach((line) => lines.push(line));
+                tracker.recomputeCompletion();
+                sideQuestChanged = true;
+            }
+            if (tracker.recordLocationEntryWithInventory(locationName, carriedItemNames)) {
+                sideQuestChanged = true;
+            }
+            if (!sideQuestChanged) {
+                continue;
+            }
+            changed = true;
+            if (sideQuest.isCompleted) {
+                sideQuest.status = 'readyToTurnIn';
+                lines.push(`Side quest ready to turn in: ${sideQuest.title}.`);
+            }
+        }
+
+        return { changed, logs: lines };
     }
 
     private progressSideQuestsOnBarterCompletion(traderName: string, itemName: string, villageName: string): boolean {
@@ -1214,6 +1252,41 @@ export default class GameQuestRuntime {
 
     private progressSideQuestsOnMonsterKill(monsterName: string): boolean {
         return this.progressActiveSideQuests((tracker) => tracker.recordMonsterKill(monsterName));
+    }
+
+    private autoRecoverSideQuestItems(
+        sideQuest: QuestNode,
+        locationName: string,
+        onRecoveredItemFound?: (item: Item) => boolean,
+    ): string[] {
+        const normalizedLocation = locationName.trim().toLocaleLowerCase();
+        if (!normalizedLocation) {
+            return [];
+        }
+        const logs: string[] = [];
+        this.visitQuestNodes(sideQuest, (node) => {
+            if (node.objectiveType !== 'recover' || node.children.length > 0 || node.isCompleted) {
+                return;
+            }
+            const recover = node.objectiveData?.recover;
+            if (!recover || recover.currentVillage.trim().toLocaleLowerCase() !== normalizedLocation) {
+                return;
+            }
+            const recoverItem = this.createRecoverQuestItem(recover.itemName);
+            if (!onRecoveredItemFound) {
+                logs.push(`Quest tracker: recover item "${recover.itemName}" could not be awarded because inventory callback is unavailable.`);
+                return;
+            }
+            const wasAdded = onRecoveredItemFound(recoverItem);
+            if (!wasAdded) {
+                logs.push(`Quest tracker: Found ${recover.itemName} in ${recover.currentVillage}, but your inventory is full.`);
+                return;
+            }
+            node.isCompleted = true;
+            recover.isPersonKnown = true;
+            logs.push(`Quest tracker: Found ${recover.itemName} lying on the ground in ${recover.currentVillage}.`);
+        });
+        return logs;
     }
 
     private progressActiveSideQuests(progressFn: (tracker: QuestProgressTracker) => boolean): boolean {

--- a/rgfn_game/test/systems/recoverQuestRuntime.test.js
+++ b/rgfn_game/test/systems/recoverQuestRuntime.test.js
@@ -190,6 +190,34 @@ function createActiveScoutSideQuest(overrides = {}) {
   };
 }
 
+function createActiveRecoverSideQuest(overrides = {}) {
+  return {
+    id: 'side-recover',
+    title: 'Recover Torlys Eshlor',
+    description: 'Retrieve Torlys Eshlor from Golden Beacon.',
+    conditionText: 'Obtain Torlys Eshlor at Golden Beacon.',
+    objectiveType: 'recover',
+    entities: [{ text: 'Torlys Eshlor', type: 'item' }, { text: 'Golden Beacon', type: 'location' }],
+    objectiveData: {
+      recover: {
+        itemName: 'Torlys Eshlor',
+        personName: 'Unknown',
+        initialVillage: 'Golden Beacon',
+        currentVillage: 'Golden Beacon',
+        isPersonKnown: false,
+        hasFled: false,
+      },
+    },
+    children: [],
+    isCompleted: false,
+    track: 'side',
+    giverNpcName: 'Rica',
+    giverVillageName: 'Selzen',
+    status: 'active',
+    ...overrides,
+  };
+}
+
 test('GameQuestRuntime revealRecoverHolder confirms target person when speaking with another villager', () => {
   const runtime = new GameQuestRuntime();
   const quest = createRecoverQuest();
@@ -455,8 +483,49 @@ test('GameQuestRuntime marks active scout side quests ready to turn in after ent
 
   const updated = runtime.recordLocationEntry('Golden Beacon', []);
 
-  assert.equal(updated, true);
+  assert.equal(updated.changed, true);
   assert.equal(sideQuest.children[0].isCompleted, true);
   assert.equal(sideQuest.isCompleted, true);
   assert.equal(sideQuest.status, 'readyToTurnIn');
+});
+
+test('GameQuestRuntime auto-recovers side-quest recover items on village entry and marks quest ready to turn in', () => {
+  const runtime = new GameQuestRuntime();
+  const mainQuest = createQuestWithKnownAndUnknownContracts();
+  const sideQuest = createActiveRecoverSideQuest();
+  const foundItems = [];
+  runtime.activeQuest = mainQuest;
+  runtime.questProgressTracker = new QuestProgressTracker(mainQuest);
+  runtime.questUiController = { renderQuest: () => {} };
+  runtime.refreshContracts = () => {};
+  runtime.activeSideQuests = [sideQuest];
+
+  const updated = runtime.recordLocationEntry('Golden Beacon', [], (item) => {
+    foundItems.push(item.name);
+    return true;
+  });
+
+  assert.equal(updated.changed, true);
+  assert.equal(foundItems.includes('Torlys Eshlor'), true);
+  assert.equal(updated.logs.some((line) => line.includes('Found Torlys Eshlor lying on the ground in Golden Beacon')), true);
+  assert.equal(sideQuest.isCompleted, true);
+  assert.equal(sideQuest.status, 'readyToTurnIn');
+});
+
+test('GameQuestRuntime does not complete recover side quest when inventory rejects awarded item', () => {
+  const runtime = new GameQuestRuntime();
+  const mainQuest = createQuestWithKnownAndUnknownContracts();
+  const sideQuest = createActiveRecoverSideQuest({ title: 'Recover blocked item' });
+  runtime.activeQuest = mainQuest;
+  runtime.questProgressTracker = new QuestProgressTracker(mainQuest);
+  runtime.questUiController = { renderQuest: () => {} };
+  runtime.refreshContracts = () => {};
+  runtime.activeSideQuests = [sideQuest];
+
+  const updated = runtime.recordLocationEntry('Golden Beacon', [], () => false);
+
+  assert.equal(updated.changed, true);
+  assert.equal(updated.logs.some((line) => line.includes('inventory is full')), true);
+  assert.equal(sideQuest.isCompleted, false);
+  assert.equal(sideQuest.status, 'active');
 });

--- a/rgfn_game/test/systems/scenarios/gameFacadeLifecycleCoordinator.test.js
+++ b/rgfn_game/test/systems/scenarios/gameFacadeLifecycleCoordinator.test.js
@@ -45,3 +45,99 @@ test('GameFacadeLifecycleCoordinator does not re-register location when first re
   assert.deepEqual(worldMapCalls.register, []);
   assert.equal(transitions.length, 1);
 });
+
+test('GameFacadeLifecycleCoordinator village entry forwards recover item callback and refreshes HUD when quest state changes', () => {
+  const addedItems = [{ name: 'Lorka' }];
+  let callbackInvocations = 0;
+  let hudRefreshes = 0;
+  const battleLogs = [];
+  const enteredVillageModes = [];
+  const groupUpdates = [];
+  const coordinator = new GameFacadeLifecycleCoordinator({
+    worldMap: {
+      getVillageNameAtPlayerPosition: () => 'Golden Beacon',
+    },
+    questRuntime: {
+      recordLocationEntry: (_village, _carried, onRecoveredItemFound) => {
+        callbackInvocations += 1;
+        const wasAdded = onRecoveredItemFound({
+          name: 'Torlys Eshlor',
+        });
+        return {
+          changed: wasAdded,
+          logs: ['Quest tracker: Found Torlys Eshlor lying on the ground in Golden Beacon.'],
+        };
+      },
+      getGroupMembers: () => [{ name: 'Escort Ally', hp: 10, maxHp: 12, status: 'following' }],
+    },
+    player: {
+      getInventory: () => [...addedItems],
+      addItemToInventory: (item) => {
+        addedItems.push({ name: item.name });
+        return true;
+      },
+    },
+    hudCoordinator: {
+      addBattleLog: (line) => battleLogs.push(line),
+      updateHUD: () => { hudRefreshes += 1; },
+      updateGroupPanel: (lines) => groupUpdates.push(lines),
+    },
+    villageCoordinator: {
+      enterVillageMode: (width, height, villageName) => enteredVillageModes.push({ width, height, villageName }),
+    },
+    canvas: { width: 800, height: 600 },
+  });
+
+  coordinator.onVillageEntered();
+
+  assert.equal(callbackInvocations, 1);
+  assert.equal(addedItems.some((item) => item.name === 'Torlys Eshlor'), true);
+  assert.equal(hudRefreshes, 1);
+  assert.equal(battleLogs.some((line) => line.includes('Found Torlys Eshlor')), true);
+  assert.equal(battleLogs.some((line) => line.includes('objectives updated at Golden Beacon')), true);
+  assert.deepEqual(enteredVillageModes, [{ width: 800, height: 600, villageName: 'Golden Beacon' }]);
+  assert.deepEqual(groupUpdates, [['Escort Ally — HP 10/12 (following)']]);
+});
+
+test('GameFacadeLifecycleCoordinator retries recovered item award when add reports success but inventory does not reflect the item', () => {
+  const inventory = [{ name: 'Lorka' }];
+  let addCalls = 0;
+  const battleLogs = [];
+  const coordinator = new GameFacadeLifecycleCoordinator({
+    worldMap: {
+      getVillageNameAtPlayerPosition: () => 'Golden Beacon',
+    },
+    questRuntime: {
+      recordLocationEntry: (_village, _carried, onRecoveredItemFound) => ({
+        changed: onRecoveredItemFound({ name: 'Torlys Eshlor' }),
+        logs: [],
+      }),
+      getGroupMembers: () => [],
+    },
+    player: {
+      getInventory: () => [...inventory],
+      addItemToInventory: (item) => {
+        addCalls += 1;
+        if (addCalls >= 2) {
+          inventory.push({ name: item.name });
+        }
+        return true;
+      },
+    },
+    hudCoordinator: {
+      addBattleLog: (line) => battleLogs.push(line),
+      updateHUD: () => {},
+      updateGroupPanel: () => {},
+    },
+    villageCoordinator: {
+      enterVillageMode: () => {},
+    },
+    canvas: { width: 800, height: 600 },
+  });
+
+  coordinator.onVillageEntered();
+
+  assert.equal(addCalls, 2);
+  assert.equal(inventory.some((item) => item.name === 'Torlys Eshlor'), true);
+  assert.equal(battleLogs.some((line) => line.includes('failed to persist recovered item')), false);
+});


### PR DESCRIPTION
### Motivation

- Ensure recover-type side quests advance when the player enters the target village by auto-awarding the recovered item and only completing the objective when the item is actually present in inventory. 
- Fix playability regressions where scout-style side quests and recover side quests did not reliably progress on village entry or the HUD/inventory view lagged behind runtime state. 

### Description

- Change `GameQuestRuntime.recordLocationEntry` to return `{ changed, logs }` and accept an optional `onRecoveredItemFound` callback, and add `progressSideQuestsOnLocationEntry` to drive side-quest progression on location entry. 
- Implement `autoRecoverSideQuestItems` in `GameQuestRuntime` to discover recover items for leaf-side-quest nodes, call the provided callback to award items, log outcomes, and only mark side quests `readyToTurnIn` when objectives are truly completed. 
- Add `awardRecoveredQuestItem` to `GameFacadeLifecycleCoordinator` which attempts to add the recovered item, verifies the inventory snapshot by name, retries once if necessary, and emits failure logs if persistence fails; forward the callback from `onVillageEntered`, surface quest logs to the HUD, and refresh the HUD immediately when quest state changes. 
- Preserve existing progression and UI refresh flow for other objective types while centralizing side-quest progression paths and adding explicit log messages for found items and failure cases. 

### Testing

- Added unit tests in `test/systems/recoverQuestRuntime.test.js` covering scout progression update shape, auto-recover on village entry, and blocked completion when the inventory award callback returns `false`, and they succeeded. 
- Added scenario tests in `test/systems/scenarios/gameFacadeLifecycleCoordinator.test.js` that verify the village-entry recover callback is invoked, the recovered item is added to inventory, the HUD refresh is triggered after quest state changes, and the retry-on-inconsistent-inventory behavior executes, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14c6ef0848323bf387da9b47da795)