### PR TITLE
Add developer World Info HUD panel and pre-generate global NPC roster with village tile coords

### DIFF
--- a/rgfn_game/docs/ui/world-info-and-npc-roster.md
+++ b/rgfn_game/docs/ui/world-info-and-npc-roster.md
@@ -1,0 +1,46 @@
+# World Info panel + global NPC list (developer mode)
+
+## What changed
+
+- **World Info moved out of the developer console** (`~` modal) into a regular draggable HUD panel opened from the hamburger menu.
+- The hamburger menu now has a **World Info** button that is visible only when persistent developer mode is enabled.
+- The World Info panel includes a direct **Open NPC List** action.
+- NPC roster entries now include:
+  - NPC name
+  - Occupation
+  - Village name
+  - Exact world tile coordinates `(col, row)` for that village
+  - Life status/personality metadata
+
+## Runtime behavior
+
+- On game runtime initialization, we now pre-generate village NPC passports for **all villages currently generated on the world map**.
+- The call is explicit in runtime assembly path:
+  1. `createRuntimeBase(...)` constructs `WorldMap`, which runs world generation (villages are created there).
+  2. `createVillageRuntime(...)` constructs `VillageActionsController`.
+  3. `createVillageRuntime(...)` immediately calls `villageActionsController.preGenerateWorldNpcRoster()`.
+  4. `preGenerateWorldNpcRoster()` iterates `getAllVillagePlacements()` and generates/upserts roster entries for each village.
+- The pre-generation call is guarded with `hasPreGeneratedWorldNpcs` to avoid accidental duplicate full-world generation if called more than once in a runtime.
+- Village entry no longer creates first-time villagers for those villages; it pulls from the global roster generated at world generation time.
+- Quest-specific NPC injections still upsert into the same global roster and remain compatible with the pre-generated data.
+- Pre-generation intentionally runs for every world village placement without short-circuiting per-village existence checks, so a partial prefilled roster cannot prevent generation for later villages.
+
+## Data model notes
+
+- `VillageNpcPassport` now stores optional village tile coordinates:
+  - `tileCol: number | null`
+  - `tileRow: number | null`
+- `VillageNpcRoster.upsert(...)` accepts optional village tile coordinates so that world-generation placement metadata can be preserved as source-of-truth.
+
+## Integration points
+
+- World map exposes `getAllVillagePlacements()` with `{ name, col, row }[]`.
+- Village actions callbacks now support `getAllVillagePlacements`.
+- Runtime assembly calls `villageActionsController.preGenerateWorldNpcRoster()` immediately after controller creation.
+
+## Why this structure
+
+- Keeps developer-only debugging information inside the same HUD panel UX as gameplay panels.
+- Avoids hidden data generation timing bugs by establishing a deterministic global NPC list at world generation stage.
+- Ensures village NPCs seen in villages and NPCs shown in roster panel are backed by the same source.
+- Keeps generation idempotent via `upsert` while still covering the full village list on startup.

--- a/rgfn_game/docs/ui/world-info-and-npc-roster.md
+++ b/rgfn_game/docs/ui/world-info-and-npc-roster.md
@@ -21,6 +21,7 @@
   3. `createVillageRuntime(...)` immediately calls `villageActionsController.preGenerateWorldNpcRoster()`.
   4. `preGenerateWorldNpcRoster()` iterates `getAllVillagePlacements()` and generates/upserts roster entries for each village.
 - The pre-generation call is guarded with `hasPreGeneratedWorldNpcs` to avoid accidental duplicate full-world generation if called more than once in a runtime.
+- Immediately after pre-generation completes, `renderRosterPanel()` is called so the NPC roster UI is populated before entering any village.
 - Village entry no longer creates first-time villagers for those villages; it pulls from the global roster generated at world generation time.
 - Quest-specific NPC injections still upsert into the same global roster and remain compatible with the pre-generated data.
 - Pre-generation intentionally runs for every world village placement without short-circuiting per-village existence checks, so a partial prefilled roster cannot prevent generation for later villages.

--- a/rgfn_game/index.html
+++ b/rgfn_game/index.html
@@ -28,6 +28,7 @@
                     <button id="toggle-selected-panel-btn" class="action-btn" type="button">Selected</button>
                     <button id="toggle-world-map-panel-btn" class="action-btn" type="button">World Map</button>
                     <button id="toggle-log-panel-btn" class="action-btn" type="button">Log</button>
+                    <button id="toggle-world-info-panel-btn" class="action-btn dev-only-btn hidden" type="button">World Info</button>
                     <button id="toggle-roster-panel-btn" class="action-btn dev-only-btn hidden" type="button">NPC Roster</button>
                 </div>
                 <div class="hud-menu-actions">
@@ -334,11 +335,19 @@
                         </div>
                     </div>
                     <div id="village-roster-panel" class="overlay-panel hidden">
-                        <h2>NPC Roster</h2>
+                        <h2>NPC List</h2>
                         <div class="village-section village-roster-panel">
                             <p class="village-section-title">Source of truth (developer mode only)</p>
                             <select id="village-roster-filter-select" class="village-ask-input"></select>
                             <div id="village-roster-list" class="village-roster-list"></div>
+                        </div>
+                    </div>
+                    <div id="world-info-panel" class="overlay-panel hidden">
+                        <h2>World Info</h2>
+                        <div class="village-section village-roster-panel">
+                            <p class="village-section-title">Developer-only world simulation snapshot</p>
+                            <pre id="world-info-overview-output" class="dev-world-map-profiling-output">{}</pre>
+                            <button id="world-info-open-roster-btn" class="action-btn" type="button">Open NPC List</button>
                         </div>
                     </div>
                 </div>
@@ -469,16 +478,6 @@
                         <label class="dev-events-toggle" for="dev-map-display-everything-discovered"><input id="dev-map-display-everything-discovered" type="checkbox"> Everything discovered</label>
                         <label class="dev-events-toggle" for="dev-map-display-fog-of-war"><input id="dev-map-display-fog-of-war" type="checkbox" checked> Fog of war</label>
                     </div>
-                </div>
-                <div class="dev-events-queue-wrap">
-                    <h3>World Info</h3>
-                    <p class="dev-events-hint dev-events-hint-tight">Developer-only world simulation snapshot (updates when panel is opened or tab is clicked).</p>
-                    <div class="quest-tabs" role="tablist" aria-label="World info tabs">
-                        <button id="dev-world-info-tab-overview" class="quest-tab is-active" type="button" role="tab" aria-selected="true">Overview</button>
-                    </div>
-                    <section id="dev-world-info-panel-overview" role="tabpanel">
-                        <pre id="dev-world-info-overview-output" class="dev-world-map-profiling-output">{}</pre>
-                    </section>
                 </div>
                 <div class="dev-events-queue-wrap">
                     <h3>World map profiling window</h3>

--- a/rgfn_game/js/game/GameFactoryHelpers.ts
+++ b/rgfn_game/js/game/GameFactoryHelpers.ts
@@ -57,6 +57,7 @@ const createVillageActionsController = (
     onAdvanceTime: (minutes, fatigueScale) => game.onVillageAdvanceTime(minutes, fatigueScale),
     onLeaveVillage: () => game.onVillageLeave(),
     getVillageDirectionHint: (name: string) => worldMap.getVillageDirectionHintFromPlayer(name),
+    getAllVillagePlacements: () => worldMap.getAllVillagePlacements(),
     getNearbyVillageNames: (villageName: string, maxDistanceCells: number) =>
         worldMap.getNearbyVillagesFromVillage(villageName, maxDistanceCells).map((entry) => entry.name),
     getKnownSettlementNames: () => worldMap.getKnownSettlementNames(),
@@ -87,6 +88,7 @@ export function createVillageRuntime(
     nextCharacterName: () => string,
 ) {
     const villageActionsController = createVillageActionsController(game, ui, player, worldMap, hudCoordinator, nextCharacterName);
+    villageActionsController.preGenerateWorldNpcRoster();
     const villageCoordinator = new GameVillageCoordinator(
         ui.hudElements,
         ui.battleUI,

--- a/rgfn_game/js/systems/encounter/DeveloperEventController.ts
+++ b/rgfn_game/js/systems/encounter/DeveloperEventController.ts
@@ -28,6 +28,7 @@ export default class DeveloperEventController {
         this.lastProfilingPayloadCacheKey = '';
         this.bindWorldMapProfilingPanelDrag();
         this.bindWorldInfoControls();
+        this.renderWorldInfoOverview();
     }
 
     public toggleModal(forceVisible?: boolean): void {
@@ -288,12 +289,7 @@ export default class DeveloperEventController {
     }
 
     private bindWorldInfoControls(): void {
-        this.developerUI.worldInfoOverviewTabBtn.addEventListener('click', () => {
-            this.developerUI.worldInfoOverviewTabBtn.classList.add('is-active');
-            this.developerUI.worldInfoOverviewTabBtn.setAttribute('aria-selected', 'true');
-            this.developerUI.worldInfoOverviewPanel.classList.remove('hidden');
-            this.renderWorldInfoOverview();
-        });
+        document.getElementById('toggle-world-info-panel-btn')?.addEventListener('click', () => this.renderWorldInfoOverview());
     }
 
     private handleProfilingPanelPointerDown(event: PointerEvent, panel: HTMLElement, dragHandle: HTMLElement): void {

--- a/rgfn_game/js/systems/encounter/DeveloperEventTypes.ts
+++ b/rgfn_game/js/systems/encounter/DeveloperEventTypes.ts
@@ -37,8 +37,6 @@ export type DeveloperUI = {
     worldMapProfilingFpsCapSelect: HTMLSelectElement;
     worldMapProfilingDevicePixelRatioClampSelect: HTMLSelectElement;
     worldMapProfilingOutput: HTMLElement;
-    worldInfoOverviewTabBtn: HTMLButtonElement;
-    worldInfoOverviewPanel: HTMLElement;
     worldInfoOverviewOutput: HTMLElement;
 };
 

--- a/rgfn_game/js/systems/game/runtime/GameDeveloperUiFactory.ts
+++ b/rgfn_game/js/systems/game/runtime/GameDeveloperUiFactory.ts
@@ -3,7 +3,7 @@ import { DeveloperUI } from '../ui/GameUiTypes.js';
 export class GameDeveloperUiFactory {
     public create = (): DeveloperUI => ({ ...this.createBaseDeveloperUi(), ...this.createProfilingUi(), ...this.createWorldInfoUi() });
 
-    private readonly createBaseDeveloperUi = (): Omit<DeveloperUI, 'worldMapProfilingToggle' | 'worldMapProfilingOpenBtn' | 'worldMapProfilingPanel' | 'worldMapProfilingDragHandle' | 'worldMapProfilingCloseBtn' | 'worldMapProfilingRefreshBtn' | 'worldMapProfilingAutoRefreshToggle' | 'worldMapProfilingRenderLayerToggles' | 'worldMapProfilingFpsCapSelect' | 'worldMapProfilingDevicePixelRatioClampSelect' | 'worldMapProfilingOutput' | 'worldInfoOverviewTabBtn' | 'worldInfoOverviewPanel' | 'worldInfoOverviewOutput'> => ({
+    private readonly createBaseDeveloperUi = (): Omit<DeveloperUI, 'worldMapProfilingToggle' | 'worldMapProfilingOpenBtn' | 'worldMapProfilingPanel' | 'worldMapProfilingDragHandle' | 'worldMapProfilingCloseBtn' | 'worldMapProfilingRefreshBtn' | 'worldMapProfilingAutoRefreshToggle' | 'worldMapProfilingRenderLayerToggles' | 'worldMapProfilingFpsCapSelect' | 'worldMapProfilingDevicePixelRatioClampSelect' | 'worldMapProfilingOutput' | 'worldInfoOverviewOutput'> => ({
         ...this.createQueueAndEncounterUi(),
         ...this.createNextRollAndRandomUi(),
         ...this.createModeAndMapDisplayUi(),
@@ -82,9 +82,7 @@ export class GameDeveloperUiFactory {
         selectionCursor: document.getElementById('dev-world-map-render-selection-cursor')! as HTMLInputElement,
     });
 
-    private readonly createWorldInfoUi = (): Pick<DeveloperUI, 'worldInfoOverviewTabBtn' | 'worldInfoOverviewPanel' | 'worldInfoOverviewOutput'> => ({
-        worldInfoOverviewTabBtn: document.getElementById('dev-world-info-tab-overview')! as HTMLButtonElement,
-        worldInfoOverviewPanel: document.getElementById('dev-world-info-panel-overview')!,
-        worldInfoOverviewOutput: document.getElementById('dev-world-info-overview-output')!,
+    private readonly createWorldInfoUi = (): Pick<DeveloperUI, 'worldInfoOverviewOutput'> => ({
+        worldInfoOverviewOutput: document.getElementById('world-info-overview-output')!,
     });
 }

--- a/rgfn_game/js/systems/game/runtime/GameHudElementsFactory.ts
+++ b/rgfn_game/js/systems/game/runtime/GameHudElementsFactory.ts
@@ -28,6 +28,7 @@ export class GameHudElementsFactory {
             newCharacterBtn: btn('new-character-btn'),
             worldMapPanel: el('world-sidebar'),
             logPanel: el('game-log-container'),
+            worldInfoPanel: el('world-info-panel'),
             rosterPanel: el('village-roster-panel'),
             questIntroModal: el('quest-intro-modal'),
             questIntroBody: el('quest-intro-body'),
@@ -149,6 +150,7 @@ export class GameHudElementsFactory {
             toggleSelectedPanelBtn: btn('toggle-selected-panel-btn'),
             toggleWorldMapPanelBtn: btn('toggle-world-map-panel-btn'),
             toggleLogPanelBtn: btn('toggle-log-panel-btn'),
+            toggleWorldInfoPanelBtn: btn('toggle-world-info-panel-btn'),
             toggleRosterPanelBtn: btn('toggle-roster-panel-btn'),
         };
     }

--- a/rgfn_game/js/systems/game/ui/GameUiDeveloperModels.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiDeveloperModels.ts
@@ -47,8 +47,6 @@ export class DeveloperUiModel {
     public worldMapProfilingFpsCapSelect!: HTMLSelectElement;
     public worldMapProfilingDevicePixelRatioClampSelect!: HTMLSelectElement;
     public worldMapProfilingOutput!: HTMLElement;
-    public worldInfoOverviewTabBtn!: HTMLButtonElement;
-    public worldInfoOverviewPanel!: HTMLElement;
     public worldInfoOverviewOutput!: HTMLElement;
 }
 

--- a/rgfn_game/js/systems/game/ui/GameUiEventBinderTypes.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiEventBinderTypes.ts
@@ -37,4 +37,4 @@ export type GameUiEventCallbacks = {
 
 export type StatName = 'vitality' | 'toughness' | 'strength' | 'agility' | 'connection' | 'intelligence';
 
-export type HudPanelToggle = 'stats' | 'skills' | 'inventory' | 'magic' | 'quests' | 'group' | 'lore' | 'selected' | 'worldMap' | 'log' | 'roster';
+export type HudPanelToggle = 'stats' | 'skills' | 'inventory' | 'magic' | 'quests' | 'group' | 'lore' | 'selected' | 'worldMap' | 'log' | 'worldInfo' | 'roster';

--- a/rgfn_game/js/systems/game/ui/GameUiHudElementsModel.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudElementsModel.ts
@@ -82,6 +82,7 @@ export class HudElementsModel {
     public groupPanel!: HTMLElement;
     public worldMapPanel!: HTMLElement;
     public logPanel!: HTMLElement;
+    public worldInfoPanel!: HTMLElement;
     public rosterPanel!: HTMLElement;
     public questsTitle!: HTMLElement;
     public questsKnownOnlyToggle!: HTMLInputElement;
@@ -107,6 +108,7 @@ export class HudElementsModel {
     public toggleSelectedPanelBtn!: HTMLButtonElement;
     public toggleWorldMapPanelBtn!: HTMLButtonElement;
     public toggleLogPanelBtn!: HTMLButtonElement;
+    public toggleWorldInfoPanelBtn!: HTMLButtonElement;
     public toggleRosterPanelBtn!: HTMLButtonElement;
     public questIntroModal!: HTMLElement;
     public questIntroBody!: HTMLElement;

--- a/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
+++ b/rgfn_game/js/systems/game/ui/GameUiHudPanelController.ts
@@ -30,6 +30,7 @@ export default class GameUiHudPanelController {
     private static readonly COMBAT_PANEL_PERSISTENCE_KEY = 'battleActions';
     private static readonly VILLAGE_ACTIONS_PANEL_PERSISTENCE_KEY = 'villageActions';
     private static readonly VILLAGE_RUMORS_PANEL_PERSISTENCE_KEY = 'villageRumors';
+    private static readonly WORLD_INFO_PANEL_PERSISTENCE_KEY = 'worldInfo';
     private static readonly VILLAGE_ROSTER_PANEL_PERSISTENCE_KEY = 'villageRoster';
     private static readonly MODE_TEXT = {
         battle: 'Battle!',
@@ -75,7 +76,9 @@ export default class GameUiHudPanelController {
         this.hudElements.toggleSelectedPanelBtn.addEventListener('click', () => this.handlePanelToggle('selected'));
         this.hudElements.toggleWorldMapPanelBtn.addEventListener('click', () => this.handlePanelToggle('worldMap'));
         this.hudElements.toggleLogPanelBtn.addEventListener('click', () => this.handlePanelToggle('log'));
+        this.hudElements.toggleWorldInfoPanelBtn.addEventListener('click', () => this.handlePanelToggle('worldInfo'));
         this.hudElements.toggleRosterPanelBtn.addEventListener('click', () => this.handlePanelToggle('roster'));
+        document.getElementById('world-info-open-roster-btn')?.addEventListener('click', () => this.handlePanelToggle('roster'));
     }
     private initializeHudPanelWindows(): void {
         this.getPanelConfigs().forEach(({ key, title, element, closable }, panelIndex) => this.decorateHudPanelWindow(key, title, element, panelIndex, closable ?? true));
@@ -94,6 +97,14 @@ export default class GameUiHudPanelController {
                 : []),
             ...(villageRumorsPanel
                 ? [{ key: null, title: 'Village Rumors', element: villageRumorsPanel, closable: false, persistenceKey: 'villageRumors' }]
+                : []),
+            ...(this.hudElements.worldInfoPanel
+                ? [{
+                    key: 'worldInfo' as const,
+                    title: 'World Info',
+                    element: this.hudElements.worldInfoPanel,
+                    persistenceKey: GameUiHudPanelController.WORLD_INFO_PANEL_PERSISTENCE_KEY,
+                }]
                 : []),
             ...(villageRosterPanel
                 ? [{

--- a/rgfn_game/js/systems/hud/HudPanelStateController.ts
+++ b/rgfn_game/js/systems/hud/HudPanelStateController.ts
@@ -9,7 +9,7 @@ export default class HudPanelStateController {
     }
 
     public togglePanel(panel: HudPanel): void {
-        if (panel === 'roster' && !isDeveloperModeEnabled()) {
+        if ((panel === 'roster' || panel === 'worldInfo') && !isDeveloperModeEnabled()) {
             return;
         }
         this.getPanelMap()[panel].classList.toggle('hidden');
@@ -28,6 +28,7 @@ export default class HudPanelStateController {
         this.hudElements.toggleSelectedPanelBtn.classList.toggle('active', !this.hudElements.selectedPanel.classList.contains('hidden'));
         this.hudElements.toggleWorldMapPanelBtn.classList.toggle('active', !this.hudElements.worldMapPanel.classList.contains('hidden'));
         this.hudElements.toggleLogPanelBtn.classList.toggle('active', !this.hudElements.logPanel.classList.contains('hidden'));
+        this.hudElements.toggleWorldInfoPanelBtn.classList.toggle('active', !this.hudElements.worldInfoPanel.classList.contains('hidden'));
         this.hudElements.toggleRosterPanelBtn.classList.toggle('active', !this.hudElements.rosterPanel.classList.contains('hidden'));
     }
 
@@ -42,13 +43,16 @@ export default class HudPanelStateController {
         selected: this.hudElements.selectedPanel,
         worldMap: this.hudElements.worldMapPanel,
         log: this.hudElements.logPanel,
+        worldInfo: this.hudElements.worldInfoPanel,
         roster: this.hudElements.rosterPanel,
     });
 
     private syncDeveloperRosterVisibility(): void {
         const developerModeEnabled = isDeveloperModeEnabled();
+        this.hudElements.toggleWorldInfoPanelBtn.classList.toggle('hidden', !developerModeEnabled);
         this.hudElements.toggleRosterPanelBtn.classList.toggle('hidden', !developerModeEnabled);
         if (!developerModeEnabled) {
+            this.hudElements.worldInfoPanel.classList.add('hidden');
             this.hudElements.rosterPanel.classList.add('hidden');
         }
     }

--- a/rgfn_game/js/systems/hud/HudTypes.ts
+++ b/rgfn_game/js/systems/hud/HudTypes.ts
@@ -84,6 +84,7 @@ export type HudElements = {
     groupPanel: HTMLElement;
     worldMapPanel: HTMLElement;
     logPanel: HTMLElement;
+    worldInfoPanel: HTMLElement;
     rosterPanel: HTMLElement;
     questsBody: HTMLElement;
     groupBody: HTMLElement;
@@ -107,10 +108,11 @@ export type HudElements = {
     toggleSelectedPanelBtn: HTMLButtonElement;
     toggleWorldMapPanelBtn: HTMLButtonElement;
     toggleLogPanelBtn: HTMLButtonElement;
+    toggleWorldInfoPanelBtn: HTMLButtonElement;
     toggleRosterPanelBtn: HTMLButtonElement;
 };
 
-export type HudPanel = 'stats' | 'skills' | 'inventory' | 'magic' | 'quests' | 'group' | 'lore' | 'selected' | 'worldMap' | 'log' | 'roster';
+export type HudPanel = 'stats' | 'skills' | 'inventory' | 'magic' | 'quests' | 'group' | 'lore' | 'selected' | 'worldMap' | 'log' | 'worldInfo' | 'roster';
 
 export type BattleUiHudElements = {
     usePotionBtn: HTMLButtonElement;

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -41,6 +41,7 @@ export default class VillageActionsController {
     private dismissedSideQuestOfferIds: Set<string> = new Set();
     private knownNpcNames: Set<string> = new Set();
     private joinedEscortNpcKeys: Set<string> = new Set();
+    private hasPreGeneratedWorldNpcs = false;
 
     constructor(player: Player, villageUI: VillageUI, gameLog: HTMLElement, callbacks: VillageActionsCallbacks, deps: { nextCharacterName?: () => string } = {}) {
         this.villageUI = villageUI;
@@ -50,6 +51,14 @@ export default class VillageActionsController {
         this.uiPresenter = this.createVillageUiPresenter(player, villageUI, gameLog);
         this.tradeInteraction = this.createTradeInteraction(player, callbacks);
         this.dialogueInteraction = this.createDialogueInteraction(player, villageUI, callbacks);
+    }
+
+    public preGenerateWorldNpcRoster(): void {
+        if (this.hasPreGeneratedWorldNpcs) {
+            return;
+        }
+        this.preGenerateVillageNpcs();
+        this.hasPreGeneratedWorldNpcs = true;
     }
 
     public enterVillage(villageName: string): void {
@@ -323,9 +332,9 @@ export default class VillageActionsController {
             this.ensureQuestPeoplePresent(villageName);
             return this.npcPassportRoster.getVillageProfiles(villageName);
         }
-
+        const villageTile = this.getVillageTilePosition(villageName);
         const roster = this.applyQuestStyleNames(this.dialogueEngine.createNpcRoster(villageName));
-        roster.forEach((npc) => this.npcPassportRoster.upsert(villageName, npc, 'generated-on-village-entry'));
+        roster.forEach((npc) => this.npcPassportRoster.upsert(villageName, npc, 'generated-on-village-entry', villageTile));
         this.ensureQuestPeoplePresent(villageName);
         return this.npcPassportRoster.getVillageProfiles(villageName);
     }
@@ -971,10 +980,36 @@ export default class VillageActionsController {
         entries.forEach((entry) => {
             const row = document.createElement('div');
             row.className = `village-roster-entry${entry.lifeStatus === 'dead' ? ' is-dead' : ''}`;
+            const tileText = entry.passport.tileCol !== null && entry.passport.tileRow !== null
+                ? `Tile: (${entry.passport.tileCol}, ${entry.passport.tileRow})`
+                : 'Tile: unknown';
             row.textContent = `${entry.passport.name} (${entry.passport.occupation}) · Village: ${entry.passport.villageName} · `
-                + `Personality: ${entry.passport.personality} · Status: ${entry.lifeStatus}`;
+                + `${tileText} · Personality: ${entry.passport.personality} · Status: ${entry.lifeStatus}`;
             listElement.appendChild(row);
         });
+    }
+
+    private preGenerateVillageNpcs(): void {
+        const villagePlacements = this.callbacks.getAllVillagePlacements?.() ?? [];
+        villagePlacements.forEach((placement) => {
+            const roster = this.applyQuestStyleNames(this.dialogueEngine.createNpcRoster(placement.name));
+            roster.forEach((npc) => this.npcPassportRoster.upsert(
+                placement.name,
+                npc,
+                'generated-on-world-generation',
+                { col: placement.col, row: placement.row },
+            ));
+        });
+    }
+
+    private getVillageTilePosition(villageName: string): { col: number; row: number } | undefined {
+        const normalizedName = villageName.trim().toLocaleLowerCase();
+        const matchingPlacement = (this.callbacks.getAllVillagePlacements?.() ?? [])
+            .find((placement) => placement.name.trim().toLocaleLowerCase() === normalizedName);
+        if (!matchingPlacement) {
+            return undefined;
+        }
+        return { col: matchingPlacement.col, row: matchingPlacement.row };
     }
 
     private shouldIncludeTraderName(traderName: string, knownSettlements: Set<string>): boolean {

--- a/rgfn_game/js/systems/village/VillageActionsController.ts
+++ b/rgfn_game/js/systems/village/VillageActionsController.ts
@@ -59,6 +59,7 @@ export default class VillageActionsController {
         }
         this.preGenerateVillageNpcs();
         this.hasPreGeneratedWorldNpcs = true;
+        this.renderRosterPanel();
     }
 
     public enterVillage(villageName: string): void {

--- a/rgfn_game/js/systems/village/VillageNpcRoster.ts
+++ b/rgfn_game/js/systems/village/VillageNpcRoster.ts
@@ -12,6 +12,8 @@ export type VillageNpcPassport = {
     personality: NpcDisposition;
     speechStyle: string;
     look: string;
+    tileCol: number | null;
+    tileRow: number | null;
 };
 
 export type VillageNpcRosterEntry = {
@@ -58,7 +60,7 @@ export default class VillageNpcRoster {
         return false;
     }
 
-    public upsert(villageName: string, npc: VillageNpcProfile, sourceTag: string): VillageNpcRosterEntry {
+    public upsert(villageName: string, npc: VillageNpcProfile, sourceTag: string, villageTile?: { col: number; row: number }): VillageNpcRosterEntry {
         const key = this.getKey(villageName, npc.name);
         const nowTick = this.nextTick();
         const existing = this.entriesByKey.get(key);
@@ -72,6 +74,8 @@ export default class VillageNpcRoster {
                 personality: npc.disposition,
                 speechStyle: npc.speechStyle,
                 look: npc.look,
+                tileCol: villageTile?.col ?? existing.passport.tileCol,
+                tileRow: villageTile?.row ?? existing.passport.tileRow,
             };
             existing.lastUpdatedAtTick = nowTick;
             existing.sourceTag = sourceTag;
@@ -89,6 +93,8 @@ export default class VillageNpcRoster {
                 personality: npc.disposition,
                 speechStyle: npc.speechStyle,
                 look: npc.look,
+                tileCol: villageTile?.col ?? null,
+                tileRow: villageTile?.row ?? null,
             },
             lifeStatus: 'alive',
             firstSeenAtTick: nowTick,

--- a/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
+++ b/rgfn_game/js/systems/village/actions/VillageActionsTypes.ts
@@ -45,6 +45,7 @@ export type VillageActionsCallbacks = {
     onAdvanceTime: (minutes: number, fatigueScale: number) => void;
     onLeaveVillage: () => void;
     getVillageDirectionHint: (settlementName: string) => VillageDirectionHint;
+    getAllVillagePlacements?: () => Array<{ name: string; col: number; row: number }>;
     getNearbyVillageNames?: (villageName: string, maxDistanceCells: number) => string[];
     getKnownSettlementNames?: () => string[];
     getKnownQuestSettlementNames?: () => string[];

--- a/rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts
+++ b/rgfn_game/js/systems/world/worldMap/WorldMapVillageNavigationAndRender.ts
@@ -184,6 +184,15 @@ export default class WorldMapVillageNavigationAndRender extends WorldMapMovement
         })
         .sort((left, right) => left.localeCompare(right));
 
+    public getAllVillagePlacements = (): Array<{ name: string; col: number; row: number }> => Array.from(this.villages.values())
+        .map((key) => {
+            const [colText, rowText] = key.split(',');
+            const col = Number(colText);
+            const row = Number(rowText);
+            return { name: this.getVillageName(col, row), col, row };
+        })
+        .sort((left, right) => left.name.localeCompare(right.name));
+
     private getVillageName(col: number, row: number): string {
         const seed = this.hashSeed((col + 11) * 92837111, (row + 17) * 689287499, 14057);
         return generateVillageName(seed);


### PR DESCRIPTION
### Motivation

- Surface developer-only world simulation snapshot in a regular draggable HUD panel instead of hiding it in the modal to improve debugging UX and make panel actions (open roster) more discoverable.
- Eliminate timing/consistency issues by deterministically pre-generating a global NPC roster at world generation time so village entries and the roster share a single source-of-truth.
- Preserve world-placement metadata for NPCs by recording village tile coordinates on roster entries for clearer tracing and QA.

### Description

- Added a new `World Info` HUD panel and menu button (developer-only) plus an `Open NPC List` action that opens the NPC roster panel from the World Info panel by calling the HUD toggle for `roster`.
- Updated runtime wiring so `createVillageRuntime(...)` calls `villageActionsController.preGenerateWorldNpcRoster()` immediately after the controller is constructed, and `VillageActionsController` tracks `hasPreGeneratedWorldNpcs` to make the call idempotent.
- Implemented `getAllVillagePlacements()` on the world map API to return `{ name, col, row }[]` and plumbed it into `VillageActionsController` via the `VillageActionsCallbacks` interface to enable world-stage roster pre-generation.
- Implemented pre-generation logic in `VillageActionsController.preGenerateVillageNpcs()` that creates/upserts NPC passports for every placement using `VillageNpcRoster.upsert(..., villageTile?)` and added optional `tileCol`/`tileRow` fields to `VillageNpcPassport` to preserve placement metadata.
- UI and type updates: added `worldInfoPanel`/`toggleWorldInfoPanelBtn` elements and `worldInfoOverviewOutput` wiring, removed old static dev-modal tab elements, updated various factories and models (developer UI, HUD elements, event types, HUD panel controller, panel persistence keys) to include the new panel and toggle developer-only visibility when developer mode is disabled.
- Adjusted roster rendering to show tile coordinates when available and to set tile metadata when generating roster entries on village-entry or during pre-generation.

### Testing

- Performed a local type-check/build (`npm run build` / `tsc`) to validate compile-time types and bundling, which completed without errors.
- No automated unit tests were added or modified in this change set, and existing automated test suites were not changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e618ce708323a0958d8dfc36e401)