### PR TITLE
Add WorldSimulationRuntime, integrate ticking into advanceTime, and add Dev World Info Overview

### DIFF
--- a/rgfn_game/docs/world/world-simulation-runtime-integration-2026-04-19.md
+++ b/rgfn_game/docs/world/world-simulation-runtime-integration-2026-04-19.md
@@ -1,0 +1,96 @@
+# World Simulation Runtime Integration (2026-04-19)
+
+## What was added
+
+- Added `WorldSimulationRuntime` with required API:
+  - `initialize(initialState?)`
+  - `tick(deltaMinutes)`
+  - `getState()`
+  - `restoreState(state)`
+- Added deterministic stage pipeline order per tick:
+  1. `movement`
+  2. `taskAssign`
+  3. `taskProgress`
+  4. `conflicts`
+  5. `villages`
+- Added persistence support for world simulation snapshot in save payload.
+- Added world simulation ticking from gameplay time progression (`advanceTime`), which is triggered by world/village player actions.
+- Added a developer-only World Info section with an `Overview` tab in the Developer Event Queue modal.
+
+## Runtime contract
+
+`WorldSimulationRuntime.getState()` returns:
+
+```ts
+{
+  worldTick: number;
+  lastDelta: number;
+  pendingEvents: string[];
+  lastStageOrder: Array<'movement' | 'taskAssign' | 'taskProgress' | 'conflicts' | 'villages'>;
+}
+```
+
+### Notes
+
+- `worldTick` is monotonic and increments once per `tick(...)` call.
+- `lastDelta` stores the sanitized non-negative delta from the latest call.
+- `pendingEvents` is currently a capped rolling buffer (up to 64 entries), safe for debug/inspection.
+- `lastStageOrder` is updated every tick and is used to assert pipeline sequencing in tests.
+
+## Why ticking is integrated via `advanceTime`
+
+In the current architecture, most meaningful player actions in world/village modes route through `onAdvanceTime(...)` callbacks (travel, ferry, village interactions, rest/wait, trade actions, etc.).
+
+Hooking `WorldSimulationRuntime.tick(deltaMinutes)` into `GameFacade.advanceTime(...)` ensures:
+
+- one consistent integration point,
+- no duplicate ticking scattered across UI handlers,
+- easy persistence and inspection.
+
+## Developer UI: World Info / Overview
+
+A new block was added to Developer Event Queue modal:
+
+- Section title: `World Info`
+- Tablist (currently one tab): `Overview`
+- JSON output fields:
+  - `worldTick`
+  - `lastDelta`
+  - `pendingEvents`
+  - `pendingEventsCount`
+  - `capturedAt`
+
+## Automated test coverage
+
+Added minimal automated checks for:
+
+1. `worldTick` growth across sequential ticks.
+2. exact stage order execution in one tick.
+
+These tests live in:
+
+- `rgfn_game/test/systems/worldSimulationRuntime.test.js`
+
+## UI manual verification checklist (issue checklist)
+
+- [ ] Start RGFN build and launch game UI.
+- [ ] Open Developer Event Queue (press `~`).
+- [ ] Confirm new **World Info** section is visible.
+- [ ] Confirm **Overview** tab exists and is active.
+- [ ] Verify initial snapshot shows numeric `worldTick` and `lastDelta`.
+- [ ] Perform one action that advances time (e.g., move on world map to trigger travel time).
+- [ ] Re-open/refresh World Info Overview and verify `worldTick` increased.
+- [ ] Perform another distinct time-advancing action (e.g., village interaction / ferry travel / wait/rest).
+- [ ] Verify `worldTick` increased again.
+- [ ] Verify `lastDelta` updates according to action time cost.
+- [ ] Verify `pendingEvents` is non-empty and includes stage-tagged entries.
+- [ ] Save/reload (if using persistent save flow) and verify simulation snapshot restores without reset when save exists.
+
+## Extra implementation notes for future phases
+
+- Current pipeline stage handlers intentionally provide lightweight placeholders/events.
+- Domain-specific logic for assignments/conflicts/villages can be incrementally injected into each stage while preserving API.
+- If UI payload grows large, consider:
+  - pagination/virtualization,
+  - partial event projection,
+  - compact mode in the Overview tab.

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -471,6 +471,16 @@
                     </div>
                 </div>
                 <div class="dev-events-queue-wrap">
+                    <h3>World Info</h3>
+                    <p class="dev-events-hint dev-events-hint-tight">Developer-only world simulation snapshot (updates when panel is opened or tab is clicked).</p>
+                    <div class="quest-tabs" role="tablist" aria-label="World info tabs">
+                        <button id="dev-world-info-tab-overview" class="quest-tab is-active" type="button" role="tab" aria-selected="true">Overview</button>
+                    </div>
+                    <section id="dev-world-info-panel-overview" role="tabpanel">
+                        <pre id="dev-world-info-overview-output" class="dev-world-map-profiling-output">{}</pre>
+                    </section>
+                </div>
+                <div class="dev-events-queue-wrap">
                     <h3>World map profiling window</h3>
                     <p class="dev-events-hint dev-events-hint-tight">Open a standalone draggable/resizable profiling window (like HUD panels) for live map draw metrics.</p>
                     <div class="dev-roll-actions">

--- a/rgfn_game/js/game/GameFacade.ts
+++ b/rgfn_game/js/game/GameFacade.ts
@@ -31,6 +31,7 @@ import { FerryRouteOption } from '../systems/world-mode/WorldModeFerryPromptCont
 import GameTimeRuntime from '../systems/time/GameTimeRuntime.js';
 import { QuestNode, QuestRewardMetadata } from '../systems/quest/QuestTypes.js';
 import { resolveSideQuestRewardMetadata } from '../systems/quest/QuestRewardResolver.js';
+import WorldSimulationRuntime, { WorldSimulationState } from '../systems/world-sim/WorldSimulationRuntime.js';
 
 export type UIBundle = {
     hudElements: HudElements;
@@ -84,6 +85,7 @@ export class GameFacade implements GameFacadeStateAccess {
     public readonly questRuntime = new GameQuestRuntime();
     public readonly persistenceRuntime = new GamePersistenceRuntime(SAVE_KEY);
     public readonly worldInteractionRuntime = new GameWorldInteractionRuntime();
+    public readonly worldSimulationRuntime = new WorldSimulationRuntime();
     public gameTime!: GameTimeRuntime;
     private readonly lifecycle = new GameFacadeLifecycleCoordinator(this);
     private readonly worldInteractionCoordinator = new GameFacadeWorldInteractionCoordinator(this);
@@ -121,6 +123,7 @@ export class GameFacade implements GameFacadeStateAccess {
         const characterSeed = this.hashStringSeed(this.player.name);
         this.gameTime = new GameTimeRuntime(savedTime, worldSeed ^ characterSeed);
         this.worldMap.setDaylightFactor(this.gameTime.getDaylightFactor());
+        this.worldSimulationRuntime.initialize(this.persistenceRuntime.getParsedSaveState()?.worldSimulation);
         this.questRuntime.initialize(
             runtime.questGenerator,
             runtime.questUiController,
@@ -264,7 +267,10 @@ export class GameFacade implements GameFacadeStateAccess {
         this.gameTime.advanceMinutes(minutes);
         this.player.addTravelFatigue(Math.max(0, fatigueScale));
         this.worldMap.setDaylightFactor(this.gameTime.getDaylightFactor());
+        this.worldSimulationRuntime.tick(minutes);
     }
+
+    public readonly getWorldSimulationState = (): WorldSimulationState => this.worldSimulationRuntime.getState();
 
     public getHudTimeSnapshot(): { clock: string; date: string; calendarTitle: string; calendarLines: string[] } {
         if (!this.gameTime) {

--- a/rgfn_game/js/game/GameRuntimeAssembly.ts
+++ b/rgfn_game/js/game/GameRuntimeAssembly.ts
@@ -98,6 +98,7 @@ const createDevController = (
     encounterSystem: EncounterSystem,
     worldMap: WorldMap,
     worldInteractionRuntime: GameFacade['worldInteractionRuntime'],
+    getWorldSimulationOverview: () => ReturnType<GameFacade['getWorldSimulationState']>,
     villageActionsController: { addLog: (message: string, type?: string) => void },
     villageCoordinator: { getDeveloperEventLabel: (type: string) => string },
 ): DeveloperEventController => new DeveloperEventController(ui.developerUI, encounterSystem, {
@@ -117,6 +118,7 @@ const createDevController = (
     getWorldMapRenderFpsCap: () => worldMap.getRenderFpsCap(),
     setWorldMapDevicePixelRatioClamp: (clamp) => worldMap.setDevicePixelRatioClamp(clamp),
     getWorldMapDevicePixelRatioClamp: () => worldMap.getDevicePixelRatioClamp(),
+    getWorldSimulationOverview,
 });
 
 // eslint-disable-next-line style-guide/function-length-warning
@@ -268,6 +270,7 @@ export function buildGameRuntime(
         runtimeBase.encounterSystem,
         runtimeBase.worldMap,
         game.worldInteractionRuntime,
+        () => game.getWorldSimulationState(),
         runtime.villageActionsController,
         runtime.villageCoordinator,
     );

--- a/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
+++ b/rgfn_game/js/game/runtime/GameFacadeLifecycleCoordinator.ts
@@ -33,6 +33,7 @@ export default class GameFacadeLifecycleCoordinator {
             this.state.questRuntime.activeQuest,
             this.state.questRuntime.activeSideQuests,
             this.state.gameTime?.getState(),
+            this.state.worldSimulationRuntime.getState(),
         );
     }
 
@@ -55,6 +56,7 @@ export default class GameFacadeLifecycleCoordinator {
             this.state.questRuntime.activeQuest,
             this.state.questRuntime.activeSideQuests,
             this.state.gameTime?.getState(),
+            this.state.worldSimulationRuntime.getState(),
         );
         this.state.worldMap?.setLastUpdateMs(performance.now() - updateStart);
     }
@@ -104,6 +106,7 @@ export default class GameFacadeLifecycleCoordinator {
             this.state.questRuntime.activeQuest,
             this.state.questRuntime.activeSideQuests,
             this.state.gameTime?.getState(),
+            this.state.worldSimulationRuntime.getState(),
         );
     }
 

--- a/rgfn_game/js/game/runtime/GameFacadeSharedTypes.ts
+++ b/rgfn_game/js/game/runtime/GameFacadeSharedTypes.ts
@@ -15,6 +15,7 @@ import type GameQuestRuntime from '../runtime/GameQuestRuntime.js';
 import type GamePersistenceRuntime from '../runtime/GamePersistenceRuntime.js';
 import type GameWorldInteractionRuntime from '../runtime/GameWorldInteractionRuntime.js';
 import type GameTimeRuntime from '../../systems/time/GameTimeRuntime.js';
+import type WorldSimulationRuntime from '../../systems/world-sim/WorldSimulationRuntime.js';
 
 export type GameFacadeStateAccess = {
     canvas: HTMLCanvasElement;
@@ -35,6 +36,7 @@ export type GameFacadeStateAccess = {
     questRuntime: GameQuestRuntime;
     persistenceRuntime: GamePersistenceRuntime;
     worldInteractionRuntime: GameWorldInteractionRuntime;
+    worldSimulationRuntime: WorldSimulationRuntime;
     gameTime: GameTimeRuntime;
     advanceTime: (minutes: number, fatigueScale: number) => void;
 };

--- a/rgfn_game/js/game/runtime/GamePersistenceRuntime.ts
+++ b/rgfn_game/js/game/runtime/GamePersistenceRuntime.ts
@@ -11,6 +11,7 @@ export type GameSaveState = {
     quest: QuestNode | null;
     sideQuests?: QuestNode[];
     time?: Record<string, unknown>;
+    worldSimulation?: Record<string, unknown>;
 };
 
 export default class GamePersistenceRuntime {
@@ -26,6 +27,7 @@ export default class GamePersistenceRuntime {
         activeQuest: QuestNode | null,
         activeSideQuests: QuestNode[] = [],
         timeState?: Record<string, unknown>,
+        worldSimulationState?: Record<string, unknown>,
     ): void {
         const snapshot = JSON.stringify({
             version: 1,
@@ -35,6 +37,7 @@ export default class GamePersistenceRuntime {
             quest: activeQuest,
             sideQuests: activeSideQuests,
             time: timeState,
+            worldSimulation: worldSimulationState,
         } as GameSaveState);
         if (snapshot === this.lastSavedSnapshot) {
             return;

--- a/rgfn_game/js/systems/encounter/DeveloperEventController.ts
+++ b/rgfn_game/js/systems/encounter/DeveloperEventController.ts
@@ -27,6 +27,7 @@ export default class DeveloperEventController {
         this.worldMapProfilingIntervalId = null;
         this.lastProfilingPayloadCacheKey = '';
         this.bindWorldMapProfilingPanelDrag();
+        this.bindWorldInfoControls();
     }
 
     public toggleModal(forceVisible?: boolean): void {
@@ -50,6 +51,7 @@ export default class DeveloperEventController {
         this.syncWorldMapRenderLayerTogglesFromMap();
         this.syncWorldMapRuntimeControlSelections();
         this.renderWorldMapProfilingPanel();
+        this.renderWorldInfoOverview();
     }
 
     public applyDeveloperModeOnStartup(): void {
@@ -233,6 +235,17 @@ export default class DeveloperEventController {
         }, null, 2);
     }
 
+    public renderWorldInfoOverview(): void {
+        const overview = this.callbacks.getWorldSimulationOverview();
+        this.developerUI.worldInfoOverviewOutput.textContent = JSON.stringify({
+            worldTick: overview.worldTick,
+            lastDelta: overview.lastDelta,
+            pendingEvents: overview.pendingEvents,
+            pendingEventsCount: overview.pendingEvents.length,
+            capturedAt: new Date().toISOString(),
+        }, null, 2);
+    }
+
     private syncWorldMapRenderLayerTogglesFromMap(): void {
         const toggles = this.callbacks.getWorldMapRenderLayerToggles();
         this.developerUI.worldMapProfilingRenderLayerToggles.terrain.checked = toggles.terrain;
@@ -263,6 +276,15 @@ export default class DeveloperEventController {
         const panel = this.developerUI.worldMapProfilingPanel;
         const dragHandle = this.developerUI.worldMapProfilingDragHandle;
         dragHandle.addEventListener('pointerdown', (event: PointerEvent) => this.handleProfilingPanelPointerDown(event, panel, dragHandle));
+    }
+
+    private bindWorldInfoControls(): void {
+        this.developerUI.worldInfoOverviewTabBtn.addEventListener('click', () => {
+            this.developerUI.worldInfoOverviewTabBtn.classList.add('is-active');
+            this.developerUI.worldInfoOverviewTabBtn.setAttribute('aria-selected', 'true');
+            this.developerUI.worldInfoOverviewPanel.classList.remove('hidden');
+            this.renderWorldInfoOverview();
+        });
     }
 
     private handleProfilingPanelPointerDown(event: PointerEvent, panel: HTMLElement, dragHandle: HTMLElement): void {

--- a/rgfn_game/js/systems/encounter/DeveloperEventTypes.ts
+++ b/rgfn_game/js/systems/encounter/DeveloperEventTypes.ts
@@ -37,6 +37,9 @@ export type DeveloperUI = {
     worldMapProfilingFpsCapSelect: HTMLSelectElement;
     worldMapProfilingDevicePixelRatioClampSelect: HTMLSelectElement;
     worldMapProfilingOutput: HTMLElement;
+    worldInfoOverviewTabBtn: HTMLButtonElement;
+    worldInfoOverviewPanel: HTMLElement;
+    worldInfoOverviewOutput: HTMLElement;
 };
 
 export type WorldMapDrawProfilingSnapshot = Record<string, { frames: number; avgMs: number; maxMs: number; lastFrameMs: number }>;
@@ -70,6 +73,7 @@ export type DeveloperCallbacks = {
     getWorldMapRenderFpsCap: () => 'uncapped' | '60' | '30';
     setWorldMapDevicePixelRatioClamp: (clamp: 'auto' | '1' | '1.5') => void;
     getWorldMapDevicePixelRatioClamp: () => 'auto' | '1' | '1.5';
+    getWorldSimulationOverview: () => { worldTick: number; lastDelta: number; pendingEvents: string[] };
 };
 
 export const ENCOUNTER_LABELS: Record<RandomEncounterType, string> = { monster: 'Monster', item: 'Item', traveler: 'Traveler' };

--- a/rgfn_game/js/systems/game/runtime/GameDeveloperUiFactory.ts
+++ b/rgfn_game/js/systems/game/runtime/GameDeveloperUiFactory.ts
@@ -1,9 +1,9 @@
 import { DeveloperUI } from '../ui/GameUiTypes.js';
 
 export class GameDeveloperUiFactory {
-    public create = (): DeveloperUI => ({ ...this.createBaseDeveloperUi(), ...this.createProfilingUi() });
+    public create = (): DeveloperUI => ({ ...this.createBaseDeveloperUi(), ...this.createProfilingUi(), ...this.createWorldInfoUi() });
 
-    private readonly createBaseDeveloperUi = (): Omit<DeveloperUI, 'worldMapProfilingToggle' | 'worldMapProfilingOpenBtn' | 'worldMapProfilingPanel' | 'worldMapProfilingDragHandle' | 'worldMapProfilingCloseBtn' | 'worldMapProfilingRefreshBtn' | 'worldMapProfilingAutoRefreshToggle' | 'worldMapProfilingRenderLayerToggles' | 'worldMapProfilingFpsCapSelect' | 'worldMapProfilingDevicePixelRatioClampSelect' | 'worldMapProfilingOutput'> => ({
+    private readonly createBaseDeveloperUi = (): Omit<DeveloperUI, 'worldMapProfilingToggle' | 'worldMapProfilingOpenBtn' | 'worldMapProfilingPanel' | 'worldMapProfilingDragHandle' | 'worldMapProfilingCloseBtn' | 'worldMapProfilingRefreshBtn' | 'worldMapProfilingAutoRefreshToggle' | 'worldMapProfilingRenderLayerToggles' | 'worldMapProfilingFpsCapSelect' | 'worldMapProfilingDevicePixelRatioClampSelect' | 'worldMapProfilingOutput' | 'worldInfoOverviewTabBtn' | 'worldInfoOverviewPanel' | 'worldInfoOverviewOutput'> => ({
         ...this.createQueueAndEncounterUi(),
         ...this.createNextRollAndRandomUi(),
         ...this.createModeAndMapDisplayUi(),
@@ -80,5 +80,11 @@ export class GameDeveloperUiFactory {
         locations: document.getElementById('dev-world-map-render-locations')! as HTMLInputElement,
         roads: document.getElementById('dev-world-map-render-roads')! as HTMLInputElement,
         selectionCursor: document.getElementById('dev-world-map-render-selection-cursor')! as HTMLInputElement,
+    });
+
+    private readonly createWorldInfoUi = (): Pick<DeveloperUI, 'worldInfoOverviewTabBtn' | 'worldInfoOverviewPanel' | 'worldInfoOverviewOutput'> => ({
+        worldInfoOverviewTabBtn: document.getElementById('dev-world-info-tab-overview')! as HTMLButtonElement,
+        worldInfoOverviewPanel: document.getElementById('dev-world-info-panel-overview')!,
+        worldInfoOverviewOutput: document.getElementById('dev-world-info-overview-output')!,
     });
 }

--- a/rgfn_game/js/systems/game/ui/GameUiDeveloperModels.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiDeveloperModels.ts
@@ -47,6 +47,9 @@ export class DeveloperUiModel {
     public worldMapProfilingFpsCapSelect!: HTMLSelectElement;
     public worldMapProfilingDevicePixelRatioClampSelect!: HTMLSelectElement;
     public worldMapProfilingOutput!: HTMLElement;
+    public worldInfoOverviewTabBtn!: HTMLButtonElement;
+    public worldInfoOverviewPanel!: HTMLElement;
+    public worldInfoOverviewOutput!: HTMLElement;
 }
 
 export type DeveloperUI = DeveloperUiModel;

--- a/rgfn_game/js/systems/world-sim/WorldSimulationRuntime.ts
+++ b/rgfn_game/js/systems/world-sim/WorldSimulationRuntime.ts
@@ -1,0 +1,94 @@
+export type WorldSimulationStage = 'movement' | 'taskAssign' | 'taskProgress' | 'conflicts' | 'villages';
+
+export type WorldSimulationState = { worldTick: number; lastDelta: number; pendingEvents: string[]; lastStageOrder: WorldSimulationStage[] };
+
+type PartialState = Partial<WorldSimulationState> | null | undefined;
+
+const PIPELINE: WorldSimulationStage[] = ['movement', 'taskAssign', 'taskProgress', 'conflicts', 'villages'];
+
+const createDefaultState = (): WorldSimulationState => ({ worldTick: 0, lastDelta: 0, pendingEvents: [], lastStageOrder: [] });
+
+const ensureNonNegativeFinite = (value: unknown): number => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric < 0) {
+        return 0;
+    }
+    return numeric;
+};
+
+const sanitizePendingEvents = (events: unknown): string[] => {
+    if (!Array.isArray(events)) {
+        return [];
+    }
+    return events
+        .filter((item) => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0)
+        .slice(0, 64);
+};
+
+const sanitizeStageOrder = (stages: unknown): WorldSimulationStage[] => {
+    if (!Array.isArray(stages)) {
+        return [];
+    }
+    return stages.filter((stage): stage is WorldSimulationStage => PIPELINE.includes(stage as WorldSimulationStage));
+};
+
+export default class WorldSimulationRuntime {
+    private state: WorldSimulationState = createDefaultState();
+
+    public initialize(initialState?: PartialState): void {
+        this.state = createDefaultState();
+        this.restoreState(initialState);
+    }
+
+    public tick(deltaMinutes: number): WorldSimulationState {
+        const safeDelta = ensureNonNegativeFinite(deltaMinutes);
+        this.state.worldTick += 1;
+        this.state.lastDelta = safeDelta;
+        this.state.lastStageOrder = [];
+
+        for (const stage of PIPELINE) {
+            this.runStage(stage, safeDelta);
+        }
+
+        return this.getState();
+    }
+
+    public readonly getState = (): WorldSimulationState => ({
+        worldTick: this.state.worldTick,
+        lastDelta: this.state.lastDelta,
+        pendingEvents: [...this.state.pendingEvents],
+        lastStageOrder: [...this.state.lastStageOrder],
+    });
+
+    public restoreState(nextState?: PartialState): void {
+        if (!nextState || typeof nextState !== 'object') {
+            return;
+        }
+
+        this.state.worldTick = Math.floor(ensureNonNegativeFinite(nextState.worldTick));
+        this.state.lastDelta = ensureNonNegativeFinite(nextState.lastDelta);
+        this.state.pendingEvents = sanitizePendingEvents(nextState.pendingEvents);
+        this.state.lastStageOrder = sanitizeStageOrder(nextState.lastStageOrder);
+    }
+
+    private runStage(stage: WorldSimulationStage, deltaMinutes: number): void {
+        this.state.lastStageOrder.push(stage);
+        const eventByStage: Record<WorldSimulationStage, string> = {
+            movement: `movement:${deltaMinutes.toFixed(2)}`,
+            taskAssign: `taskAssign:tick-${this.state.worldTick}`,
+            taskProgress: `taskProgress:${deltaMinutes.toFixed(2)}`,
+            conflicts: `conflicts:scan-${this.state.worldTick}`,
+            villages: `villages:update-${this.state.worldTick}`,
+        };
+        this.enqueueEvent(eventByStage[stage]);
+    }
+
+    private enqueueEvent(eventLabel: string): void {
+        this.state.pendingEvents.push(eventLabel);
+        if (this.state.pendingEvents.length > 64) {
+            this.state.pendingEvents = this.state.pendingEvents.slice(-64);
+        }
+    }
+}

--- a/rgfn_game/test/systems/worldSimulationRuntime.test.js
+++ b/rgfn_game/test/systems/worldSimulationRuntime.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import WorldSimulationRuntime from '../../dist/systems/world-sim/WorldSimulationRuntime.js';
+
+test('WorldSimulationRuntime increments worldTick on each tick', () => {
+  const runtime = new WorldSimulationRuntime();
+  runtime.initialize();
+
+  assert.equal(runtime.getState().worldTick, 0);
+  runtime.tick(5);
+  assert.equal(runtime.getState().worldTick, 1);
+  runtime.tick(12);
+  assert.equal(runtime.getState().worldTick, 2);
+});
+
+test('WorldSimulationRuntime runs stages in the expected pipeline order', () => {
+  const runtime = new WorldSimulationRuntime();
+  runtime.initialize();
+  runtime.tick(10);
+
+  assert.deepEqual(runtime.getState().lastStageOrder, [
+    'movement',
+    'taskAssign',
+    'taskProgress',
+    'conflicts',
+    'villages',
+  ]);
+});


### PR DESCRIPTION
### Motivation
- Introduce a small, testable world-life simulation runtime to centralize per-minute world updates and pipeline sequencing for future domain logic.
- Ensure player-driven time advances (travel, village actions, sleep, ferry, etc.) drive the world simulation consistently from a single entrypoint (`advanceTime`).
- Expose minimal developer diagnostics so QA and engineers can inspect `worldTick` progression and pending simulation events in the UI.

### Description
- Added a new runtime `WorldSimulationRuntime` at `rgfn_game/js/systems/world-sim/WorldSimulationRuntime.ts` with the API `initialize/ tick/ getState/ restoreState` and a deterministic pipeline `movement → taskAssign → taskProgress → conflicts → villages` that records `worldTick`, `lastDelta`, `pendingEvents` and `lastStageOrder`.
- Integrated the runtime into the game lifecycle by adding `worldSimulationRuntime` to `GameFacade`, calling `worldSimulationRuntime.initialize(...)` during runtime assignment, and calling `worldSimulationRuntime.tick(minutes)` from `GameFacade.advanceTime(...)`, and exposing `getWorldSimulationState()` for consumers.
- Persisted simulation snapshot in saves by extending `GamePersistenceRuntime` to include `worldSimulation` and wiring lifecycle save points in `GameFacadeLifecycleCoordinator` to include the simulation state.
- Added a developer-only World Info Overview UI inside the Developer Event Queue (HTML, factory and model bindings in `index.html`, `GameDeveloperUiFactory`, `GameUiDeveloperModels`, and `DeveloperEventController`), and hooked the dev controller callbacks via `GameRuntimeAssembly` (`getWorldSimulationOverview`).
- Added minimal automated tests at `rgfn_game/test/systems/worldSimulationRuntime.test.js` validating `worldTick` growth and the exact pipeline stage order, and added documentation with a manual UI verification checklist at `rgfn_game/docs/world/world-simulation-runtime-integration-2026-04-19.md`.

### Testing
- Ran `npm run build:rgfn` and the TypeScript build completed successfully.
- Ran the new unit tests with `node --test rgfn_game/test/systems/worldSimulationRuntime.test.js` and they passed; the full RGFN test suite `npm run test:rgfn` also completed with all tests passing (173 tests in this run).
- Ran `npx eslint` against the touched TypeScript sources and addressed linter feedback for files modified in this change (no remaining errors on touched files).
- Note: `npm run lint:ts:rgfn` still reports pre-existing repo-wide lint problems unrelated to these changes; touched files were reviewed and cleaned locally as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51d6a483483238ac5f0f50fd96fe0)