### PR TITLE
Migrate formation runtime to OOP TypeScript modules

### DIFF
--- a/docs/NEON_VOID_MIGRATION_NOTES.md
+++ b/docs/NEON_VOID_MIGRATION_NOTES.md
@@ -78,3 +78,40 @@ This requirement should be treated as default guidance for all future Neon Void 
 1. Introduce `FormationParser`, `WaveDifficultyResolver`, and `FormationPlanner` TS classes in separate files under `js/core/game/formations/` to satisfy OOP-first migration guidance while staying within style-guide length limits.
 2. Make `formations.js` a thin adapter over the compiled TS implementation once all direct JS dependencies are migrated.
 3. Add focused tests for parser failure modes (bad probability expressions, malformed ship tokens, minWave + endless interactions).
+
+## 2026-04-17: formation runtime OOP TS migration checkpoint
+
+### What was migrated
+- Implemented formation runtime logic as typed class modules under `js/core/game/formations/`:
+  - `FormationManager` (orchestration and wave planning API)
+  - `FormationParser` (definition parsing flow)
+  - `FormationPlanner` (selection and timeline building)
+  - `WaveDifficultyResolver` (scheduled + endless difficulty resolution)
+  - `FormationParserUtils` and `FormationNormalization` (focused helper logic)
+  - `FormationTypes` (shared contracts)
+- Updated `js/core/game/formations.ts` to use the new TS runtime classes instead of casting results from legacy `formations.js`.
+- Kept legacy runtime path `js/core/game/formations.js` unchanged so existing JS importers/tests remain stable during mixed migration.
+
+### Why this checkpoint matters
+- This is the first full OOP runtime uplift for formations (not just typed facade contracts).
+- Future migration work can move caller modules to TS without relying on `as` casts around formation planner behavior.
+- Internal responsibilities are now split into smaller files, reducing future lint/style churn when changing individual formation concerns.
+
+### Validation performed in this checkpoint
+- `npx eslint js/core/game/formations.ts js/core/game/formations/*.ts` passed with zero warnings.
+- `npm run build` passed (TypeScript compile).
+- `node --test test/game/formations.test.js` passed (4/4).
+
+### Important test-environment note
+- Running root `npm test` currently fails for pre-existing reasons outside this checkpoint:
+  - multiple `eva_game` and `rgfn_game` tests import from missing `dist/` outputs unless those project-specific builds run first;
+  - several unrelated root projectile tests fail with `enemy.takeDamage is not a function`.
+- Recommended scoped commands for Neon Void migration validation:
+  1. `npm run build`
+  2. `node --test test/game/formations.test.js`
+  3. targeted lint for touched files.
+
+### Follow-up opportunities
+1. Add dedicated tests for parser edge-cases (invalid probability expression fallback, malformed ship tokens, offset parsing).
+2. Add TS-native tests that import from `js/core/game/formations.ts` once TS test harness is introduced.
+3. In a later migration step, move `js/core/game/formations.js` to a thin adapter over compiled output and retire duplicate runtime logic.

--- a/docs/NEON_VOID_TYPESCRIPT_MIGRATION.md
+++ b/docs/NEON_VOID_TYPESCRIPT_MIGRATION.md
@@ -1158,3 +1158,16 @@ Good luck with the migration! 🚀
 - Keep parser/planner/resolver in separate files to satisfy style-guide limits (file/function length).
 - Migrate with compatibility adapters first; remove JS adapters only when all importers use TS-compatible entrypoints.
 - Validate at each step with `npm run build`, targeted tests (`test/game/formations.test.js`), and per-file ESLint checks.
+
+### 2026-04-17
+- Completed the planned “full OOP migration of formation runtime logic into TS classes split by responsibility”.
+- Added class modules under `js/core/game/formations/` and rewired `js/core/game/formations.ts` to use typed runtime classes directly.
+- Maintained mixed-mode compatibility by keeping `formations.js` as the current JS runtime path.
+- Verified with:
+  - `npx eslint js/core/game/formations.ts js/core/game/formations/*.ts`
+  - `npm run build`
+  - `node --test test/game/formations.test.js`
+
+### Updated immediate next step (after 2026-04-17 checkpoint)
+- Add parser/planner edge-case tests for malformed tokens and probability expression fallback.
+- Start migrating one high-coupling caller from JS to TS using `formations.ts` typed runtime API to validate end-to-end adoption path.

--- a/js/core/game/formations.ts
+++ b/js/core/game/formations.ts
@@ -1,66 +1,41 @@
-import createFormationManagerJs, {
-    createFormationManager as createFormationManagerUntyped,
-    parseFormationText as parseFormationTextUntyped,
-} from './formations.js';
+import FormationManagerRuntime from './formations/FormationManager.js';
+import FormationParser from './formations/FormationParser.js';
+import {
+    FormationDefinition,
+    FormationManagerConfig,
+    FormationPlan,
+    FormationShipDescriptor,
+    FormationEvent,
+    WaveScheduleEntry,
+} from './formations/FormationTypes.js';
 
-export type FormationShipDescriptor = {
-    type: string;
-    time?: number;
-    y?: number;
-    x?: number;
-    color?: string;
-    groupSize?: number;
-    spacing?: number;
-    offsets?: number[];
-    colors?: string[];
-};
+const DEFAULTS = { formationGap: 0.75, minimumWeight: 0 };
 
-export type FormationDefinition = {
-    id: string;
-    label: string;
-    difficulty: number;
-    ships: FormationShipDescriptor[];
-    minWave?: number;
-    gap?: number;
-};
-
-export type FormationEvent = FormationShipDescriptor & {
-    time: number;
-    formationId: string;
-};
-
-export type FormationPlan = {
-    wave: number;
-    totalDifficulty: number;
-    remainingDifficulty: number;
-    totalEnemies: number;
-    events: FormationEvent[];
-    selections: FormationDefinition[];
+export type {
+    FormationDefinition,
+    FormationEvent,
+    FormationManagerConfig,
+    FormationPlan,
+    FormationShipDescriptor,
 };
 
 export type FormationManager = {
     defaults: { formationGap: number; minimumWeight: number };
     formations: FormationDefinition[];
     planWave: (wave: number, options?: { totalDifficulty?: number; random?: () => number; iterationLimit?: number }) => FormationPlan | null;
-    hasFormations?: () => boolean;
+    hasFormations: () => boolean;
 };
 
-export type FormationManagerConfig = {
-    definitions?: string;
-    defaults?: Partial<{ formationGap: number; minimumWeight: number }>;
-    formations?: FormationDefinition[];
-    endlessDifficulty?: { startWave?: number; base?: number; growth?: number; max?: number };
-    difficultyMultiplier?: number;
+export const parseFormationText = (definitions: string, defaults: FormationManagerConfig['defaults'] = {}): FormationDefinition[] => {
+    const parser = new FormationParser();
+    return parser.parseFormationText(definitions, { ...DEFAULTS, ...(defaults ?? {}) });
 };
-
-export const parseFormationText = (definitions: string, defaults: FormationManagerConfig['defaults'] = {}) =>
-    parseFormationTextUntyped(definitions, defaults) as FormationDefinition[];
 
 export const createFormationManager = (
     config: FormationManagerConfig = {},
-    waveSchedule: Array<{ difficulty?: number }> = []
-) => createFormationManagerUntyped(config, waveSchedule) as FormationManager | null;
+    waveSchedule: WaveScheduleEntry[] = [],
+): FormationManager | null => FormationManagerRuntime.create(config, waveSchedule);
 
-type FormationFactory = (config?: FormationManagerConfig, waveSchedule?: Array<{ difficulty?: number }>) => FormationManager | null;
+type FormationFactory = (config?: FormationManagerConfig, waveSchedule?: WaveScheduleEntry[]) => FormationManager | null;
 
-export default createFormationManagerJs as FormationFactory;
+export default createFormationManager as FormationFactory;

--- a/js/core/game/formations/FormationManager.ts
+++ b/js/core/game/formations/FormationManager.ts
@@ -1,0 +1,51 @@
+import FormationParser from './FormationParser.js';
+import FormationPlanner from './FormationPlanner.js';
+import {
+    FormationDefaults,
+    FormationDefinition,
+    FormationManagerConfig,
+    FormationPlan,
+    PlanWaveOptions,
+    WaveScheduleEntry,
+} from './FormationTypes.js';
+import WaveDifficultyResolver from './WaveDifficultyResolver.js';
+
+const DEFAULTS: FormationDefaults = { formationGap: 0.75, minimumWeight: 0 };
+
+export default class FormationManager {
+    public readonly defaults: FormationDefaults;
+    public readonly formations: FormationDefinition[];
+
+    private readonly config: FormationManagerConfig;
+    private readonly waveSchedule: WaveScheduleEntry[];
+    private readonly planner: FormationPlanner;
+    private readonly difficultyResolver: WaveDifficultyResolver;
+
+    constructor(config: FormationManagerConfig = {}, waveSchedule: WaveScheduleEntry[] = []) {
+        this.config = config;
+        this.waveSchedule = waveSchedule;
+        this.defaults = { ...DEFAULTS, ...(config.defaults ?? {}) };
+        const parser = new FormationParser();
+        const parsedFormations = parser.parseFormationText(config.definitions ?? '', this.defaults);
+        this.formations = Array.isArray(config.formations) && config.formations.length
+            ? parser.normalizeFormations(config.formations, this.defaults)
+            : parsedFormations;
+        this.planner = new FormationPlanner();
+        this.difficultyResolver = new WaveDifficultyResolver();
+    }
+
+    public static create(config: FormationManagerConfig = {}, waveSchedule: WaveScheduleEntry[] = []): FormationManager | null {
+        const manager = new FormationManager(config, waveSchedule);
+        return manager.hasFormations() ? manager : null;
+    }
+
+    public hasFormations = (): boolean => this.formations.length > 0;
+
+    public planWave(wave: number, options: PlanWaveOptions = {}): FormationPlan | null {
+        const totalDifficulty = Number.isFinite(options.totalDifficulty)
+            ? (options.totalDifficulty as number)
+            : this.difficultyResolver.resolveWaveDifficulty(this.config, this.waveSchedule, wave);
+        return this.planner.planWave(wave, this.formations, this.defaults, totalDifficulty, options);
+    }
+
+}

--- a/js/core/game/formations/FormationNormalization.ts
+++ b/js/core/game/formations/FormationNormalization.ts
@@ -1,0 +1,48 @@
+import { FormationDefinition, FormationDefaults, FormationShipDescriptor } from './FormationTypes.js';
+import { createProbabilityFunction } from './FormationParserUtils.js';
+
+type FormationDraft = FormationDefinition & { probability?: string };
+
+const toNumber = (value: unknown, fallback = 0): number => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const normalizeColor = (ship: FormationShipDescriptor): void => {
+    const lowered = ship.color?.toLowerCase();
+    if (lowered === 'auto' || lowered === 'random') {
+        ship.color = undefined;
+    }
+};
+
+export const normalizeShip = (descriptor: FormationShipDescriptor): FormationShipDescriptor => {
+    const ship = { ...descriptor, time: toNumber(descriptor.time, 0) };
+    normalizeColor(ship);
+    if (Number.isFinite(ship.groupSize)) {
+        ship.groupSize = Math.max(1, Math.floor(ship.groupSize as number));
+    }
+    if (Array.isArray(ship.offsets)) {
+        ship.offsets = ship.offsets.map((value) => toNumber(value, 0));
+    }
+    return ship;
+};
+
+export const finalizeFormation = (draft: FormationDraft | null, defaults: FormationDefaults): FormationDefinition | null => {
+    if (!draft || !draft.ships.length) {
+        return null;
+    }
+    const ships = draft.ships.map((ship) => normalizeShip(ship));
+    const difficulty = Number.isFinite(draft.difficulty) && draft.difficulty > 0 ? draft.difficulty : ships.length;
+    const minWave = Number.isFinite(draft.minWave) ? Math.max(1, Math.floor(draft.minWave ?? 1)) : 1;
+    const duration = ships.reduce((maxTime, ship) => Math.max(maxTime, ship.time ?? 0), 0);
+    return {
+        id: draft.id,
+        label: draft.label,
+        difficulty,
+        probabilityFn: createProbabilityFunction(draft.probability, defaults),
+        ships,
+        duration,
+        gap: Number.isFinite(draft.gap) ? draft.gap : undefined,
+        minWave,
+    };
+};

--- a/js/core/game/formations/FormationParser.ts
+++ b/js/core/game/formations/FormationParser.ts
@@ -1,0 +1,80 @@
+import { FormationDefinition, FormationDefaults } from './FormationTypes.js';
+import {
+    createIdState,
+    parseHeader,
+    parseShipLine,
+} from './FormationParserUtils.js';
+import { finalizeFormation } from './FormationNormalization.js';
+
+export default class FormationParser {
+    private readonly idState = createIdState();
+
+    public parseFormationText(definitions: string, defaults: FormationDefaults): FormationDefinition[] {
+        if (!definitions || typeof definitions !== 'string') {
+            return [];
+        }
+        return this.collectFormations(definitions.split(/\r?\n/), defaults);
+    }
+
+    public normalizeFormations(formations: FormationDefinition[], defaults: FormationDefaults): FormationDefinition[] {
+        if (!Array.isArray(formations)) {
+            return [];
+        }
+        return formations
+            .map((formation) => finalizeFormation(formation as FormationDefinition & { probability?: string }, defaults))
+            .filter((formation): formation is FormationDefinition => Boolean(formation));
+    }
+
+    private collectFormations(lines: string[], defaults: FormationDefaults): FormationDefinition[] {
+        const formations: FormationDefinition[] = [];
+        let current: (FormationDefinition & { probability?: string }) | null = null;
+        for (const rawLine of lines) {
+            current = this.processLine(rawLine.trim(), defaults, formations, current);
+        }
+        this.pushCurrent(formations, current, defaults);
+        return formations;
+    }
+
+    private processLine(
+        line: string,
+        defaults: FormationDefaults,
+        formations: FormationDefinition[],
+        current: (FormationDefinition & { probability?: string }) | null,
+    ): (FormationDefinition & { probability?: string }) | null {
+        const next = this.handleBoundary(line, defaults, formations, current);
+        if (next !== current || !line || line.startsWith('#')) {
+            return next;
+        }
+        return this.appendShip(next, line);
+    }
+
+    private handleBoundary(
+        line: string,
+        defaults: FormationDefaults,
+        formations: FormationDefinition[],
+        current: (FormationDefinition & { probability?: string }) | null,
+    ): (FormationDefinition & { probability?: string }) | null {
+        if (!line) {return current;}
+        if (line === '---') {
+            this.pushCurrent(formations, current, defaults);
+            return null;
+        }
+        if (!line.startsWith('#')) {return current;}
+        this.pushCurrent(formations, current, defaults);
+        return { ...parseHeader(line, this.idState), ships: [] };
+    }
+
+    private appendShip(current: (FormationDefinition & { probability?: string }) | null, line: string): (FormationDefinition & { probability?: string }) | null {
+        if (!current) {return current;}
+        const ship = parseShipLine(line);
+        if (ship) {current.ships.push(ship);}
+        return current;
+    }
+
+    private pushCurrent(formations: FormationDefinition[], current: (FormationDefinition & { probability?: string }) | null, defaults: FormationDefaults): void {
+        const finalized = finalizeFormation(current, defaults);
+        if (finalized) {
+            formations.push(finalized);
+        }
+    }
+}

--- a/js/core/game/formations/FormationParserUtils.ts
+++ b/js/core/game/formations/FormationParserUtils.ts
@@ -1,0 +1,128 @@
+import { FormationDefinition, FormationDefaults, FormationShipDescriptor } from './FormationTypes.js';
+
+const HEADER_MARK = /^#\s*/;
+const COMMENT_SUFFIX = /\s+#.*$/;
+const ID_SANITIZE = /[^a-zA-Z0-9]+/g;
+
+type FormationDraft = FormationDefinition & { probability?: string };
+
+type IdState = { nextId: number };
+
+const toNumber = (value: unknown, fallback = 0): number => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const toFiniteOrUndefined = (value: unknown): number | undefined => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const sanitizeId = (label: string, state: IdState): string => {
+    const trimmed = String(label ?? '').replace(ID_SANITIZE, '-').replace(/^-+|-+$/g, '').toLowerCase();
+    if (trimmed) {
+        return trimmed;
+    }
+    state.nextId += 1;
+    return `formation-${state.nextId}`;
+};
+
+export const createProbabilityFunction = (expression: string | undefined, defaults: FormationDefaults): ((wave: number, formation: FormationDefinition) => number) => {
+    const minimumWeight = defaults.minimumWeight ?? 0;
+    if (!expression || typeof expression !== 'string') {
+        return () => 1;
+    }
+    const compiled = compileExpression(expression);
+    if (!compiled) {
+        return () => minimumWeight;
+    }
+    return (wave, formation) => resolveProbability(compiled, minimumWeight, wave, formation);
+};
+
+const compileExpression = (expression: string): ((wave: number, formation: FormationDefinition) => number) | null => {
+    try {
+        return new Function('wave', 'formation', `return (${expression});`) as (wave: number, formation: FormationDefinition) => number;
+    } catch {
+        return null;
+    }
+};
+
+const resolveProbability = (
+    compiled: (wave: number, formation: FormationDefinition) => number,
+    minimumWeight: number,
+    wave: number,
+    formation: FormationDefinition,
+): number => {
+    try {
+        const value = Number(compiled(wave, formation));
+        return Number.isFinite(value) && value > 0 ? value : minimumWeight;
+    } catch {
+        return minimumWeight;
+    }
+};
+
+export const parseHeader = (line: string, state: IdState): FormationDraft => {
+    const segments = line.replace(HEADER_MARK, '').trim().split('|').map((part) => part.trim()).filter(Boolean);
+    const [first, ...rest] = segments;
+    const header: FormationDraft = { id: sanitizeId(first ?? '', state), label: first ?? '', difficulty: Number.NaN, probability: '', ships: [] };
+    for (const segment of rest) {
+        applyHeaderSegment(header, segment);
+    }
+    return header;
+};
+
+const applyHeaderSegment = (header: FormationDraft, segment: string): void => {
+    const [rawKey, ...valueParts] = segment.split('=');
+    const key = rawKey?.trim().toLowerCase();
+    if (!key) {
+        return;
+    }
+    const value = valueParts.join('=').trim();
+    if (key === 'difficulty') {header.difficulty = toNumber(value, Number.NaN);}
+    if (key === 'probability') {header.probability = value;}
+    if (key === 'gap') {header.gap = toFiniteOrUndefined(value);}
+    if (key === 'minwave') {header.minWave = toFiniteOrUndefined(value);}
+};
+
+export const parseShipLine = (line: string): FormationShipDescriptor | null => {
+    const tokens = line.replace(COMMENT_SUFFIX, '').trim().split(/\s+/).filter(Boolean);
+    if (!tokens.length) {
+        return null;
+    }
+    const [typeToken, ...restTokens] = tokens;
+    const descriptor: FormationShipDescriptor = { type: (typeToken ?? '').toLowerCase(), time: 0 };
+    for (const token of restTokens) {
+        applyShipToken(descriptor, token);
+    }
+    return descriptor;
+};
+
+const applyShipToken = (descriptor: FormationShipDescriptor, token: string): void => {
+    if (token.startsWith('@')) {
+        descriptor.time = toNumber(token.slice(1), descriptor.time ?? 0);
+        return;
+    }
+    const [rawKey, rawValue] = token.split('=');
+    const key = rawKey?.trim().toLowerCase();
+    if (!key) {
+        return;
+    }
+    applyShipProperty(descriptor, key, rawValue?.trim());
+};
+
+const applyShipProperty = (descriptor: FormationShipDescriptor, key: string, value: string | undefined): void => {
+    if (key === 'y') {descriptor.y = toFiniteOrUndefined(value);}
+    if (key === 'x') {descriptor.x = toFiniteOrUndefined(value);}
+    if (key === 'color') {descriptor.color = value ? value.toLowerCase() : undefined;}
+    if (key === 'group' || key === 'groupsize') {descriptor.groupSize = Math.max(1, Math.floor(toNumber(value, descriptor.groupSize ?? 0)));}
+    if (key === 'spacing') {descriptor.spacing = toFiniteOrUndefined(value);}
+    if (key === 'offset') {appendOffset(descriptor, toNumber(value, 0));}
+};
+
+const appendOffset = (descriptor: FormationShipDescriptor, offset: number): void => {
+    const offsets = Array.isArray(descriptor.offsets) ? descriptor.offsets.slice() : [];
+    offsets.push(offset);
+    descriptor.offsets = offsets;
+};
+
+export const createIdState = (): IdState => ({ nextId: 0 });

--- a/js/core/game/formations/FormationPlanner.ts
+++ b/js/core/game/formations/FormationPlanner.ts
@@ -1,0 +1,95 @@
+import { FormationDefaults, FormationDefinition, FormationEvent, FormationPlan, PlanWaveOptions } from './FormationTypes.js';
+
+type WeightedChoice<T> = { items: T[]; weights: number[]; random?: () => number };
+
+type SelectionResult = { selections: FormationDefinition[]; remaining: number };
+
+export default class FormationPlanner {
+    public planWave(
+        wave: number,
+        formations: FormationDefinition[],
+        defaults: FormationDefaults,
+        totalDifficulty: number,
+        options: PlanWaveOptions = {},
+    ): FormationPlan | null {
+        if (!Number.isFinite(totalDifficulty) || totalDifficulty <= 0) {return null;}
+        const result = this.selectFormations(wave, formations, totalDifficulty, options);
+        if (!result.selections.length) {return null;}
+        const events = this.buildEventsTimeline(result.selections, defaults);
+        const spent = result.selections.reduce((sum, formation) => sum + formation.difficulty, 0);
+        return { wave, totalDifficulty: spent, remainingDifficulty: Math.max(0, result.remaining), totalEnemies: events.length, events, selections: result.selections };
+    }
+
+    private selectFormations(wave: number, formations: FormationDefinition[], totalDifficulty: number, options: PlanWaveOptions): SelectionResult {
+        const randomFn = typeof options.random === 'function' ? options.random : undefined;
+        const selections: FormationDefinition[] = [];
+        const safetyLimit = Math.max(1, options.iterationLimit ?? 200);
+        let remaining = Math.max(0, Math.floor(totalDifficulty));
+        let iterations = 0;
+        while (remaining > 0 && iterations < safetyLimit) {
+            iterations += 1;
+            const chosen = this.chooseFormation(wave, formations, remaining, randomFn);
+            if (!chosen) {break;}
+            selections.push(chosen);
+            remaining -= chosen.difficulty;
+        }
+        return { selections, remaining };
+    }
+
+    private chooseFormation(wave: number, formations: FormationDefinition[], remaining: number, random?: () => number): FormationDefinition | null {
+        const candidates = formations.filter((formation) => formation.difficulty <= remaining && wave >= (formation.minWave ?? 1));
+        if (!candidates.length) {return null;}
+        const weights = candidates.map((candidate) => candidate.probabilityFn?.(wave, candidate) ?? 0);
+        return this.weightedRandomChoice({ items: candidates, weights, random });
+    }
+
+    private buildEventsTimeline(selections: FormationDefinition[], defaults: FormationDefaults): FormationEvent[] {
+        const events: FormationEvent[] = [];
+        let cursorTime = 0;
+        for (const selection of selections) {
+            cursorTime = this.appendSelectionEvents(events, selection, cursorTime, defaults);
+        }
+        events.sort((a, b) => a.time - b.time || a.formationId.localeCompare(b.formationId));
+        return events;
+    }
+
+    private appendSelectionEvents(events: FormationEvent[], selection: FormationDefinition, cursorTime: number, defaults: FormationDefaults): number {
+        let localMax = 0;
+        for (const ship of selection.ships) {
+            localMax = Math.max(localMax, ship.time ?? 0);
+            events.push(this.toEvent(selection, ship, cursorTime));
+        }
+        const gap = Number.isFinite(selection.gap) ? (selection.gap as number) : defaults.formationGap;
+        return cursorTime + localMax + Math.max(0, gap);
+    }
+
+    private readonly toEvent = (selection: FormationDefinition, ship: FormationDefinition['ships'][number], cursorTime: number): FormationEvent => ({
+        time: cursorTime + Math.max(0, ship.time ?? 0),
+        type: ship.type,
+        color: ship.color,
+        x: ship.x,
+        y: ship.y,
+        groupSize: ship.groupSize,
+        spacing: ship.spacing,
+        offsets: Array.isArray(ship.offsets) ? ship.offsets.slice() : undefined,
+        colors: Array.isArray(ship.colors) ? ship.colors.slice() : undefined,
+        formationId: selection.id,
+    });
+
+    private weightedRandomChoice<T>({ items, weights, random }: WeightedChoice<T>): T | null {
+        if (!items.length) {return null;}
+        const total = weights.reduce((sum, weight) => sum + (Number.isFinite(weight) ? Math.max(0, weight) : 0), 0);
+        if (total <= 0) {return this.fallbackChoice(items, random);}
+        let roll = (random?.() ?? Math.random()) * total;
+        for (let i = 0; i < items.length; i += 1) {
+            roll -= Number.isFinite(weights[i]) ? Math.max(0, weights[i]) : 0;
+            if (roll <= 0) {return items[i];}
+        }
+        return items.length ? items[items.length - 1] : null;
+    }
+
+    private fallbackChoice<T>(items: T[], random?: () => number): T {
+        const index = Math.floor((random?.() ?? Math.random()) * items.length);
+        return items[Math.min(items.length - 1, Math.max(0, index))];
+    }
+}

--- a/js/core/game/formations/FormationTypes.ts
+++ b/js/core/game/formations/FormationTypes.ts
@@ -1,0 +1,58 @@
+export type FormationDefaults = {
+    formationGap: number;
+    minimumWeight: number;
+};
+
+export type FormationShipDescriptor = {
+    type: string;
+    time?: number;
+    y?: number;
+    x?: number;
+    color?: string;
+    groupSize?: number;
+    spacing?: number;
+    offsets?: number[];
+    colors?: string[];
+};
+
+export type FormationDefinition = {
+    id: string;
+    label: string;
+    difficulty: number;
+    probability?: string;
+    probabilityFn?: (wave: number, formation: FormationDefinition) => number;
+    ships: FormationShipDescriptor[];
+    duration?: number;
+    minWave?: number;
+    gap?: number;
+};
+
+export type FormationEvent = FormationShipDescriptor & {
+    time: number;
+    formationId: string;
+};
+
+export type FormationPlan = {
+    wave: number;
+    totalDifficulty: number;
+    remainingDifficulty: number;
+    totalEnemies: number;
+    events: FormationEvent[];
+    selections: FormationDefinition[];
+};
+
+export type FormationManagerConfig = {
+    definitions?: string;
+    defaults?: Partial<FormationDefaults>;
+    formations?: FormationDefinition[];
+    endlessDifficulty?: { startWave?: number; base?: number; growth?: number; max?: number };
+    difficultyMultiplier?: number;
+};
+
+export type PlanWaveOptions = {
+    totalDifficulty?: number;
+    random?: () => number;
+    iterationLimit?: number;
+};
+
+export type WaveScheduleEntry = { difficulty?: number };

--- a/js/core/game/formations/WaveDifficultyResolver.ts
+++ b/js/core/game/formations/WaveDifficultyResolver.ts
@@ -1,0 +1,37 @@
+import { scaleDifficulty } from '../../../utils/difficultyScaling.js';
+import { FormationManagerConfig, WaveScheduleEntry } from './FormationTypes.js';
+
+export default class WaveDifficultyResolver {
+    public resolveWaveDifficulty(config: FormationManagerConfig, waveSchedule: WaveScheduleEntry[], wave: number): number {
+        const scheduled = this.getScheduledDifficulty(waveSchedule, Math.max(0, Math.floor(wave) - 1));
+        if (Number.isFinite(scheduled)) {return scaleDifficulty(scheduled as number, config);}
+        return scaleDifficulty(this.resolveEndlessDifficulty(config, waveSchedule, wave), config);
+    }
+
+    private resolveEndlessDifficulty(config: FormationManagerConfig, waveSchedule: WaveScheduleEntry[], wave: number): number {
+        const endless = config.endlessDifficulty ?? {};
+        const scheduledLength = Array.isArray(waveSchedule) ? waveSchedule.length : 0;
+        const startWave = Number.isFinite(endless.startWave) ? (endless.startWave as number) : (scheduledLength > 0 ? scheduledLength + 1 : 1);
+        if (wave < startWave) {
+            const last = this.getScheduledDifficulty(waveSchedule, scheduledLength - 1);
+            return Number.isFinite(last) ? (last as number) : 0;
+        }
+        return this.computeEndlessValue(endless, waveSchedule, startWave, wave);
+    }
+
+    private computeEndlessValue(endless: NonNullable<FormationManagerConfig['endlessDifficulty']>, waveSchedule: WaveScheduleEntry[], startWave: number, wave: number): number {
+        const lastScheduled = this.getScheduledDifficulty(waveSchedule, waveSchedule.length - 1);
+        const base = Number.isFinite(endless.base) ? (endless.base as number) : (Number.isFinite(lastScheduled) ? (lastScheduled as number) : 0);
+        const growth = Number.isFinite(endless.growth) ? (endless.growth as number) : 0;
+        const max = Number.isFinite(endless.max) ? (endless.max as number) : Infinity;
+        const waveOffset = Math.max(0, wave - startWave);
+        return Math.min(max, Math.max(0, Math.round(base + growth * waveOffset)));
+    }
+
+    private getScheduledDifficulty(waveSchedule: WaveScheduleEntry[] | WaveScheduleEntry[][], index: number): number | undefined {
+        if (!Array.isArray(waveSchedule) || index < 0 || index >= waveSchedule.length) {return undefined;}
+        const entry = waveSchedule[index] as WaveScheduleEntry | WaveScheduleEntry[];
+        if (Number.isFinite((entry as WaveScheduleEntry)?.difficulty)) {return (entry as WaveScheduleEntry).difficulty;}
+        return Array.isArray(entry) ? this.getScheduledDifficulty(entry, entry.length - 1) : undefined;
+    }
+}

--- a/skills/neon-void-formations-ts-migration/SKILL.md
+++ b/skills/neon-void-formations-ts-migration/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: neon-void-formations-ts-migration
+description: Workflow for continuing Neon Void formation-system TypeScript migration with OOP-first structure, mixed JS/TS compatibility, and deterministic validation commands.
+---
+
+# Neon Void Formations TS Migration
+
+Use this when continuing migration work around `js/core/game/formations*`.
+
+## Goals
+- Keep runtime stable for legacy JS call-sites.
+- Migrate logic in small OOP units (manager/parser/planner/resolver).
+- Maintain zero lint warnings in touched TS files.
+
+## Required flow
+1. Inspect current checkpoints:
+   - `docs/NEON_VOID_MIGRATION_NOTES.md`
+   - `docs/NEON_VOID_TYPESCRIPT_MIGRATION.md`
+
+2. Keep mixed-mode compatibility:
+   - Do **not** remove `js/core/game/formations.js` unless all runtime importers are migrated.
+   - Implement new logic in `js/core/game/formations.ts` and `js/core/game/formations/*.ts` first.
+
+3. Use OOP-first split:
+   - Parser (`FormationParser`)
+   - Planner (`FormationPlanner`)
+   - Difficulty resolver (`WaveDifficultyResolver`)
+   - Manager orchestration (`FormationManager`)
+
+4. Validation commands (run all):
+   - `npx eslint js/core/game/formations.ts js/core/game/formations/*.ts`
+   - `npm run build`
+   - `node --test test/game/formations.test.js`
+
+5. Documentation update (mandatory):
+   - Append migration checkpoint details to `docs/NEON_VOID_MIGRATION_NOTES.md`.
+   - Update progress/next-step section in `docs/NEON_VOID_TYPESCRIPT_MIGRATION.md`.
+
+## Known repo-level caveat
+- Root `npm test` includes eva/rgfn tests that may fail without their own `dist/` builds; treat this as out-of-scope unless the task explicitly targets those suites.


### PR DESCRIPTION
### Motivation
- Replace the previous typed-cast facade with a proper OOP TypeScript runtime for the formation subsystem to improve type safety, maintainability, and make later caller migrations straightforward.
- Split responsibilities (parsing, planning, difficulty resolution, orchestration) into focused classes to satisfy the repository’s OOP-first migration guidance and style constraints.

### Description
- Implemented OOP runtime modules under `js/core/game/formations/`: `FormationManager.ts`, `FormationParser.ts`, `FormationPlanner.ts`, `WaveDifficultyResolver.ts`, `FormationParserUtils.ts`, `FormationNormalization.ts`, and `FormationTypes.ts` to encapsulate parsing, planning, normalization and difficulty resolution logic.
- Rewrote `js/core/game/formations.ts` to use the new typed runtime classes (`createFormationManager` now forwards to the new `FormationManager` runtime) while preserving the external API (`parseFormationText`, `createFormationManager`, default export) and kept the legacy `js/core/game/formations.js` runtime path to avoid breaking mixed JS/TS importers.
- Added migration documentation updates to `docs/NEON_VOID_MIGRATION_NOTES.md` and `docs/NEON_VOID_TYPESCRIPT_MIGRATION.md` describing the checkpoint, validation steps, caveats and follow-ups.
- Added a reusable skill `skills/neon-void-formations-ts-migration/SKILL.md` with the workflow and validation commands for future formation migration work.

### Testing
- Ran linter for the touched formation files with `npx eslint js/core/game/formations.ts js/core/game/formations/*.ts` and it completed with zero warnings for the updated scope.
- Built the project with `npm run build` and the TypeScript compilation completed successfully.
- Ran the targeted unit suite with `node --test test/game/formations.test.js` and it passed (4/4).
- Ran the repository test command `npm test` which surfaced pre-existing, out-of-scope failures in other projects (`eva_game` / `rgfn_game` dist import issues and unrelated projectile tests); these failures are documented in the migration notes and do not affect the formation checkpoint validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28d0cbfe083238af7ec21d70ab46d)