### PR TITLE
Fix side-quest turn-in rewards not applying in RGFN

### DIFF
--- a/rgfn_game/docs/quests/side-quest-turn-in-reward-fix-2026-04-16.md
+++ b/rgfn_game/docs/quests/side-quest-turn-in-reward-fix-2026-04-16.md
@@ -1,0 +1,21 @@
+# Side-Quest Turn-In Reward Fix (2026-04-16)
+
+## Symptom
+- Side-quest turn-in logs displayed `"Reward received: <xp>, <gold>, <item>"`, but player progression did not change.
+- XP, level progression, and gold stayed unchanged after successful side-quest turn-in.
+
+## Root Cause
+- `GameQuestRuntime.turnInSideQuest()` changed quest status to `completed` and returned reward text only.
+- `GameFacade.turnInSideQuest()` forwarded runtime results without applying `rewardMetadata` to the player state.
+- Result: reward messaging existed, but no gameplay state mutation happened for XP/gold.
+
+## Fix
+- `GameQuestRuntime.turnInSideQuest()` now returns `rewardMetadata` alongside reward text for successful turn-ins.
+- `GameFacade.turnInSideQuest()` now applies:
+  - `player.gold += rewardMetadata.gold`
+  - `player.addXp(rewardMetadata.xp)`
+- This ensures quest rewards are actually granted during hand-in, matching the log output and design intent.
+
+## Notes
+- Reward item names generated for side quests (`Repair Kit`, `Hunter Tonic`, `Scout Charm`, `Trail Rations`) are currently descriptive reward text, not wired to concrete inventory item IDs.
+- XP and gold are now authoritative reward effects at turn-in.

--- a/rgfn_game/docs/quests/side-quest-turn-in-reward-fix-2026-04-16.md
+++ b/rgfn_game/docs/quests/side-quest-turn-in-reward-fix-2026-04-16.md
@@ -8,14 +8,17 @@
 - `GameQuestRuntime.turnInSideQuest()` changed quest status to `completed` and returned reward text only.
 - `GameFacade.turnInSideQuest()` forwarded runtime results without applying `rewardMetadata` to the player state.
 - Result: reward messaging existed, but no gameplay state mutation happened for XP/gold.
+- After first fix, another gap remained for legacy/in-flight side quests that had reward text but no `rewardMetadata` (for example from older saves). Those quests still logged rewards without applying XP/gold.
 
 ## Fix
 - `GameQuestRuntime.turnInSideQuest()` now returns `rewardMetadata` alongside reward text for successful turn-ins.
 - `GameFacade.turnInSideQuest()` now applies:
   - `player.gold += rewardMetadata.gold`
   - `player.addXp(rewardMetadata.xp)`
+- Added reward metadata resolver fallback that parses legacy reward text (`"<xp> XP, <gold>g, <item>"`) whenever structured metadata is absent, so side-quest rewards apply consistently across existing and newly generated quests.
 - This ensures quest rewards are actually granted during hand-in, matching the log output and design intent.
 
 ## Notes
 - Reward item names generated for side quests (`Repair Kit`, `Hunter Tonic`, `Scout Charm`, `Trail Rations`) are currently descriptive reward text, not wired to concrete inventory item IDs.
 - XP and gold are now authoritative reward effects at turn-in.
+- Resolver supports all side-quest types because reward application happens centrally in `GameFacade.turnInSideQuest()` after any successful side-quest hand-in, independent of objective type (`scout`, `deliver`, `recover`, etc.).

--- a/rgfn_game/docs/quests/side-quest-turn-in-reward-fix-2026-04-16.md
+++ b/rgfn_game/docs/quests/side-quest-turn-in-reward-fix-2026-04-16.md
@@ -9,6 +9,7 @@
 - `GameFacade.turnInSideQuest()` forwarded runtime results without applying `rewardMetadata` to the player state.
 - Result: reward messaging existed, but no gameplay state mutation happened for XP/gold.
 - After first fix, another gap remained for legacy/in-flight side quests that had reward text but no `rewardMetadata` (for example from older saves). Those quests still logged rewards without applying XP/gold.
+- After applying rewards in runtime/facade, village side-quest turn-in still did not force an immediate HUD refresh (`onUpdateHUD`) like other village economy actions do. This made XP/gold appear unchanged in the UI even after reward mutation.
 
 ## Fix
 - `GameQuestRuntime.turnInSideQuest()` now returns `rewardMetadata` alongside reward text for successful turn-ins.
@@ -16,6 +17,7 @@
   - `player.gold += rewardMetadata.gold`
   - `player.addXp(rewardMetadata.xp)`
 - Added reward metadata resolver fallback that parses legacy reward text (`"<xp> XP, <gold>g, <item>"`) whenever structured metadata is absent, so side-quest rewards apply consistently across existing and newly generated quests.
+- Added an immediate HUD refresh callback invocation after successful side-quest turn-in (`VillageActionsController.completeSideQuestTurnIn -> callbacks.onUpdateHUD()`), so stats/inventory panels reflect new XP and gold instantly.
 - This ensures quest rewards are actually granted during hand-in, matching the log output and design intent.
 
 ## Notes

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -30,6 +30,7 @@ import type { GameFacadeStateAccess } from './runtime/GameFacadeSharedTypes.js';
 import { FerryRouteOption } from '../systems/world-mode/WorldModeFerryPromptController.js';
 import GameTimeRuntime from '../systems/time/GameTimeRuntime.js';
 import { QuestNode, QuestRewardMetadata } from '../systems/quest/QuestTypes.js';
+import { resolveSideQuestRewardMetadata } from '../systems/quest/QuestRewardResolver.js';
 
 export type UIBundle = {
     hudElements: HudElements;
@@ -199,11 +200,12 @@ export class GameFacade implements GameFacadeStateAccess {
         rewardMetadata?: QuestRewardMetadata;
     } => {
         const result = this.questRuntime.turnInSideQuest(questId, npcName, villageName);
-        if (!result.turnedIn || !result.rewardMetadata) {
+        const rewardMetadata = resolveSideQuestRewardMetadata(result.rewardMetadata, result.reward);
+        if (!result.turnedIn || !rewardMetadata) {
             return result;
         }
-        this.player.gold += Math.max(0, Math.floor(result.rewardMetadata.gold));
-        this.player.addXp(Math.max(0, Math.floor(result.rewardMetadata.xp)));
+        this.player.gold += Math.max(0, Math.floor(rewardMetadata.gold));
+        this.player.addXp(Math.max(0, Math.floor(rewardMetadata.xp)));
         return result;
     };
 

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -29,7 +29,7 @@ import { createGameRuntime } from './GameFactory.js';
 import type { GameFacadeStateAccess } from './runtime/GameFacadeSharedTypes.js';
 import { FerryRouteOption } from '../systems/world-mode/WorldModeFerryPromptController.js';
 import GameTimeRuntime from '../systems/time/GameTimeRuntime.js';
-import { QuestNode } from '../systems/quest/QuestTypes.js';
+import { QuestNode, QuestRewardMetadata } from '../systems/quest/QuestTypes.js';
 
 export type UIBundle = {
     hudElements: HudElements;
@@ -192,8 +192,20 @@ export class GameFacade implements GameFacadeStateAccess {
         questId: string,
         npcName: string,
         villageName: string,
-    ): { turnedIn: boolean; reason?: 'inactive' | 'not-found' | 'wrong-giver' | 'not-ready' | 'already-completed'; reward?: string } =>
-        this.questRuntime.turnInSideQuest(questId, npcName, villageName);
+    ): {
+        turnedIn: boolean;
+        reason?: 'inactive' | 'not-found' | 'wrong-giver' | 'not-ready' | 'already-completed';
+        reward?: string;
+        rewardMetadata?: QuestRewardMetadata;
+    } => {
+        const result = this.questRuntime.turnInSideQuest(questId, npcName, villageName);
+        if (!result.turnedIn || !result.rewardMetadata) {
+            return result;
+        }
+        this.player.gold += Math.max(0, Math.floor(result.rewardMetadata.gold));
+        this.player.addXp(Math.max(0, Math.floor(result.rewardMetadata.xp)));
+        return result;
+    };
 
     public tryCreateQuestMonsterEncounter = (): {
         enemies: import('../entities/Skeleton.js').default[];

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -2,7 +2,15 @@
 /* eslint-disable style-guide/rule17-comma-layout, style-guide/arrow-function-style */
 import QuestProgressTracker from '../../systems/quest/QuestProgressTracker.js';
 import Item, { DISCOVERABLE_ITEM_LIBRARY } from '../../entities/Item.js';
-import { DefendObjectiveData, DefendObjectiveDefender, EscortObjectiveData, QuestNode, QuestStatus, RecoverObjectiveData } from '../../systems/quest/QuestTypes.js';
+import {
+    DefendObjectiveData,
+    DefendObjectiveDefender,
+    EscortObjectiveData,
+    QuestNode,
+    QuestRewardMetadata,
+    QuestStatus,
+    RecoverObjectiveData,
+} from '../../systems/quest/QuestTypes.js';
 import QuestUiController from '../../systems/quest/ui/QuestUiController.js';
 import QuestGenerator from '../../systems/quest/QuestGenerator.js';
 import WorldMap from '../../systems/world/worldMap/WorldMap.js';
@@ -165,7 +173,12 @@ export default class GameQuestRuntime {
         questId: string,
         npcName: string,
         villageName: string,
-    ): { turnedIn: boolean; reason?: 'inactive' | 'not-found' | 'wrong-giver' | 'not-ready' | 'already-completed'; reward?: string } {
+    ): {
+        turnedIn: boolean;
+        reason?: 'inactive' | 'not-found' | 'wrong-giver' | 'not-ready' | 'already-completed';
+        reward?: string;
+        rewardMetadata?: QuestRewardMetadata;
+    } {
         const normalizedQuestId = questId.trim();
         if (!normalizedQuestId) {
             return { turnedIn: false, reason: 'not-found' };
@@ -186,7 +199,8 @@ export default class GameQuestRuntime {
         quest.status = 'completed';
         quest.isCompleted = true;
         this.renderQuestUi();
-        return { turnedIn: true, reward: quest.reward };
+        const rewardMetadata = quest.rewardMetadata ? { ...quest.rewardMetadata } : undefined;
+        return { turnedIn: true, reward: quest.reward, rewardMetadata };
     }
 
     public markSideQuestReadyToTurnIn(questId: string): boolean {

--- a/rgfn_game/js/systems/quest/QuestRewardResolver.ts
+++ b/rgfn_game/js/systems/quest/QuestRewardResolver.ts
@@ -1,0 +1,33 @@
+import { QuestRewardMetadata } from './QuestTypes.js';
+
+const XP_REWARD_PATTERN = /(\d+)\s*xp/i;
+const GOLD_REWARD_PATTERN = /(\d+)\s*g\b/i;
+
+const parseRewardValue = (text: string, pattern: RegExp): number | null => {
+    const match = text.match(pattern);
+    if (!match) {
+        return null;
+    }
+    const value = Number.parseInt(match[1], 10);
+    return Number.isNaN(value) ? null : value;
+};
+
+const parseLegacyRewardText = (rewardText: string): QuestRewardMetadata | null => {
+    const xp = parseRewardValue(rewardText, XP_REWARD_PATTERN);
+    const gold = parseRewardValue(rewardText, GOLD_REWARD_PATTERN);
+    if (xp === null || gold === null) {
+        return null;
+    }
+    const itemName = rewardText.split(',').slice(2).join(',').trim() || 'Unknown reward item';
+    return { xp, gold, itemName, requiresTurnIn: true };
+};
+
+export const resolveSideQuestRewardMetadata = (rewardMetadata: QuestRewardMetadata | undefined, rewardText: string | undefined): QuestRewardMetadata | null => {
+    if (rewardMetadata) {
+        return rewardMetadata;
+    }
+    if (!rewardText) {
+        return null;
+    }
+    return parseLegacyRewardText(rewardText);
+};

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -667,6 +667,7 @@ export default class VillageActionsController {
         this.readySideQuestLogIds.delete(questId);
         this.addLog(`${selectedNpc.name} accepts your side-quest turn-in for ${questId}.${reward ? ` Reward received: ${reward}.` : ''}`, 'system');
         this.addLog('Quest tracker updated: side quest turned in.', 'system-message');
+        this.callbacks.onUpdateHUD();
         this.refreshSelectedNpcSideQuestUi(selectedNpc);
     }
 

--- a/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
+++ b/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
@@ -1,7 +1,7 @@
 import Item from '../../../entities/Item.js';
 import Skeleton from '../../../entities/Skeleton.js';
 import { PersonDirectionHint, VillageDirectionHint, VillageNpcProfile } from '../VillageDialogueEngine.js';
-import { DeliverObjectiveData, LocalDeliveryObjectiveData, QuestNode } from '../../quest/QuestTypes.js';
+import { DeliverObjectiveData, LocalDeliveryObjectiveData, QuestNode, QuestRewardMetadata } from '../../quest/QuestTypes.js';
 
 export type VillageUI = {
     sidebar: HTMLElement;
@@ -66,11 +66,12 @@ export type VillageActionsCallbacks = {
     getActiveSideQuests?: () => QuestNode[];
     acceptSideQuest?: (questId: string) => { accepted: boolean; reason?: 'inactive' | 'not-found' | 'already-active' };
     markSideQuestReadyToTurnIn?: (questId: string) => boolean;
-    turnInSideQuest?: (
-        questId: string,
-        npcName: string,
-        villageName: string,
-    ) => { turnedIn: boolean; reason?: 'inactive' | 'not-found' | 'wrong-giver' | 'not-ready' | 'already-completed'; reward?: string };
+    turnInSideQuest?: (questId: string, npcName: string, villageName: string) => {
+        turnedIn: boolean;
+        reason?: 'inactive' | 'not-found' | 'wrong-giver' | 'not-ready' | 'already-completed';
+        reward?: string;
+        rewardMetadata?: QuestRewardMetadata;
+    };
 };
 
 export type QuestEscortContract = {

--- a/rgfn_game/test/systems/questRewardResolver.test.js
+++ b/rgfn_game/test/systems/questRewardResolver.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveSideQuestRewardMetadata } from '../../dist/systems/quest/QuestRewardResolver.js';
+
+test('resolveSideQuestRewardMetadata prefers explicit metadata when present', () => {
+  const resolved = resolveSideQuestRewardMetadata(
+    { xp: 17, gold: 33, itemName: 'Scout Charm', requiresTurnIn: true },
+    '99 XP, 99g, Not used'
+  );
+
+  assert.equal(resolved?.xp, 17);
+  assert.equal(resolved?.gold, 33);
+  assert.equal(resolved?.itemName, 'Scout Charm');
+});
+
+test('resolveSideQuestRewardMetadata parses legacy reward strings', () => {
+  const resolved = resolveSideQuestRewardMetadata(undefined, '21 XP, 29g, Hunter Tonic');
+
+  assert.equal(resolved?.xp, 21);
+  assert.equal(resolved?.gold, 29);
+  assert.equal(resolved?.itemName, 'Hunter Tonic');
+  assert.equal(resolved?.requiresTurnIn, true);
+});
+
+test('resolveSideQuestRewardMetadata returns null when reward text does not include XP and gold', () => {
+  const resolved = resolveSideQuestRewardMetadata(undefined, 'Unknown reward');
+  assert.equal(resolved, null);
+});

--- a/rgfn_game/test/systems/recoverQuestRuntime.test.js
+++ b/rgfn_game/test/systems/recoverQuestRuntime.test.js
@@ -156,6 +156,7 @@ function createSideQuest(overrides = {}) {
     giverNpcName: 'Mira',
     giverVillageName: 'Ashford',
     reward: '18g',
+    rewardMetadata: { xp: 18, gold: 18, itemName: 'Scout Charm', requiresTurnIn: true },
     status: 'available',
     ...overrides,
   };
@@ -440,6 +441,8 @@ test('GameQuestRuntime side-quest turn-in requires the original quest giver and 
 
   const success = runtime.turnInSideQuest('side-turnin', 'Mira', 'Ashford');
   assert.equal(success.turnedIn, true);
+  assert.equal(success.rewardMetadata?.xp, 18);
+  assert.equal(success.rewardMetadata?.gold, 18);
   assert.equal(runtime.activeSideQuests[0].status, 'completed');
 });
 

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -892,6 +892,7 @@ test('VillageActionsController shows turn-in action for ready side quests and tu
   const villageUI = createVillageUi();
   const gameLog = createElement();
   let turnInCalls = 0;
+  let hudUpdates = 0;
   const readyQuest = {
     id: 'side-quest-ready',
     title: 'Deliver Herbs',
@@ -901,7 +902,7 @@ test('VillageActionsController shows turn-in action for ready side quests and tu
     children: [],
   };
   const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
-    onUpdateHUD: () => {},
+    onUpdateHUD: () => { hudUpdates += 1; },
     onLeaveVillage: () => {},
     onAdvanceTime: () => {},
     getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
@@ -924,6 +925,7 @@ test('VillageActionsController shows turn-in action for ready side quests and tu
   assert.equal(hasTurnInButton, true);
   controller.handleTurnInSideQuest('side-quest-ready');
   assert.equal(turnInCalls, 1);
+  assert.equal(hudUpdates, 1);
   assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('turn-in')), true);
 }));
 


### PR DESCRIPTION
### Motivation
- Side-quest turn-ins logged a reward string but did not mutate player state, so XP and gold were not granted to the player. This caused visible logs but no gameplay effect.
- The runtime returned only display text for rewards, leaving higher layers without structured reward data to apply to the `Player`.

### Description
- `GameQuestRuntime.turnInSideQuest()` now returns structured `rewardMetadata` (if present) alongside the existing `reward` text for successful turn-ins, by exporting `QuestRewardMetadata` from `QuestTypes` and including it in the return shape. (`rgfn_game/js/game/runtime/GameQuestRuntime.ts`)
- `GameFacade.turnInSideQuest()` now consumes returned `rewardMetadata` and applies rewards to the player by doing `player.gold += ...` and `player.addXp(...)`, ensuring XP and gold are actually awarded when a side quest is turned in. (`rgfn_game/js/game/GameFacade.ts`) 
- Callback typing was updated so village action callbacks accept and propagate `rewardMetadata` in the turn-in payload. (`rgfn_game/js/systems/village/actions/VillageActionsTypes.ts`) 
- Tests updated/added to assert `rewardMetadata` propagation on successful turn-in and confirm runtime behavior. (`rgfn_game/test/systems/recoverQuestRuntime.test.js`) 
- Added a short doc describing symptom, root cause and fix for future reference. (`rgfn_game/docs/quests/side-quest-turn-in-reward-fix-2026-04-16.md`) 

### Testing
- Ran the RGFN test suite with `npm run test:rgfn`, all tests passed (163 tests, 0 failures). 
- Ran `npx eslint` against the modified files with no errors reported for those files. 
- `npm run lint:ts:rgfn` currently reports pre-existing repository-wide lint errors unrelated to these changes (issues in `dist/` and other files); these errors were present before this change and were not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e150b3d5ec8323a3c42d47dd5255c6)