### PR TITLE
Make side-quest giver village clickable in Quests panel

### DIFF
--- a/rgfn_game/docs/quest/side-quest-giver-village-link-2026-04-19.md
+++ b/rgfn_game/docs/quest/side-quest-giver-village-link-2026-04-19.md
@@ -1,0 +1,20 @@
+# Side Quest Giver Village Link in Quest Cards (2026-04-19)
+
+## What changed
+- In the **Side Quests** panel card header metadata (`Giver: ... · Village: ...`), the village name is now rendered as a clickable location link button (`data-location-name="<village>"`) instead of plain text.
+- The village link reuses existing quest location-link styling (`quest-entity-name location`) so it appears blue/underlined and behaves the same way as other quest location links.
+
+## Implementation notes
+- File updated: `rgfn_game/js/systems/quest/ui/QuestUiController.ts`
+  - Added `buildLocationLinkMarkup(locationName)` helper.
+  - Side-quest card builder now uses that helper for `giverVillageName`.
+- No new click handler was required; `handleLocationClick(...)` already delegates all `[data-location-name]` interactions to world-map focus callback.
+
+## Regression coverage
+- Extended scenario test in `rgfn_game/test/systems/scenarios/questUiController.test.js`:
+  - verifies side-quest card markup contains `data-location-name="Oakcross"`;
+  - verifies village uses location-link class (`quest-entity-name location`).
+
+## Why this is safe
+- Uses existing event contract and existing CSS class contract.
+- Does not alter quest generation/runtime state; UI-only markup update.

--- a/rgfn_game/js/systems/quest/ui/QuestUiController.ts
+++ b/rgfn_game/js/systems/quest/ui/QuestUiController.ts
@@ -255,7 +255,7 @@ export default class QuestUiController {
     private buildSideQuestCardMarkup(quest: QuestNode): string {
         const status = quest.status ?? 'active';
         const giverNpc = this.escapeHtml(quest.giverNpcName ?? 'Unknown giver');
-        const giverVillage = this.escapeHtml(quest.giverVillageName ?? 'Unknown village');
+        const giverVillage = this.buildLocationLinkMarkup(quest.giverVillageName ?? 'Unknown village');
         const rewardMarkup = quest.reward ? `<div class="side-quest-meta">Reward: ${this.escapeHtml(quest.reward)}</div>` : '';
         const treeMarkup = this.markupBuilder.buildQuestTreeMarkup(quest);
         const title = this.escapeHtml(quest.title);
@@ -272,6 +272,11 @@ export default class QuestUiController {
         </details>`;
     }
     private formatStatus = (status: string): string => status === 'readyToTurnIn' ? 'Ready to turn in' : status.charAt(0).toUpperCase() + status.slice(1);
+
+    private buildLocationLinkMarkup(locationName: string): string {
+        const escapedLocationName = this.escapeHtml(locationName);
+        return `<button type="button" class="quest-entity-name location" data-location-name="${escapedLocationName}">${escapedLocationName}</button>`;
+    }
     private handleSideFilterButtonClick(): void {
         if (this.activeTab !== 'side') {
             return;

--- a/rgfn_game/test/systems/scenarios/questUiController.test.js
+++ b/rgfn_game/test/systems/scenarios/questUiController.test.js
@@ -352,6 +352,8 @@ test('QuestUiController renders known side quests in side tab with nested object
   assert.equal(body.innerHTML.includes('Village Supplies'), true);
   assert.equal(body.innerHTML.includes('Gather Resin Bundles'), true);
   assert.equal(body.innerHTML.includes('side-quest-status'), true);
+  assert.equal(body.innerHTML.includes('data-location-name="Oakcross"'), true);
+  assert.equal(body.innerHTML.includes('quest-entity-name location'), true);
 });
 
 test('QuestUiController applies side quest status filter popup selections and persists status list', () => {


### PR DESCRIPTION
### Motivation
- Side quest cards currently render the giver village as plain text in the Quests panel, but other village/location names are clickable; this change makes the giver village behave identically for consistent UX.

### Description
- Replaced the plain-escaped village text with a location link in `buildSideQuestCardMarkup` by adding `buildLocationLinkMarkup(locationName)` in `rgfn_game/js/systems/quest/ui/QuestUiController.ts` so `Village: <name>` becomes a clickable `button` with `data-location-name` and `quest-entity-name location` styling.
- Kept existing click handling by reusing the `data-location-name` contract that `handleLocationClick(...)` already responds to, so no new event handlers were necessary.
- Added assertions to `rgfn_game/test/systems/scenarios/questUiController.test.js` to verify the side-quest markup now includes `data-location-name="Oakcross"` and the `quest-entity-name location` class.
- Added an implementation note document at `rgfn_game/docs/quest/side-quest-giver-village-link-2026-04-19.md` describing the change and regression coverage.

### Testing
- Ran `npx eslint rgfn_game/js/systems/quest/ui/QuestUiController.ts` and the lint check for the modified file passed.
- Ran `npm run test:rgfn` (which triggers `tsc -p rgfn_game/tsconfig.json`), but the build step failed due to pre-existing TypeScript errors unrelated to this change in `rgfn_game/js/systems/village/VillageActionsController.ts` at lines 139 and 704, so the full test suite did not run.
- The updated scenario test assertions are present and ready to run once the unrelated TypeScript build errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e48f20408323bf90e6b5078ba873)