### PR TITLE
rgfn: open NPC dialogue modal directly on rumor list click

### DIFF
--- a/rgfn_game/docs/village/village-dialogue-modal.md
+++ b/rgfn_game/docs/village/village-dialogue-modal.md
@@ -12,7 +12,7 @@ Move NPC conversations into a dedicated popup dialogue window (classic RPG style
   - `#village-dialogue-selected-npc`
   - `#village-dialogue-close-btn`
 - Kept NPC list selection in the village rumors block, but moved talk actions into the modal.
-- Added `Open NPC dialogue window` button in village rumors section.
+- Removed the extra open button from rumors section; NPC click now opens dialogue popup immediately.
 - Integrated existing conversation controls into modal:
   - ask about location
   - ask about person
@@ -26,7 +26,7 @@ Move NPC conversations into a dedicated popup dialogue window (classic RPG style
 ## Runtime behavior
 
 - Player selects NPC from village rumors list.
-- Player opens dialogue popup.
+- Dialogue popup opens immediately.
 - The popup displays:
   1. selected NPC summary,
   2. dialogue log,
@@ -61,7 +61,6 @@ This keeps one shared source of dialogue events while showing NPC conversation i
 
 `GameUiEventBinder` now binds:
 
-- open dialogue button,
 - close dialogue button,
 - backdrop click-to-close for dialogue modal,
 - Escape key close for dialogue modal while it is open.
@@ -130,3 +129,15 @@ File: `rgfn_game/test/systems/villageActionsController.test.js`.
 
 - If needed, next step is to render only NPC conversation lines in modal (filter by tags), while keeping full system log in main log panel.
 - Optional follow-up: keyboard shortcut (e.g. `T` or `Enter`) to open dialogue modal when NPC selected.
+
+## Follow-up pitfall fixed (April 19, 2026)
+
+- Symptom: opening NPC dialogue required two clicks (`select NPC` -> `Open NPC dialogue window`).
+- UX impact: extra redundant step in village rumors flow.
+- Fix:
+  - Removed `Open NPC dialogue window` button from village UI markup and UI models.
+  - Removed binder wiring and presenter logic that toggled that button.
+  - Updated `handleSelectNpc(...)` to open the dialogue modal immediately after selection.
+- Regression guard:
+  - Scenario test now verifies modal is hidden before selection and shown right after clicking NPC.
+

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -329,7 +329,6 @@
                         <div class="village-section">
                             <p id="village-npc-title" class="village-npc-title">Choose someone to talk to</p>
                             <div id="village-npc-list" class="village-npc-list"></div>
-                            <button id="village-open-dialogue-btn" class="action-btn">Open NPC dialogue window</button>
                             <button id="village-sleep-room-btn" class="action-btn">Sleep in room</button>
                         </div>
                     </div>

--- a/rgfn_game/js/systems/game/ui/GameUiFactory.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiFactory.ts
@@ -75,7 +75,6 @@ export default class GameUiFactory {
         title: document.getElementById('village-title')!,
         prompt: document.getElementById('village-prompt')!,
         actions: document.getElementById('village-actions')!,
-        openDialogueBtn: document.getElementById('village-open-dialogue-btn')! as HTMLButtonElement,
         sleepRoomBtn: document.getElementById('village-sleep-room-btn')! as HTMLButtonElement,
         dialogueModal: document.getElementById('village-dialogue-modal')!,
         dialogueCloseBtn: document.getElementById('village-dialogue-close-btn')! as HTMLButtonElement,

--- a/rgfn_game/js/systems/game/ui/GameUiPrimaryEventBinder.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiPrimaryEventBinder.ts
@@ -116,7 +116,6 @@ export default class GameUiPrimaryEventBinder {
         this.villageUI.sellSelect.addEventListener('change', () => this.villageActionsController.updateButtons());
         this.villageUI.sellSelectedBtn.addEventListener('click', () => this.villageActionsController.handleSellSelected());
         this.villageUI.askVillageInput.addEventListener('change', () => this.villageActionsController.updateButtons());
-        this.villageUI.openDialogueBtn.addEventListener('click', () => this.villageActionsController.openDialogueWindow());
         this.villageUI.dialogueCloseBtn.addEventListener('click', () => this.villageActionsController.closeDialogueWindow());
         this.villageUI.dialogueModal.addEventListener('click', (event: MouseEvent) => this.closeDialogueFromOverlay(event));
         document.addEventListener('keydown', (event: KeyboardEvent) => this.handleDialogueCloseHotkeys(event));

--- a/rgfn_game/js/systems/game/ui/GameUiSceneModels.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiSceneModels.ts
@@ -47,7 +47,6 @@ export class VillageUiModel {
     public title!: HTMLElement;
     public prompt!: HTMLElement;
     public actions!: HTMLElement;
-    public openDialogueBtn!: HTMLButtonElement;
     public sleepRoomBtn!: HTMLButtonElement;
     public dialogueModal!: HTMLElement;
     public dialogueCloseBtn!: HTMLButtonElement;

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -118,6 +118,7 @@ export default class VillageActionsController {
         this.selectedNpcId = npc.id;
         this.knownNpcNames.add(npc.name);
         this.refreshNpcUi();
+        this.uiPresenter.openDialogueWindow();
         this.addLog(`You approach ${npc.name} the ${npc.role}.`, 'player');
         this.addLog(`${npc.name} looks ${npc.look} and speaks in a ${npc.speechStyle} manner.`, 'system-message');
         this.addRecoverLeadFromNpc(npc);

--- a/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
+++ b/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
@@ -9,7 +9,6 @@ export type VillageUI = {
     title: HTMLElement;
     prompt: HTMLElement;
     actions: HTMLElement;
-    openDialogueBtn: HTMLButtonElement;
     sleepRoomBtn: HTMLButtonElement;
     villageWaitBtn: HTMLButtonElement;
     dialogueModal: HTMLElement;

--- a/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
+++ b/rgfn_game/js/systems/village/actions/VillageUiPresenter.ts
@@ -50,7 +50,6 @@ export default class VillageUiPresenter {
         this.deps.villageUI.sellSelectedBtn.disabled = this.deps.villageUI.sellSelect.disabled;
         const selectedNpc = this.deps.getSelectedNpc();
         const hasSelectedNpc = selectedNpc !== null;
-        this.deps.villageUI.openDialogueBtn.disabled = !hasSelectedNpc;
         this.deps.villageUI.askVillageBtn.disabled = !hasSelectedNpc;
         this.deps.villageUI.askPersonBtn.disabled = !hasSelectedNpc;
         const selectedNpcName = selectedNpc?.name ?? '';

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -73,7 +73,6 @@ function createVillageUi() {
     title: createElement(),
     prompt: createElement(),
     actions: createElement(),
-    openDialogueBtn: createElement('button'),
     sleepRoomBtn: createElement('button'),
     villageWaitBtn: createElement('button'),
     dialogueModal: createElement(),
@@ -473,10 +472,8 @@ test('VillageActionsController mirrors dialogue lines into modal log and toggles
 
   controller.enterVillage('Mossbrook');
   controller.handleEnter('Mossbrook');
-  assert.equal(villageUI.openDialogueBtn.disabled, true);
+  assert.equal(villageUI.dialogueModal.classList.contains('hidden'), true);
   controller.handleSelectNpc(0);
-  assert.equal(villageUI.openDialogueBtn.disabled, false);
-  controller.openDialogueWindow();
   assert.equal(villageUI.dialogueModal.classList.removed.includes('hidden'), true);
 
   controller.addLog('Modal mirror check', 'system');


### PR DESCRIPTION
### Motivation
- Simplify the village rumors UX by removing an extra click step required to open NPC dialogue, so selecting an NPC opens the dialogue modal immediately.
- Reduce UI surface area and remove an obsolete button and wiring that no longer fit the streamlined flow.

### Description
- Removed the `Open NPC dialogue window` button from the village rumors markup (`rgfn_game/index.html`) and deleted the `openDialogueBtn` from the village UI types and scene model (`VillageActionsTypes.ts`, `GameUiSceneModels.ts`).
- Removed factory/binder wiring that referenced the removed button (`GameUiFactory.ts`, `GameUiPrimaryEventBinder.ts`) and cleared the presenter code that toggled the now-removed button (`VillageUiPresenter.ts`).
- Changed `VillageActionsController.handleSelectNpc(...)` to call `uiPresenter.openDialogueWindow()` immediately after selecting an NPC, making the rumors list the direct trigger for opening the modal (`VillageActionsController.ts`).
- Updated scenario test stubs and assertions to reflect the new one-click flow and removed the obsolete `openDialogueBtn` test expectations (`rgfn_game/test/systems/scenarios/villageActionsController.test.js`).
- Updated documentation to document the new direct-open behavior and added an April 19, 2026 follow-up note describing the UX simplification (`rgfn_game/docs/village/village-dialogue-modal.md`).

### Testing
- Ran ESLint targeted to the modified files with `npx eslint <files>` and the linter completed for those files (no new errors introduced in the changed files).
- Ran the full RGFN lint script `npm run lint:ts:rgfn`, which reports pre-existing repository-wide linter issues unrelated to this change (the run failed due to those existing issues, not changes made here).
- Built and ran the full RGFN test suite with `npm run test:rgfn`, which failed due to a pre-existing unrelated failing test in `recoverQuestRuntime.test.js` (assertion mismatch), so the global suite result is failing but unrelated to the UI change.
- Ran the focused controller scenario test with `node --test --test-name-pattern="mirrors dialogue lines into modal log and toggles modal visibility" rgfn_game/test/systems/scenarios/villageActionsController.test.js` and it passed, validating the new one-click flow and modal log mirroring behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b4e9aa3c8323be209069ae067e68)