### PR TITLE
RGFN: add developer-only side-quest Regenerate button in quests panel

### DIFF
--- a/rgfn_game/docs/quests/side-quest-regenerate-dev-tool-2026-04-17.md
+++ b/rgfn_game/docs/quests/side-quest-regenerate-dev-tool-2026-04-17.md
@@ -50,3 +50,25 @@ Recommended checks:
 
 - Regeneration currently uses runtime random generation and does not pin seed per click.
 - The regenerate action replaces quest identity (new quest id), so external references to old quest ids become stale.
+
+## Follow-up fix (2026-04-19): NPC dialogue panel stale offer details
+
+### Symptom
+
+After regenerating a quest from the Quests panel, the village NPC dialogue side-quest board could still show the pre-regeneration offer text until the NPC was reselected.
+
+### Root cause
+
+`GameQuestRuntime.replaceKnownSideQuest(...)` re-rendered the Quests panel immediately, but the village dialogue side-quest UI was maintained by `VillageActionsController` and was not refreshed from that path.
+
+### Resolution
+
+- Added a public `VillageActionsController.refreshSelectedNpcSideQuestUi()` method to refresh side-quest board content for the currently selected NPC.
+- Updated `GameFacade.regenerateSideQuest(...)` to call that refresh method after successful quest replacement.
+- Added focused regression coverage in `villageActionsController.test.js` asserting selected-NPC side-quest cards re-render with regenerated offer data.
+
+### Verification checklist
+
+1. Enter a village and open dialogue with an NPC that has a side-quest offer.
+2. Regenerate that quest from Quests → Side.
+3. Confirm the NPC dialogue offer card updates immediately (title/details/reward) without changing NPC selection.

--- a/rgfn_game/docs/quests/side-quest-regenerate-dev-tool-2026-04-17.md
+++ b/rgfn_game/docs/quests/side-quest-regenerate-dev-tool-2026-04-17.md
@@ -1,0 +1,52 @@
+# Side-quest Regenerate Developer Tool (2026-04-17)
+
+## What was added
+
+A developer-only **Regenerate** button now appears in the **Quests → Side** panel on every visible side-quest card.
+
+- The button is only rendered when persistent developer mode is enabled (`DeveloperModeConfig.enabled = true`).
+- Clicking the button replaces that specific side quest with a newly generated random side quest from the same giver NPC and village.
+- The replacement keeps the quest in the same panel bucket:
+  - `available` quests remain `available`.
+  - all other statuses are regenerated as `active` (so the regenerated quest is testable immediately).
+
+## Why this helps
+
+This removes the slow loop of waiting for village offer refreshes or manually reloading saves to get new side-quest variants.
+
+It is especially useful for:
+
+- validating objective text variants;
+- quickly cycling reward metadata;
+- testing location hint formatting;
+- stress-testing quest progression and turn-in UX with many random templates.
+
+## Runtime wiring summary
+
+- `QuestUiController` now owns regenerate button rendering and click handling for side-quest cards.
+- `GameRuntimeAssembly` wires UI callbacks:
+  - `isDeveloperModeEnabled` (visibility gate),
+  - `onRegenerateSideQuest` (action callback).
+- `GameFacade.regenerateSideQuest` performs generation and replacement orchestration.
+- `GameQuestRuntime` provides:
+  - `getKnownSideQuest(questId)`,
+  - `replaceKnownSideQuest(questId, replacement)`.
+
+## QA notes
+
+Recommended checks:
+
+1. Enable developer mode in the developer modal.
+2. Open Quests panel and switch to Side tab.
+3. Confirm each side-quest card shows **Regenerate**.
+4. Click regenerate on:
+   - an available quest,
+   - an active quest,
+   - a ready/completed quest (if present in known list).
+5. Verify the card updates to a new title/objectives and the success feedback message appears.
+6. Disable developer mode and verify the button no longer appears.
+
+## Known constraints
+
+- Regeneration currently uses runtime random generation and does not pin seed per click.
+- The regenerate action replaces quest identity (new quest id), so external references to old quest ids become stale.

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -205,7 +205,11 @@ export class GameFacade implements GameFacadeStateAccess {
         regeneratedQuest.track = 'side';
         regeneratedQuest.status = currentQuest.status === 'available' ? 'available' : 'active';
         regeneratedQuest.isCompleted = false;
-        return this.questRuntime.replaceKnownSideQuest(questId, regeneratedQuest);
+        const replaced = this.questRuntime.replaceKnownSideQuest(questId, regeneratedQuest);
+        if (replaced) {
+            this.villageActionsController?.refreshSelectedNpcSideQuestUi();
+        }
+        return replaced;
     };
     public acceptSideQuest = (questId: string): { accepted: boolean; reason?: 'inactive' | 'not-found' | 'already-active' } =>
         this.questRuntime.acceptSideQuest(questId);

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -186,6 +186,27 @@ export class GameFacade implements GameFacadeStateAccess {
     public getVillageNpcActiveSideQuests = (villageName: string, npcName: string): QuestNode[] =>
         this.questRuntime.getVillageNpcActiveSideQuests(villageName, npcName);
     public getActiveSideQuests = (): QuestNode[] => this.questRuntime.getActiveSideQuests();
+    public regenerateSideQuest = async (questId: string): Promise<boolean> => {
+        if (!this.questGenerator) {
+            return false;
+        }
+        const currentQuest = this.questRuntime.getKnownSideQuest(questId);
+        if (!currentQuest) {
+            return false;
+        }
+        const giverNpcName = currentQuest.giverNpcName?.trim();
+        const giverVillageName = currentQuest.giverVillageName?.trim();
+        if (!giverNpcName || !giverVillageName) {
+            return false;
+        }
+
+        const regeneratedQuestId = this.createSideQuestId(giverVillageName, giverNpcName);
+        const regeneratedQuest = await this.questGenerator.generateSideQuest(regeneratedQuestId, giverNpcName, giverVillageName);
+        regeneratedQuest.track = 'side';
+        regeneratedQuest.status = currentQuest.status === 'available' ? 'available' : 'active';
+        regeneratedQuest.isCompleted = false;
+        return this.questRuntime.replaceKnownSideQuest(questId, regeneratedQuest);
+    };
     public acceptSideQuest = (questId: string): { accepted: boolean; reason?: 'inactive' | 'not-found' | 'already-active' } =>
         this.questRuntime.acceptSideQuest(questId);
     public turnInSideQuest = (
@@ -264,6 +285,12 @@ export class GameFacade implements GameFacadeStateAccess {
             hash = Math.imul(hash, 16777619);
         }
         return hash >>> 0;
+    }
+
+    private createSideQuestId(villageName: string, npcName: string): string {
+        const normalizedVillage = villageName.trim().toLocaleLowerCase();
+        const normalizedNpc = npcName.trim().toLocaleLowerCase().replace(/\s+/g, '_');
+        return `side.${normalizedVillage}.${normalizedNpc}.${Date.now()}.${Math.floor(Math.random() * 10000)}`;
     }
 
     private async generateVillageSideQuestOffers(

--- a/rgfn_game/js/game/GameRuntimeAssembly.ts
+++ b/rgfn_game/js/game/GameRuntimeAssembly.ts
@@ -18,6 +18,7 @@ import GameRuntimeUiBinder from './runtime/GameRuntimeUiBinder.js';
 import { GameFacade } from './GameFacade.js';
 import { RuntimeUi, createHudCoordinator, createRenderRouter, createRuntimeBase, createVillageRuntime } from './GameFactoryHelpers.js';
 import { createBattleCommandController, createBattleCoordinator, createBattlePlayerActionController, createBattleTurnController, createWorldModeControllerRuntime } from './GameFactoryBattleHelpers.js';
+import { isDeveloperModeEnabled } from '../utils/DeveloperModeConfig.js';
 
 type RuntimeBase = {
     player: any;
@@ -76,7 +77,11 @@ const createQuestUiController = (game: GameFacade, ui: RuntimeUi): QuestUiContro
         ui.hudElements.questIntroModal,
         ui.hudElements.questIntroBody,
         ui.hudElements.questIntroCloseBtn,
-        { onLocationClick: (locationName: string) => game.onQuestLocationClick(locationName) },
+        {
+            onLocationClick: (locationName: string) => game.onQuestLocationClick(locationName),
+            isDeveloperModeEnabled,
+            onRegenerateSideQuest: (questId: string) => game.regenerateSideQuest(questId),
+        },
     );
 };
 

--- a/rgfn_game/js/game/runtime/GameQuestRuntime.ts
+++ b/rgfn_game/js/game/runtime/GameQuestRuntime.ts
@@ -117,6 +117,49 @@ export default class GameQuestRuntime {
             .map((quest) => ({ ...quest }));
     }
 
+    public getKnownSideQuest(questId: string): QuestNode | null {
+        const normalizedQuestId = questId.trim();
+        if (!normalizedQuestId) {
+            return null;
+        }
+
+        for (const offers of this.sideQuestOffersByNpc.values()) {
+            const offer = offers.find((entry) => entry.id === normalizedQuestId);
+            if (offer) {
+                return { ...offer };
+            }
+        }
+
+        const activeQuest = this.activeSideQuests.find((entry) => entry.id === normalizedQuestId);
+        return activeQuest ? { ...activeQuest } : null;
+    }
+
+    public replaceKnownSideQuest(questId: string, replacement: QuestNode): boolean {
+        const normalizedQuestId = questId.trim();
+        if (!normalizedQuestId || !replacement.id.trim()) {
+            return false;
+        }
+
+        for (const [npcKey, offers] of this.sideQuestOffersByNpc.entries()) {
+            const offerIndex = offers.findIndex((entry) => entry.id === normalizedQuestId);
+            if (offerIndex < 0) {
+                continue;
+            }
+            offers[offerIndex] = replacement;
+            this.sideQuestOffersByNpc.set(npcKey, offers);
+            this.renderQuestUi();
+            return true;
+        }
+
+        const activeIndex = this.activeSideQuests.findIndex((entry) => entry.id === normalizedQuestId);
+        if (activeIndex < 0) {
+            return false;
+        }
+        this.activeSideQuests[activeIndex] = replacement;
+        this.renderQuestUi();
+        return true;
+    }
+
     public clearVillageSideQuestOffers(villageName: string): void {
         const normalizedVillage = villageName.trim().toLocaleLowerCase();
         if (!normalizedVillage) {

--- a/rgfn_game/js/systems/quest/ui/QuestUiController.ts
+++ b/rgfn_game/js/systems/quest/ui/QuestUiController.ts
@@ -2,7 +2,6 @@
 import { QuestNode } from '../QuestTypes.js';
 import QuestUiMarkupBuilder from './QuestUiMarkupBuilder.js';
 import QuestUiFeedbackPresenter from './QuestUiFeedbackPresenter.js';
-
 const KNOWN_ONLY_TOGGLE_STORAGE_KEY = 'rgfn_quests_known_only_toggle_v1';
 const KNOWN_ONLY_TOGGLE_DEFAULT = true;
 const SIDE_STATUS_FILTER_STORAGE_KEY = 'rgfn_side_quests_status_filter_v1';
@@ -13,11 +12,11 @@ const SIDE_STATUS_DEFAULT_FILTER = new Set<SideQuestStatus>(['active', 'readyToT
 type QuestTab = 'main' | 'side';
 type SideQuestStatus = typeof SIDE_STATUS_ORDER[number];
 type SideStatusFilterCheckboxes = Record<SideQuestStatus, HTMLInputElement>;
-
 type QuestUiCallbacks = {
     onLocationClick: (locationName: string) => boolean;
+    isDeveloperModeEnabled: () => boolean;
+    onRegenerateSideQuest: (questId: string) => Promise<boolean>;
 };
-
 export default class QuestUiController {
     private readonly questTitle: HTMLElement;
     private readonly mainTabBtn: HTMLButtonElement;
@@ -43,7 +42,6 @@ export default class QuestUiController {
     private activeTab: QuestTab = 'main';
     private mainKnownOnlyEnabled = KNOWN_ONLY_TOGGLE_DEFAULT;
     private sideStatusFilter: Set<SideQuestStatus> = new Set(SIDE_STATUS_DEFAULT_FILTER);
-
     constructor(
         questTitle: HTMLElement,
         mainTabBtn: HTMLButtonElement,
@@ -83,7 +81,6 @@ export default class QuestUiController {
         this.applyPersistedKnownOnlyState();
         this.bindEvents();
     }
-
     public renderQuest(quest: QuestNode, sideQuests: QuestNode[] = []): void {
         this.lastRenderedQuest = quest;
         this.lastRenderedSideQuests = sideQuests;
@@ -91,15 +88,12 @@ export default class QuestUiController {
         this.introBody.innerHTML = markup;
         this.renderCurrentTab();
     }
-
     public showIntro(): void {
         this.introModal.classList.remove('hidden');
     }
-
     private setFeedback(message: string, isError: boolean): void {
         this.feedbackPresenter.setFeedback(message, isError);
     }
-
     private bindEvents(): void {
         this.introCloseBtn.addEventListener('click', () => this.introModal.classList.add('hidden'));
         this.knownOnlyToggle.addEventListener('change', () => this.handleKnownOnlyToggleChange());
@@ -108,10 +102,10 @@ export default class QuestUiController {
         this.mainTabBtn.addEventListener('click', () => this.switchTab('main'));
         this.sideTabBtn.addEventListener('click', () => this.switchTab('side'));
         this.introModal.addEventListener('click', (event: MouseEvent) => this.handleIntroModalClick(event));
+        this.questBody.addEventListener('click', (event: MouseEvent) => { void this.handleRegenerateButtonClick(event); });
         this.bindLocationClicks(this.questBody);
         this.bindLocationClicks(this.introBody);
     }
-
     private assignSideFilterElements(
         sideFilterContainer: HTMLElement,
         sideFilterButton: HTMLButtonElement,
@@ -125,46 +119,38 @@ export default class QuestUiController {
         this.sideFilterApplyButton = sideFilterApplyButton;
         this.sideStatusFilterCheckboxes = sideStatusFilterCheckboxes;
     }
-
     private handleKnownOnlyToggleChange(): void {
         if (this.activeTab !== 'main') {
             return;
         }
-
         this.mainKnownOnlyEnabled = this.knownOnlyToggle.checked;
         this.persistKnownOnlyState();
         if (this.lastRenderedQuest) {
             this.renderCurrentTab();
         }
     }
-
     private handleIntroModalClick(event: MouseEvent): void {
         if (event.target === this.introModal) {
             this.introModal.classList.add('hidden');
         }
     }
-
     private applyPersistedKnownOnlyState(): void {
         this.mainKnownOnlyEnabled = this.readKnownOnlyState() ?? KNOWN_ONLY_TOGGLE_DEFAULT;
         this.sideStatusFilter = this.readSideStatusFilter();
         this.updateModeToggleUi();
     }
-
     private persistKnownOnlyState(): void {
         const storage = this.getLocalStorage();
         if (!storage) {
             return;
         }
-
         storage.setItem(KNOWN_ONLY_TOGGLE_STORAGE_KEY, this.knownOnlyToggle.checked ? '1' : '0');
     }
-
     private readKnownOnlyState(): boolean | null {
         const storage = this.getLocalStorage();
         if (!storage) {
             return null;
         }
-
         const rawValue = storage.getItem(KNOWN_ONLY_TOGGLE_STORAGE_KEY);
         if (rawValue === '1') {
             return true;
@@ -174,30 +160,25 @@ export default class QuestUiController {
         }
         return null;
     }
-
     private persistSideStatusFilter(): void {
         const storage = this.getLocalStorage();
         if (!storage) {
             return;
         }
-
         const serializedFilter = SIDE_STATUS_ORDER
             .filter((status) => this.sideStatusFilter.has(status))
             .join(',');
         storage.setItem(SIDE_STATUS_FILTER_STORAGE_KEY, serializedFilter);
     }
-
     private readSideStatusFilter(): Set<SideQuestStatus> {
         const storage = this.getLocalStorage();
         if (!storage) {
             return new Set(SIDE_STATUS_DEFAULT_FILTER);
         }
-
         const rawValue = storage.getItem(SIDE_STATUS_FILTER_STORAGE_KEY);
         if (!rawValue) {
             return new Set(SIDE_STATUS_DEFAULT_FILTER);
         }
-
         const statuses = rawValue
             .split(',')
             .map((value) => value.trim())
@@ -205,26 +186,21 @@ export default class QuestUiController {
         if (statuses.length === 0) {
             return new Set(SIDE_STATUS_DEFAULT_FILTER);
         }
-
         return new Set(statuses);
     }
-
     private getLocalStorage(): Storage | null {
         if (typeof window === 'undefined') {
             return null;
         }
-
         try {
             return window.localStorage;
         } catch {
             return null;
         }
     }
-
     private bindLocationClicks(container: HTMLElement): void {
         container.addEventListener('click', (event: MouseEvent) => this.handleLocationClick(event));
     }
-
     private switchTab(tab: QuestTab): void {
         this.activeTab = tab;
         this.mainTabBtn.classList.toggle('is-active', tab === 'main');
@@ -237,7 +213,6 @@ export default class QuestUiController {
         this.updateModeToggleUi();
         this.renderCurrentTab();
     }
-
     private updateModeToggleUi(): void {
         this.modeToggleContainer.style.display = this.activeTab === 'main' ? '' : 'none';
         this.sideFilterContainer.style.display = this.activeTab === 'side' ? '' : 'none';
@@ -250,7 +225,6 @@ export default class QuestUiController {
         this.syncSideFilterCheckboxesFromState();
         this.sideFilterButton.textContent = this.buildSideFilterButtonLabel();
     }
-
     private renderCurrentTab(): void {
         if (!this.lastRenderedQuest) {
             return;
@@ -261,13 +235,11 @@ export default class QuestUiController {
         }
         this.renderSideQuestTab(this.lastRenderedSideQuests);
     }
-
     private renderMainQuestTab(quest: QuestNode): void {
         const markup = this.markupBuilder.buildQuestTreeMarkup(quest);
         this.questTitle.textContent = `Main Quest: ${quest.title}`;
         this.questBody.innerHTML = markup;
     }
-
     private renderSideQuestTab(sideQuests: QuestNode[]): void {
         this.questTitle.textContent = 'Side Quests';
         const filteredQuests = sideQuests.filter((quest) => this.sideStatusFilter.has(this.toSideQuestStatus(quest.status)));
@@ -275,13 +247,11 @@ export default class QuestUiController {
             this.questBody.innerHTML = '<p>No known side quests yet.</p>';
             return;
         }
-
         const cards = filteredQuests
             .map((quest) => this.buildSideQuestCardMarkup(quest))
             .join('');
         this.questBody.innerHTML = `<div class="side-quest-list">${cards}</div>`;
     }
-
     private buildSideQuestCardMarkup(quest: QuestNode): string {
         const status = quest.status ?? 'active';
         const giverNpc = this.escapeHtml(quest.giverNpcName ?? 'Unknown giver');
@@ -291,16 +261,17 @@ export default class QuestUiController {
         const title = this.escapeHtml(quest.title);
         const statusLabel = this.formatStatus(status);
         const shouldOpenByDefault = status !== 'completed';
+        const regenerateButtonMarkup = this.callbacks.isDeveloperModeEnabled()
+            ? `<button class="side-quest-regenerate-btn" type="button" data-side-quest-regenerate-id="${this.escapeHtml(quest.id)}">Regenerate</button>`
+            : '';
         return `<details class="side-quest-card" ${shouldOpenByDefault ? 'open' : ''}>
-            <summary>${title}<span class="side-quest-status is-${this.escapeHtml(status.toLocaleLowerCase())}">${statusLabel}</span></summary>
+            <summary>${title}<span class="side-quest-status is-${this.escapeHtml(status.toLocaleLowerCase())}">${statusLabel}</span>${regenerateButtonMarkup}</summary>
             <div class="side-quest-meta">Giver: ${giverNpc} · Village: ${giverVillage}</div>
             ${rewardMarkup}
             ${treeMarkup}
         </details>`;
     }
-
     private formatStatus = (status: string): string => status === 'readyToTurnIn' ? 'Ready to turn in' : status.charAt(0).toUpperCase() + status.slice(1);
-
     private handleSideFilterButtonClick(): void {
         if (this.activeTab !== 'side') {
             return;
@@ -311,7 +282,6 @@ export default class QuestUiController {
         }
         this.hideSideFilterPopup();
     }
-
     private handleSideFilterApplyClick(): void {
         const selectedStatuses = SIDE_STATUS_ORDER.filter((status) => this.sideStatusFilterCheckboxes[status].checked);
         if (selectedStatuses.length === 0) {
@@ -319,62 +289,51 @@ export default class QuestUiController {
             this.setFeedback('Select at least one side-quest status before applying filter.', true);
             return;
         }
-
         this.sideStatusFilter = new Set(selectedStatuses);
         this.persistSideStatusFilter();
         this.sideFilterButton.textContent = this.buildSideFilterButtonLabel();
         this.hideSideFilterPopup();
         this.renderSideQuestTab(this.lastRenderedSideQuests);
     }
-
     private syncSideFilterCheckboxesFromState(): void {
         SIDE_STATUS_ORDER.forEach((status) => {
             this.sideStatusFilterCheckboxes[status].checked = this.sideStatusFilter.has(status);
         });
     }
-
     private buildSideFilterButtonLabel(): string {
         const visibleCount = SIDE_STATUS_ORDER.filter((status) => this.sideStatusFilter.has(status)).length;
         return `${SIDE_FILTER_BUTTON_LABEL_PREFIX} (${visibleCount}/${SIDE_STATUS_ORDER.length})`;
     }
-
     private showSideFilterPopup(): void {
         this.syncSideFilterCheckboxesFromState();
         this.sideFilterPopup.style.display = '';
     }
-
     private hideSideFilterPopup = (): void => { this.sideFilterPopup.style.display = 'none'; };
-
     private toSideQuestStatus(status: string | undefined): SideQuestStatus {
         if (status === 'available' || status === 'readyToTurnIn' || status === 'completed') {
             return status;
         }
         return 'active';
     }
-
     private escapeHtml = (text: string): string => text
         .split('&').join('&amp;')
         .split('<').join('&lt;')
         .split('>').join('&gt;')
         .split('"').join('&quot;')
         .split("'").join('&#39;');
-
     private handleLocationClick(event: MouseEvent): void {
         const target = event.target;
         if (!(target instanceof HTMLElement)) {
             return;
         }
-
         const button = target.closest('[data-location-name]');
         if (!(button instanceof HTMLElement)) {
             return;
         }
-
         const locationName = button.dataset.locationName;
         if (!locationName) {
             return;
         }
-
         const shownOnMap = this.callbacks.onLocationClick(locationName);
         this.setFeedback(
             shownOnMap ? `Showing ${locationName} on the world map.` : `${locationName} is not discovered yet.`,
@@ -382,6 +341,34 @@ export default class QuestUiController {
         );
         if (shownOnMap) {
             this.introModal.classList.add('hidden');
+        }
+    }
+    private async handleRegenerateButtonClick(event: MouseEvent): Promise<void> {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+            return;
+        }
+        const button = target.closest('[data-side-quest-regenerate-id]');
+        if (!(button instanceof HTMLButtonElement) || !this.callbacks.isDeveloperModeEnabled()) {
+            return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        const questId = button.dataset.sideQuestRegenerateId;
+        if (!questId) {
+            return;
+        }
+        button.disabled = true;
+        try {
+            const regenerated = await this.callbacks.onRegenerateSideQuest(questId);
+            this.setFeedback(
+                regenerated
+                    ? 'Side quest regenerated.'
+                    : 'Could not regenerate side quest.',
+                !regenerated,
+            );
+        } finally {
+            button.disabled = false;
         }
     }
 }

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -121,8 +121,16 @@ export default class VillageActionsController {
         this.addLog(`You approach ${npc.name} the ${npc.role}.`, 'player');
         this.addLog(`${npc.name} looks ${npc.look} and speaks in a ${npc.speechStyle} manner.`, 'system-message');
         this.addRecoverLeadFromNpc(npc);
-        this.refreshSelectedNpcSideQuestUi(npc);
+        this.refreshSelectedNpcSideQuestBoard(npc);
         this.callbacks.onAdvanceTime(8, 0.12);
+    }
+
+    public refreshSelectedNpcSideQuestUi(): void {
+        const selectedNpc = this.getSelectedNpc();
+        if (!selectedNpc) {
+            return;
+        }
+        this.refreshSelectedNpcSideQuestBoard(selectedNpc);
     }
 
     public handleAcceptSideQuest(questId: string): void {
@@ -165,7 +173,7 @@ export default class VillageActionsController {
         const questTitle = offers.find((quest) => quest.id === questId)?.title ?? questId;
         this.dismissedSideQuestOfferIds.add(questId);
         this.addLog(`Side-quest offer hidden: ${questTitle}.`, 'system-message');
-        this.refreshSelectedNpcSideQuestUi(selectedNpc);
+        this.refreshSelectedNpcSideQuestBoard(selectedNpc);
     }
 
     public handleAskAboutSettlement(): void { this.dialogueInteraction.handleAskAboutSettlement(); this.callbacks.onAdvanceTime(14, 0.1); }
@@ -280,12 +288,7 @@ export default class VillageActionsController {
         updateButtons: () => this.updateButtons(),
         getCourierObjectiveForNpc: (npcName, villageName) => this.getActiveCourierObjectiveForNpc(npcName, villageName),
         markSideQuestReadyToTurnIn: (questId) => this.callbacks.markSideQuestReadyToTurnIn?.(questId) ?? false,
-        refreshSelectedNpcSideQuestUi: () => {
-            const npc = this.getSelectedNpc();
-            if (npc) {
-                this.refreshSelectedNpcSideQuestUi(npc);
-            }
-        },
+        refreshSelectedNpcSideQuestUi: () => this.refreshSelectedNpcSideQuestUi(),
     });
 
     private refreshNpcUi(): void {
@@ -587,7 +590,7 @@ export default class VillageActionsController {
         );
     }
 
-    private refreshSelectedNpcSideQuestUi(npc: VillageNpcProfile): void {
+    private refreshSelectedNpcSideQuestBoard(npc: VillageNpcProfile): void {
         const offers = this.callbacks.getVillageSideQuestOffers?.(this.currentVillageName, npc.name) ?? [];
         const visibleOffers = offers.filter((offer) => !this.dismissedSideQuestOfferIds.has(offer.id));
         const activeQuests = this.callbacks.getVillageNpcActiveSideQuests?.(this.currentVillageName, npc.name) ?? [];
@@ -698,7 +701,7 @@ export default class VillageActionsController {
             this.addLog(`Side quest accepted: ${questId}.`, 'system');
         }
         this.addLog('Quest tracker updated with accepted side quest.', 'system-message');
-        this.refreshSelectedNpcSideQuestUi(selectedNpc);
+        this.refreshSelectedNpcSideQuestUi();
     }
 
     private completeSideQuestTurnIn(selectedNpc: VillageNpcProfile, questId: string, reward?: string): void {
@@ -706,7 +709,7 @@ export default class VillageActionsController {
         this.readySideQuestLogIds.delete(questId);
         this.addLog(`${selectedNpc.name} accepts your side-quest turn-in for ${questId}.${reward ? ` Reward received: ${reward}.` : ''}`, 'system');
         this.addLog('Quest tracker updated: side quest turned in.', 'system-message');
-        this.refreshSelectedNpcSideQuestUi(selectedNpc);
+        this.refreshSelectedNpcSideQuestUi();
     }
 
     private logSideQuestAcceptFailure(questId: string, reason?: 'inactive' | 'not-found' | 'already-active'): boolean {

--- a/rgfn_game/style.css
+++ b/rgfn_game/style.css
@@ -1303,6 +1303,9 @@ button.quest-entity-name.location:hover {
 }
 
 .side-quest-card > summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     cursor: pointer;
     color: var(--color-primary-accent);
     font-weight: 700;
@@ -1326,6 +1329,21 @@ button.quest-entity-name.location:hover {
 
 .side-quest-status.is-completed {
     color: #2f6f39;
+}
+
+.side-quest-regenerate-btn {
+    margin-left: auto;
+    padding: 2px 6px;
+    font-size: 10px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--color-highlight) 55%, transparent);
+    background: color-mix(in srgb, var(--color-primary-bg) 55%, transparent);
+    color: var(--color-highlight);
+    cursor: pointer;
+}
+
+.side-quest-regenerate-btn:hover {
+    background: color-mix(in srgb, var(--color-highlight) 20%, transparent);
 }
 
 .side-quest-meta {

--- a/rgfn_game/test/systems/recoverQuestRuntime.test.js
+++ b/rgfn_game/test/systems/recoverQuestRuntime.test.js
@@ -471,6 +471,28 @@ test('GameQuestRuntime side-quest turn-in requires the original quest giver and 
   assert.equal(runtime.activeSideQuests[0].status, 'completed');
 });
 
+test('GameQuestRuntime exposes and replaces known side quests across offers and active lists', () => {
+  const runtime = new GameQuestRuntime();
+  const offeredQuest = createSideQuest({ id: 'side-offer', status: 'available' });
+  const activeQuest = createSideQuest({ id: 'side-active', status: 'active' });
+  runtime.questUiController = { renderQuest: () => {} };
+  runtime.registerVillageSideQuestOffer(offeredQuest);
+  runtime.registerVillageSideQuestOffer(activeQuest);
+  runtime.acceptSideQuest('side-active');
+
+  assert.equal(runtime.getKnownSideQuest('side-offer')?.id, 'side-offer');
+  assert.equal(runtime.getKnownSideQuest('side-active')?.id, 'side-active');
+
+  const replacementOffer = createSideQuest({ id: 'side-offer-2', title: 'Fresh Offer', status: 'available' });
+  const replacementActive = createSideQuest({ id: 'side-active-2', title: 'Fresh Active', status: 'active' });
+  assert.equal(runtime.replaceKnownSideQuest('side-offer', replacementOffer), true);
+  assert.equal(runtime.replaceKnownSideQuest('side-active', replacementActive), true);
+
+  assert.equal(runtime.getKnownSideQuest('side-offer'), null);
+  assert.equal(runtime.getKnownSideQuest('side-offer-2')?.title, 'Fresh Offer');
+  assert.equal(runtime.activeSideQuests[0].id, 'side-active-2');
+});
+
 test('GameQuestRuntime marks deliver side quests ready when reaching destination with carried courier item', () => {
   const runtime = new GameQuestRuntime();
   const mainQuest = createRecoverQuest();
@@ -503,7 +525,7 @@ test('GameQuestRuntime marks deliver side quests ready when reaching destination
   ];
 
   const changed = runtime.recordLocationEntry('Golden Beacon', ['Eshdra Lorka']);
-  assert.equal(changed, true);
+  assert.equal(changed.changed, true);
   assert.equal(runtime.activeSideQuests[0].status, 'readyToTurnIn');
 });
 

--- a/rgfn_game/test/systems/scenarios/questUiController.test.js
+++ b/rgfn_game/test/systems/scenarios/questUiController.test.js
@@ -68,6 +68,15 @@ function createStorageMock(initial = null) {
   };
 }
 
+function createCallbacks(overrides = {}) {
+  return {
+    onLocationClick: () => false,
+    isDeveloperModeEnabled: () => false,
+    onRegenerateSideQuest: async () => false,
+    ...overrides,
+  };
+}
+
 test('QuestUiController hides the default boilerplate on the root quest but keeps unique child text', () => {
   const title = createElement();
   const knownOnlyToggle = createCheckbox(false);
@@ -75,7 +84,7 @@ test('QuestUiController hides the default boilerplate on the root quest but keep
   const modal = createElement();
   const intro = createElement();
   const closeBtn = createElement();
-  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), body, modal, intro, closeBtn, { onLocationClick: () => false });
+  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), body, modal, intro, closeBtn, createCallbacks());
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -114,7 +123,7 @@ test('QuestUiController hides the default boilerplate on the root quest but keep
 });
 
 test('QuestUiController opens and closes the intro modal through bound events', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), createCallbacks());
   const modal = controller['introModal'];
   const closeBtn = controller['introCloseBtn'];
 
@@ -127,7 +136,7 @@ test('QuestUiController opens and closes the intro modal through bound events', 
 });
 
 test('QuestUiController keeps intro modal hidden by default until explicitly opened', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), createCallbacks());
   const modal = controller['introModal'];
 
   assert.deepEqual(modal.classList.added, ['hidden']);
@@ -135,7 +144,7 @@ test('QuestUiController keeps intro modal hidden by default until explicitly ope
 });
 
 test('QuestUiController renders completion styling and checkmark for completed quest nodes', () => {
-  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), createCallbacks());
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -171,7 +180,7 @@ test('QuestUiController clears quest feedback after configured timeout', () => {
   };
 
   try {
-    const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    const controller = new QuestUiController(createElement(), createElement(), createElement(), createCheckbox(false), createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), createCallbacks());
 
     controller['setFeedback']('Oakcross is not discovered yet.', true);
     assert.equal(scheduledDelay, 5000);
@@ -193,7 +202,7 @@ test('QuestUiController known-only mode hides quests below the first incomplete 
   const title = createElement();
   const knownOnlyToggle = createCheckbox(true);
   const body = createElement();
-  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), body, createElement(), createElement(), createElement(), { onLocationClick: () => false });
+  const controller = new QuestUiController(title, createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), body, createElement(), createElement(), createElement(), createCallbacks());
   const quest = {
     id: 'main',
     title: 'Signal Dawn',
@@ -250,7 +259,7 @@ test('QuestUiController defaults known-only toggle to checked when no saved pref
 
   try {
     const knownOnlyToggle = createCheckbox(false);
-    new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), createCallbacks());
     assert.equal(knownOnlyToggle.checked, true);
   } finally {
     global.window = originalWindow;
@@ -264,7 +273,7 @@ test('QuestUiController persists and restores known-only toggle state via localS
 
   try {
     const knownOnlyToggle = createCheckbox(true);
-    const controller = new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), { onLocationClick: () => false });
+    const controller = new QuestUiController(createElement(), createElement(), createElement(), knownOnlyToggle, createElement(), createElement(), createElement(), createElement(), createElement(), createElement(), createSideStatusFilterCheckboxes(), createElement(), createElement(), createElement(), createElement(), createCallbacks());
     assert.equal(knownOnlyToggle.checked, false);
 
     knownOnlyToggle.checked = true;
@@ -303,7 +312,7 @@ test('QuestUiController renders known side quests in side tab with nested object
     createElement(),
     createElement(),
     createElement(),
-    { onLocationClick: () => false },
+    createCallbacks(),
   );
   const mainQuest = {
     id: 'main',
@@ -373,7 +382,7 @@ test('QuestUiController applies side quest status filter popup selections and pe
       createElement(),
       createElement(),
       createElement(),
-      { onLocationClick: () => false },
+      createCallbacks(),
     );
     const mainQuest = { id: 'main', title: 'Signal Dawn', description: '', conditionText: '', objectiveType: 'scout', entities: [], children: [] };
     const activeQuest = { id: 'side.1', title: 'Active Quest', description: '', conditionText: '', objectiveType: 'gather', entities: [], status: 'active', children: [] };
@@ -394,5 +403,97 @@ test('QuestUiController applies side quest status filter popup selections and pe
     assert.equal(body.innerHTML.includes('Available Quest'), true);
   } finally {
     global.window = originalWindow;
+  }
+});
+
+test('QuestUiController renders side quest regenerate buttons only when developer mode is enabled', () => {
+  const sideTabBtn = createElement();
+  const body = createElement();
+  const controller = new QuestUiController(
+    createElement(),
+    createElement(),
+    sideTabBtn,
+    createCheckbox(true),
+    createElement(),
+    createElement(),
+    createElement(),
+    createElement(),
+    createElement(),
+    createElement(),
+    createSideStatusFilterCheckboxes(),
+    body,
+    createElement(),
+    createElement(),
+    createElement(),
+    createCallbacks({ isDeveloperModeEnabled: () => true }),
+  );
+  const mainQuest = { id: 'main', title: 'Signal Dawn', description: '', conditionText: '', objectiveType: 'scout', entities: [], children: [] };
+  const sideQuest = { id: 'side.dev', title: 'Developer Quest', description: '', conditionText: '', objectiveType: 'gather', entities: [], status: 'active', children: [] };
+
+  controller.renderQuest(mainQuest, [sideQuest]);
+  sideTabBtn.listeners.click();
+
+  assert.equal(body.innerHTML.includes('data-side-quest-regenerate-id=\"side.dev\"'), true);
+});
+
+test('QuestUiController triggers side quest regeneration callback when clicking regenerate in developer mode', async () => {
+  const originalHTMLElement = global.HTMLElement;
+  const originalHTMLButtonElement = global.HTMLButtonElement;
+  class FakeElement {}
+  class FakeButton extends FakeElement {}
+  global.HTMLElement = FakeElement;
+  global.HTMLButtonElement = FakeButton;
+
+  const sideTabBtn = createElement();
+  const body = createElement();
+  const regenerateCalls = [];
+  try {
+    const controller = new QuestUiController(
+      createElement(),
+      createElement(),
+      sideTabBtn,
+      createCheckbox(true),
+      createElement(),
+      createElement(),
+      createElement(),
+      createElement(),
+      createElement(),
+      createElement(),
+      createSideStatusFilterCheckboxes(),
+      body,
+      createElement(),
+      createElement(),
+      createElement(),
+      createCallbacks({
+        isDeveloperModeEnabled: () => true,
+        onRegenerateSideQuest: async (questId) => {
+          regenerateCalls.push(questId);
+          return true;
+        },
+      }),
+    );
+    const mainQuest = { id: 'main', title: 'Signal Dawn', description: '', conditionText: '', objectiveType: 'scout', entities: [], children: [] };
+    const sideQuest = { id: 'side.regen', title: 'Regenerate Me', description: '', conditionText: '', objectiveType: 'gather', entities: [], status: 'active', children: [] };
+
+    controller.renderQuest(mainQuest, [sideQuest]);
+    sideTabBtn.listeners.click();
+
+    const button = new FakeButton();
+    button.dataset = { sideQuestRegenerateId: 'side.regen' };
+    button.disabled = false;
+    const target = new FakeElement();
+    target.closest = () => button;
+    const event = {
+      target,
+      preventDefault() {},
+      stopPropagation() {},
+    };
+    await body.listeners.click(event);
+
+    assert.deepEqual(regenerateCalls, ['side.regen']);
+    assert.equal(controller['feedbackElements'][0].textContent, 'Side quest regenerated.');
+  } finally {
+    global.HTMLElement = originalHTMLElement;
+    global.HTMLButtonElement = originalHTMLButtonElement;
   }
 });

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -865,6 +865,52 @@ test('VillageActionsController requires explicit side-quest acceptance and expos
   assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Side quest accepted')), true);
 }));
 
+test('VillageActionsController refreshSelectedNpcSideQuestUi re-renders selected NPC offer details after regeneration', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  let currentOffers = [{
+    id: 'side-old',
+    title: 'Old Offer',
+    description: 'Old quest details.',
+    reward: '11g',
+    status: 'available',
+    children: [{ description: 'Old task.' }],
+  }];
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onLeaveVillage: () => {},
+    onAdvanceTime: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+    getVillageSideQuestOffers: () => currentOffers,
+    getVillageNpcActiveSideQuests: () => [],
+  });
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'hollow-0', name: 'Kadra Zentor', role: 'Miller', look: 'braided hair', speechStyle: 'direct', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Hollow Reach');
+  controller.handleSelectNpc(0);
+  assert.equal(containsTextInTree(villageUI.sideQuestList, 'Old Offer — Offer available'), true);
+
+  currentOffers = [{
+    id: 'side-new',
+    title: 'Regenerated Offer',
+    description: 'New quest details.',
+    reward: '27g',
+    status: 'available',
+    children: [{ description: 'New task.' }],
+  }];
+  controller.refreshSelectedNpcSideQuestUi();
+
+  const latestCard = villageUI.sideQuestList.children.at(-1);
+  assert.ok(latestCard);
+  assert.equal(containsTextInTree(latestCard, 'Regenerated Offer — Offer available'), true);
+  assert.equal(containsTextInTree(latestCard, 'Reward preview: 27g'), true);
+}));
+
 test('VillageActionsController allows refusing a side-quest offer and keeps other offers visible', () => withDocumentStub(() => {
   const villageUI = createVillageUi();
   const gameLog = createElement();


### PR DESCRIPTION
### Motivation

- Provide a fast developer testing tool to replace / cycle individual side quests from the Quests → Side panel without waiting for world refreshes or manual save/load loops.

### Description

- Render a compact `Regenerate` button on each side-quest card when developer mode is enabled and handle clicks in `QuestUiController` to call an async regeneration callback. (UI markup, event binding and feedback.)
- Wire UI callbacks in `GameRuntimeAssembly` so the quest UI can check `isDeveloperModeEnabled` and call `onRegenerateSideQuest` provided by the game facade.
- Add `GameFacade.regenerateSideQuest` which generates a fresh side quest for the same giver/village, preserves `available` vs other statuses (others become `active`), and replaces the known quest in runtime.
- Add `GameQuestRuntime.getKnownSideQuest` and `replaceKnownSideQuest` to find and swap quests across both offer and active stores and re-render the quest UI.
- Add compact styling for the regenerate control in `rgfn_game/style.css` and a QA/implementation doc at `rgfn_game/docs/quests/side-quest-regenerate-dev-tool-2026-04-17.md`.
- Tests: extend UI controller tests to cover developer-only rendering and click flow, and add runtime tests for known-quest lookup/replace; small test assertion fix for `recordLocationEntry` return shape.

### Testing

- Ran the full RGFN test suite with `npm run test:rgfn` and all tests passed (166 tests, 0 failures). ✅
- Ran targeted lint on changed files with `npx eslint rgfn_game/js/systems/quest/ui/QuestUiController.ts rgfn_game/js/game/GameRuntimeAssembly.ts rgfn_game/js/game/runtime/GameQuestRuntime.ts rgfn_game/js/game/GameFacade.ts --ext .ts` and it passed for the modified files. ✅
- Ran the repository-level TypeScript linter step `npm run lint:ts:rgfn` which surfaced unrelated existing repo-wide warnings/errors prior to changes; those remain out-of-scope for this PR. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ab854f7483239003c9e84eade1bb)