### PR TITLE
RGFN: surface side-quest type in offer header and trim boilerplate intro

### DIFF
--- a/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
+++ b/rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md
@@ -218,6 +218,30 @@
   - offer registration,
   - accept,
   - mark-ready-to-turn-in,
+
+## 2026-04-19: Offer-card header now includes side-quest type and trims boilerplate line
+
+- Village side-quest cards now expose the **side-quest type directly in the first line**:
+  - Format: `<Quest Title> — <Status> (<Type>)`
+  - Example: `Kadra Zentor's Request — Offer available (Purge)`.
+- Type label resolution prioritizes the first leaf objective type when present (the actionable objective), then falls back to the root quest objective type.
+- Type labels are normalized for readability:
+  - `deliver` / `localDelivery` → `Courier`
+  - `eliminate` / `hunt` → `Purge`
+  - others map 1:1 (`Scout`, `Recover`, `Escort`, `Defend`, `Gather`, `Repair`, `Patrol`, `Travel`, `Barter`).
+- The old root-description boilerplate line is now suppressed when it matches:
+  - `Assist <NPC> with a local task in <Village>.`
+- Practical result:
+  - players can scan offer lists by quest category immediately (Courier/Purge/etc.),
+  - redundant introductory copy is removed from the card body,
+  - concrete objective context remains available through the existing `Task details: ...` line.
+
+### Regression coverage
+
+- `villageActionsController` scenario tests now assert:
+  - offer card header includes the normalized type label,
+  - boilerplate root description is omitted,
+  - task-details line still renders for leaf objective descriptions.
   - turn-in completion.
 - This prevents stale HUD state where village-side quest cards update but HUD Quests panel does not.
   - Offer cards remain labeled **Offer available** and include an **Accept quest** button.

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -15,7 +15,7 @@ import {
     VillageUI,
 } from './actions/VillageActionsTypes.js';
 import { isDeveloperModeEnabled } from '../../utils/DeveloperModeConfig.js';
-import { DeliverObjectiveData, QuestNode } from '../quest/QuestTypes.js';
+import { DeliverObjectiveData, QuestNode, QuestObjectiveType } from '../quest/QuestTypes.js';
 import { balanceConfig } from '../../config/balance/balanceConfig.js';
 export default class VillageActionsController {
     private readonly villageUI: VillageUI;
@@ -639,7 +639,11 @@ export default class VillageActionsController {
 
     private appendSideQuestCardText(card: HTMLElement, quest: QuestNode, isOffer: boolean): void {
         const statusText = isOffer ? 'Offer available' : this.getSideQuestStatusText(quest.status);
-        const lines = [`${quest.title} — ${statusText}`, quest.description];
+        const sideQuestType = this.getSideQuestTypeLabel(quest);
+        const lines = [`${quest.title} — ${statusText} (${sideQuestType})`];
+        if (!this.isBoilerplateSideQuestDescription(quest.description)) {
+            lines.push(quest.description);
+        }
         const taskDetails = this.getSideQuestTaskDetails(quest);
         if (taskDetails) {
             lines.push(`Task details: ${taskDetails}`);
@@ -651,6 +655,53 @@ export default class VillageActionsController {
                 element.textContent = line;
                 card.appendChild(element);
             });
+    }
+
+    private getSideQuestTypeLabel(quest: QuestNode): string {
+        const primaryObjectiveType = quest.children[0]?.objectiveType ?? quest.objectiveType;
+        return this.getObjectiveTypeLabel(primaryObjectiveType);
+    }
+
+    private getObjectiveTypeLabel(objectiveType: QuestObjectiveType): string {
+        if (objectiveType === 'deliver' || objectiveType === 'localDelivery') {
+            return 'Courier';
+        }
+        if (objectiveType === 'eliminate' || objectiveType === 'hunt') {
+            return 'Purge';
+        }
+        if (objectiveType === 'travel') {
+            return 'Travel';
+        }
+        if (objectiveType === 'barter') {
+            return 'Barter';
+        }
+        if (objectiveType === 'scout') {
+            return 'Scout';
+        }
+        if (objectiveType === 'recover') {
+            return 'Recover';
+        }
+        if (objectiveType === 'escort') {
+            return 'Escort';
+        }
+        if (objectiveType === 'defend') {
+            return 'Defend';
+        }
+        if (objectiveType === 'gather') {
+            return 'Gather';
+        }
+        if (objectiveType === 'repair') {
+            return 'Repair';
+        }
+        return 'Patrol';
+    }
+
+    private isBoilerplateSideQuestDescription(description: string): boolean {
+        const normalizedDescription = description.trim();
+        if (/^Assist .+ with a local task in .+\.$/u.test(normalizedDescription)) {
+            return true;
+        }
+        return false;
     }
 
     private getSideQuestTaskDetails(quest: QuestNode): string {

--- a/rgfn_game/test/systems/scenarios/villageActionsController.test.js
+++ b/rgfn_game/test/systems/scenarios/villageActionsController.test.js
@@ -946,6 +946,54 @@ test('VillageActionsController does not auto-accept side quests in developer mod
   assert.equal(gameLog.children.some((child) => String(child.textContent ?? '').includes('Auto-accepted side quests')), false);
 })));
 
+test('VillageActionsController labels side-quest type in card header and omits boilerplate offer description', () => withDocumentStub(() => {
+  const villageUI = createVillageUi();
+  const gameLog = createElement();
+  const offerQuest = {
+    id: 'side-quest-offer-type',
+    title: 'Kadra Zentor\'s Request',
+    description: 'Assist Kadra Zentor with a local task in Selzen.',
+    reward: '29g',
+    status: 'available',
+    objectiveType: 'scout',
+    children: [
+      {
+        id: 'side-quest-offer-type-leaf',
+        title: 'Purge Sproutlings',
+        description: 'Track and purge rare mutant targets.',
+        reward: '29g',
+        status: 'available',
+        objectiveType: 'eliminate',
+        children: [],
+      },
+    ],
+  };
+  const controller = new VillageActionsController(createPlayerStub(), villageUI, gameLog, {
+    onUpdateHUD: () => {},
+    onLeaveVillage: () => {},
+    onAdvanceTime: () => {},
+    getVillageDirectionHint: (settlementName) => ({ settlementName, exists: false }),
+    onVillageBarterCompleted: () => {},
+    getVillageSideQuestOffers: () => [offerQuest],
+    getVillageNpcActiveSideQuests: () => [],
+    acceptSideQuest: () => ({ accepted: true }),
+  });
+  controller['dialogueEngine'] = {
+    createNpcRoster: () => [{ id: 'sel-0', name: 'Kadra Zentor', role: 'Scout', look: 'cloak', speechStyle: 'calm', disposition: 'truthful' }],
+    buildLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+    buildPersonLocationAnswer: () => ({ speech: '', tone: '', truthfulness: 'truth' }),
+  };
+
+  controller.enterVillage('Selzen');
+  controller.handleSelectNpc(0);
+
+  const offerCard = villageUI.sideQuestList.children[0];
+  assert.equal(Boolean(offerCard), true);
+  assert.equal(offerCard.children.some((entry) => entry.textContent?.includes('Offer available (Purge)')), true);
+  assert.equal(offerCard.children.some((entry) => entry.textContent === 'Assist Kadra Zentor with a local task in Selzen.'), false);
+  assert.equal(offerCard.children.some((entry) => entry.textContent?.includes('Task details: Track and purge rare mutant targets.')), true);
+}));
+
 test('VillageActionsController shows turn-in action for ready side quests and turn-in is explicit', () => withDocumentStub(() => {
   const villageUI = createVillageUi();
   const gameLog = createElement();


### PR DESCRIPTION
### Motivation
- Make village side-quest offers scannable by surfacing a normalized quest type (Courier, Purge, etc.) in the offer card header so players can see the side-quest category at a glance. 
- Reduce UI clutter by removing the repetitive boilerplate intro line (`Assist <NPC> with a local task in <Village>.`) when it adds no actionable detail. 
- Preserve concrete objective context by keeping the existing `Task details:` and reward preview lines so players still see the actionable scope before accepting.

### Description
- Updated the side-quest card renderer in `VillageActionsController` to show the header as `<title> — <status> (<Type>)` by computing a `sideQuestType` derived from the first leaf objective or falling back to the root `objectiveType`. 
- Added helpers `getSideQuestTypeLabel`, `getObjectiveTypeLabel`, and `isBoilerplateSideQuestDescription` to normalize objective types (e.g., `deliver`/`localDelivery` → `Courier`, `eliminate`/`hunt` → `Purge`) and to detect/suppress the boilerplate description. 
- Guarded the card body so the boilerplate description is omitted while `Task details:` (from first non-empty child description different from root) and `Reward preview:` remain displayed. 
- Added a scenario test in `rgfn_game/test/systems/scenarios/villageActionsController.test.js` that asserts header includes the normalized type, the boilerplate line is omitted, and task-details still render. 
- Documented the UX change in `rgfn_game/docs/quests/side-quest-village-runtime-2026-04-14.md` with regression coverage notes.

### Testing
- Ran `npx eslint rgfn_game/js/systems/village/VillageActionsController.ts rgfn_game/test/systems/scenarios/villageActionsController.test.js` and the checked files passed linting. 
- Ran repository lint `npm run lint:ts:rgfn` which failed due to pre-existing style-guide errors (unrelated files like `VillageDialogueEngine.ts`); the failures are pre-existing and not introduced by this change. 
- Ran full RGFN tests via `npm run test:rgfn`; the test suite run completed but the overall job failed due to an existing failing test in `recoverQuestRuntime.test.js` (`GameQuestRuntime marks deliver side quests ready when reaching destination with carried courier item`) unrelated to this change. 
- Ran `node --test rgfn_game/test/systems/scenarios/villageActionsController.test.js` where the new scenario test passes, while other unrelated failures in that suite reflect pre-existing issues in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b5cbf5cc8323990ecf2ccdc3add5)