### PR TITLE
Add world faction state, raid interception, and 24h capture rule

### DIFF
--- a/rgfn_game/docs/misc/verification-and-testing.md
+++ b/rgfn_game/docs/misc/verification-and-testing.md
@@ -1316,3 +1316,45 @@ This prints:
   - inventory weapon click equips,
   - equipped slot click unequips,
   - right-click inventory still drops item.
+
+## 2026-05-11 World Factions attack→intercept/capture manual checklist
+
+### What was added
+- `WorldSimulationRuntime` now tracks `factions` (`red`, `blue`) with:
+  - `territoryCellIds[]`
+  - `activeSquadIds[]`
+- Runtime now resolves:
+  - nearest-target raid assignment,
+  - defender intercept scheduling,
+  - intercept conflict event logging,
+  - capture timer progression,
+  - control switch after 24h undefended hold.
+- World Info (dev-only) now includes a logical `tabs.factions` block with:
+  - territories,
+  - raids,
+  - capture timers,
+  - intercept traces.
+
+### Manual UI checklist (dev-only)
+1. Enable Developer Mode.
+2. Open **World Info** panel.
+3. Confirm `tabs.factions.territories` has `red` and `blue` entries.
+4. Advance simulation by one world tick (any in-game action causing world tick).
+5. In `tabs.factions.raids`, verify raid exists and has nearest blue target cell.
+6. In `tabs.factions.intercepts`, verify intercept trace appears.
+7. In `tabs.factions.captureTimers`, verify timer appears for target cell.
+8. Continue advancing time and observe timer growth in hours.
+9. At `>= 24` hours with no defenders (`defenderPresent=false`), verify:
+   - target cell removed from blue territory,
+   - target cell added to red territory,
+   - capture timer for that cell removed,
+   - capture resolution event emitted in pending events.
+10. Capture screenshots for the chain:
+   - before raid,
+   - during intercept/capture timer,
+   - after ownership switch.
+
+### Notes for debugging
+- If timer does not progress, inspect `lastDelta` and ensure world ticks are happening.
+- If no raid appears, ensure no unresolved raid already exists.
+- If ownership does not switch at 24h, inspect `captureTimers[target].defenderPresent` and `progressHours`.

--- a/rgfn_game/js/systems/encounter/DeveloperEventController.ts
+++ b/rgfn_game/js/systems/encounter/DeveloperEventController.ts
@@ -244,6 +244,15 @@ export default class DeveloperEventController {
             lastDelta: overview.lastDelta,
             pendingEvents: overview.pendingEvents,
             pendingEventsCount: overview.pendingEvents.length,
+            tabs: {
+                overview: { worldTick: overview.worldTick, lastDelta: overview.lastDelta },
+                factions: {
+                    territories: overview.factions,
+                    raids: overview.raids,
+                    captureTimers: overview.captureTimers,
+                    intercepts: overview.intercepts,
+                },
+            },
             persistence: {
                 key: persistence.key,
                 version: persistence.version,

--- a/rgfn_game/js/systems/encounter/DeveloperEventTypes.ts
+++ b/rgfn_game/js/systems/encounter/DeveloperEventTypes.ts
@@ -71,7 +71,15 @@ export type DeveloperCallbacks = {
     getWorldMapRenderFpsCap: () => 'uncapped' | '60' | '30';
     setWorldMapDevicePixelRatioClamp: (clamp: 'auto' | '1' | '1.5') => void;
     getWorldMapDevicePixelRatioClamp: () => 'auto' | '1' | '1.5';
-    getWorldSimulationOverview: () => { worldTick: number; lastDelta: number; pendingEvents: string[] };
+    getWorldSimulationOverview: () => {
+        worldTick: number;
+        lastDelta: number;
+        pendingEvents: string[];
+        factions: Record<string, { factionId: string; territoryCellIds: string[]; activeSquadIds: string[] }>;
+        raids: Array<{ raidId: string; attackerFactionId: string; defenderFactionId: string; fromCellId: string; targetCellId: string; status: string }>;
+        captureTimers: Record<string, { attackerFactionId: string; defenderPresent: boolean; progressHours: number }>;
+        intercepts: string[];
+    };
     getPersistenceOverview: () => {
         key: string;
         version: number;

--- a/rgfn_game/js/systems/world-sim/WorldSimulationRuntime.ts
+++ b/rgfn_game/js/systems/world-sim/WorldSimulationRuntime.ts
@@ -1,12 +1,26 @@
-export type WorldSimulationStage = 'movement' | 'taskAssign' | 'taskProgress' | 'conflicts' | 'villages';
-
-export type WorldSimulationState = { worldTick: number; lastDelta: number; pendingEvents: string[]; lastStageOrder: WorldSimulationStage[] };
+import { FactionId, FactionState, WorldSimulationStage, WorldSimulationState } from './WorldSimulationTypes.js';
+export type { WorldSimulationState } from './WorldSimulationTypes.js';
 
 type PartialState = Partial<WorldSimulationState> | null | undefined;
 
 const PIPELINE: WorldSimulationStage[] = ['movement', 'taskAssign', 'taskProgress', 'conflicts', 'villages'];
+const CAPTURE_HOURS_REQUIRED = 24;
 
-const createDefaultState = (): WorldSimulationState => ({ worldTick: 0, lastDelta: 0, pendingEvents: [], lastStageOrder: [] });
+const createDefaultFactions = (): Record<FactionId, FactionState> => ({
+    red: { factionId: 'red', territoryCellIds: ['0,0'], activeSquadIds: ['red-1'] },
+    blue: { factionId: 'blue', territoryCellIds: ['2,0'], activeSquadIds: ['blue-1'] },
+});
+
+const createDefaultState = (): WorldSimulationState => ({
+    worldTick: 0,
+    lastDelta: 0,
+    pendingEvents: [],
+    lastStageOrder: [],
+    factions: createDefaultFactions(),
+    raids: [],
+    captureTimers: {},
+    intercepts: [],
+});
 
 const ensureNonNegativeFinite = (value: unknown): number => {
     const numeric = Number(value);
@@ -20,11 +34,7 @@ const sanitizePendingEvents = (events: unknown): string[] => {
     if (!Array.isArray(events)) {
         return [];
     }
-    return events
-        .filter((item) => typeof item === 'string')
-        .map((item) => item.trim())
-        .filter((item) => item.length > 0)
-        .slice(0, 64);
+    return events.filter((item) => typeof item === 'string').map((item) => item.trim()).filter((item) => item.length > 0).slice(0, 64);
 };
 
 const sanitizeStageOrder = (stages: unknown): WorldSimulationStage[] => {
@@ -32,6 +42,13 @@ const sanitizeStageOrder = (stages: unknown): WorldSimulationStage[] => {
         return [];
     }
     return stages.filter((stage): stage is WorldSimulationStage => PIPELINE.includes(stage as WorldSimulationStage));
+};
+
+const toCell = (cellId: string): [number, number] => cellId.split(',').map((n) => Number.parseInt(n, 10)) as [number, number];
+const dist = (a: string, b: string): number => {
+    const [ax, ay] = toCell(a);
+    const [bx, by] = toCell(b);
+    return Math.abs(ax - bx) + Math.abs(ay - by);
 };
 
 export default class WorldSimulationRuntime {
@@ -47,30 +64,25 @@ export default class WorldSimulationRuntime {
         this.state.worldTick += 1;
         this.state.lastDelta = safeDelta;
         this.state.lastStageOrder = [];
-
         for (const stage of PIPELINE) {
             this.runStage(stage, safeDelta);
         }
-
         return this.getState();
     }
 
-    public readonly getState = (): WorldSimulationState => ({
-        worldTick: this.state.worldTick,
-        lastDelta: this.state.lastDelta,
-        pendingEvents: [...this.state.pendingEvents],
-        lastStageOrder: [...this.state.lastStageOrder],
-    });
+    public readonly getState = (): WorldSimulationState => JSON.parse(JSON.stringify(this.state));
 
     public restoreState(nextState?: PartialState): void {
         if (!nextState || typeof nextState !== 'object') {
             return;
         }
-
         this.state.worldTick = Math.floor(ensureNonNegativeFinite(nextState.worldTick));
         this.state.lastDelta = ensureNonNegativeFinite(nextState.lastDelta);
         this.state.pendingEvents = sanitizePendingEvents(nextState.pendingEvents);
         this.state.lastStageOrder = sanitizeStageOrder(nextState.lastStageOrder);
+        if (nextState.factions?.red && nextState.factions?.blue) {
+            this.state.factions = nextState.factions as Record<FactionId, FactionState>;
+        }
     }
 
     private runStage(stage: WorldSimulationStage, deltaMinutes: number): void {
@@ -83,6 +95,72 @@ export default class WorldSimulationRuntime {
             villages: `villages:update-${this.state.worldTick}`,
         };
         this.enqueueEvent(eventByStage[stage]);
+        this.runStageSideEffects(stage, deltaMinutes);
+    }
+
+    private runStageSideEffects(stage: WorldSimulationStage, deltaMinutes: number): void {
+        if (stage === 'taskAssign') {
+            this.assignRaidToNearestEnemyCell();
+        }
+        if (stage === 'conflicts') {
+            this.resolveInterceptsAndConflicts();
+        }
+        if (stage === 'villages') {
+            this.processCaptures(deltaMinutes / 60);
+        }
+    }
+
+    private assignRaidToNearestEnemyCell(): void {
+        if (this.state.raids.some((raid) => raid.status !== 'resolved')) {
+            return;
+        }
+        const redOrigin = this.state.factions.red.territoryCellIds[0];
+        const blueCells = this.state.factions.blue.territoryCellIds;
+        const nearest = blueCells.reduce((acc, cell) => (dist(redOrigin, cell) < dist(redOrigin, acc) ? cell : acc), blueCells[0]);
+        this.state.raids.push({
+            raidId: `raid-${this.state.worldTick}`,
+            attackerFactionId: 'red',
+            defenderFactionId: 'blue',
+            fromCellId: redOrigin,
+            targetCellId: nearest,
+            status: 'moving',
+        });
+    }
+
+    private resolveInterceptsAndConflicts(): void {
+        this.state.intercepts = [];
+        for (const raid of this.state.raids) {
+            if (raid.status !== 'moving') {
+                continue;
+            }
+            if (this.state.factions.blue.activeSquadIds.length > 0) {
+                raid.status = 'intercepted';
+                this.state.intercepts.push(`${raid.raidId}:blue-intercept`);
+                this.enqueueEvent(`conflict:intercept:${raid.raidId}`);
+                raid.status = 'capturing';
+                const existing = this.state.captureTimers[raid.targetCellId];
+                this.state.captureTimers[raid.targetCellId] = existing ?? { attackerFactionId: 'red', defenderPresent: false, progressHours: 0 };
+            }
+        }
+    }
+
+    private processCaptures(deltaHours: number): void {
+        Object.entries(this.state.captureTimers).forEach(([cellId, timer]) => {
+            if (timer.defenderPresent) {
+                timer.progressHours = 0;
+                return;
+            }
+            timer.progressHours += deltaHours;
+            this.enqueueEvent(`capture:${cellId}:${timer.progressHours.toFixed(2)}h`);
+            if (timer.progressHours >= CAPTURE_HOURS_REQUIRED) {
+                this.state.factions.blue.territoryCellIds = this.state.factions.blue.territoryCellIds.filter((cell) => cell !== cellId);
+                if (!this.state.factions.red.territoryCellIds.includes(cellId)) {
+                    this.state.factions.red.territoryCellIds.push(cellId);
+                }
+                delete this.state.captureTimers[cellId];
+                this.enqueueEvent(`capture:resolved:${cellId}:red`);
+            }
+        });
     }
 
     private enqueueEvent(eventLabel: string): void {

--- a/rgfn_game/js/systems/world-sim/WorldSimulationTypes.ts
+++ b/rgfn_game/js/systems/world-sim/WorldSimulationTypes.ts
@@ -1,0 +1,22 @@
+export type WorldSimulationStage = 'movement' | 'taskAssign' | 'taskProgress' | 'conflicts' | 'villages';
+export type FactionId = 'red' | 'blue';
+export type FactionState = { factionId: FactionId; territoryCellIds: string[]; activeSquadIds: string[] };
+export type RaidState = {
+    raidId: string;
+    attackerFactionId: FactionId;
+    defenderFactionId: FactionId;
+    fromCellId: string;
+    targetCellId: string;
+    status: 'moving' | 'intercepted' | 'capturing' | 'resolved';
+};
+export type CaptureTimerState = { attackerFactionId: FactionId; defenderPresent: boolean; progressHours: number };
+export type WorldSimulationState = {
+    worldTick: number;
+    lastDelta: number;
+    pendingEvents: string[];
+    lastStageOrder: WorldSimulationStage[];
+    factions: Record<FactionId, FactionState>;
+    raids: RaidState[];
+    captureTimers: Record<string, CaptureTimerState>;
+    intercepts: string[];
+};

--- a/rgfn_game/test/systems/worldSimulationRuntime.test.js
+++ b/rgfn_game/test/systems/worldSimulationRuntime.test.js
@@ -27,3 +27,33 @@ test('WorldSimulationRuntime runs stages in the expected pipeline order', () => 
     'villages',
   ]);
 });
+
+test('WorldSimulationRuntime switches control after 24h undefended capture timer', () => {
+  const runtime = new WorldSimulationRuntime();
+  runtime.initialize();
+
+  const targetCell = runtime.getState().factions.blue.territoryCellIds[0];
+  runtime.tick(60);
+  assert.ok(runtime.getState().captureTimers[targetCell]);
+  runtime.tick(22 * 60);
+  assert.ok(runtime.getState().captureTimers[targetCell]);
+  runtime.tick(60);
+
+  const state = runtime.getState();
+  assert.ok(state.factions.red.territoryCellIds.includes(targetCell));
+  assert.ok(!state.factions.blue.territoryCellIds.includes(targetCell));
+  assert.equal(state.captureTimers[targetCell], undefined);
+});
+
+test('WorldSimulationRuntime keeps capture timer below 24h before control switch', () => {
+  const runtime = new WorldSimulationRuntime();
+  runtime.initialize();
+
+  const targetCell = runtime.getState().factions.blue.territoryCellIds[0];
+  runtime.tick(60);
+  runtime.tick(22 * 60);
+  const timer = runtime.getState().captureTimers[targetCell];
+
+  assert.ok(timer.progressHours < 24);
+  assert.ok(runtime.getState().factions.blue.territoryCellIds.includes(targetCell));
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal faction war model so the world sim can dispatch raids, allow defenders to intercept, and let attackers capture territory when undefended for 24h. 
- Surface the new faction data in the dev-only `World Info` panel for observability and debugging. 
- Cover the new behavior with automated tests to prevent regressions in capture/timer logic.

### Description
- Added type definitions in `rgfn_game/js/systems/world-sim/WorldSimulationTypes.ts` for `FactionState`, `RaidState`, `CaptureTimerState`, and the expanded `WorldSimulationState`. 
- Extended `WorldSimulationRuntime` (`rgfn_game/js/systems/world-sim/WorldSimulationRuntime.ts`) to track `factions`, `raids`, `captureTimers`, and `intercepts`, to pick the nearest enemy cell and spawn a raid, to schedule defender intercepts and emit conflict events, and to progress capture timers and transfer control after `24` hours of undefended hold. 
- Exposed faction diagnostics to dev UI by adding a `tabs.factions` payload in `rgfn_game/js/systems/encounter/DeveloperEventController.ts` and updating the callback signature in `rgfn_game/js/systems/encounter/DeveloperEventTypes.ts`. 
- Added runtime tests `rgfn_game/test/systems/worldSimulationRuntime.test.js` verifying tick/pipe order, capture timer progression, and territory ownership switch at 24h. 
- Documented a developer manual checklist in `rgfn_game/docs/misc/verification-and-testing.md` describing how to observe the full chain `attack → intercept → capture` in `World Info`.

### Testing
- Built the RGFN TypeScript project with `npm run build:rgfn` and the build completed successfully. 
- Ran the targeted test suite with `npm test -- rgfn_game/test/systems/worldSimulationRuntime.test.js` and all tests passed (4/4). 
- Ran lint checks with `npx eslint` on the modified files and fixed style issues; ESLint reports no blocking errors on the touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0242fcb1a08323a20c3ad31fc0c4af)